### PR TITLE
Verification issue in test `mmm_target.c`

### DIFF
--- a/tests/4.5/application_kernels/mmm_target.c
+++ b/tests/4.5/application_kernels/mmm_target.c
@@ -81,7 +81,7 @@ int main (int argc, char *argv[])
     for (j=0; j<colB; j++)
       if( 500 != c[i*rowA+j]){
         printf("Error: [%d][%d] should be 500 is %d\n",i,j,c[i*rowA+j]);
-        error += error;
+        error++;
      }
    
   }


### PR DESCRIPTION
Fix verification mechanism.

Line 84 is not actually incrementing correctly the number of errors (error += error will always be 0).