### PR TITLE
Data race and verification issue in test `mmm_target_parallel_for_sim…

### DIFF
--- a/tests/4.5/application_kernels/mmm_target_parallel_for_simd.c
+++ b/tests/4.5/application_kernels/mmm_target_parallel_for_simd.c
@@ -66,7 +66,7 @@ int main (int argc, char *argv[])
   
 #pragma omp target map(to: a[0:DimA],b[0:DimB]) map(from: c[0:DimC])
 {
-#pragma omp teams distribute parallel for simd collapse(2) 
+#pragma omp teams distribute parallel for simd collapse(2) private(k)
     for (i=0; i<rowA; i++)
       for(j=0; j<colB; j++)
         for(k=0; k<colA; k++)
@@ -82,7 +82,7 @@ int main (int argc, char *argv[])
     for (j=0; j<colB; j++)
       if( 500 != c[i*rowA+j]){
         printf("Error: [%d][%d] should be 500 is %d\n",i,j,c[i*rowA+j]);
-        error += error;
+        error++;
      }
    
   }


### PR DESCRIPTION
Fix data race and verification mechanism.

1 - [Line 69](https://github.com/SOLLVE/sollve_vv/blob/master/tests/4.5/application_kernels/mmm_target_parallel_for_simd.c#L69) is missing a `private(k)` clause causing a data race on `k`. The `collapse(2)` will take care of the first two loop, but the loop on `k` will be executed by all threads which will be sharing the `k` index variable causing a race condition.

2 - [Line 85](https://github.com/SOLLVE/sollve_vv/blob/master/tests/4.5/application_kernels/mmm_target_parallel_for_simd.c#L85) is not actually incrementing correctly the number of errors (`error += error` will always be 0).