### PR TITLE
Fix data races from use of omp master in omp teams

### DIFF
--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_collapse.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_collapse.F90
@@ -51,7 +51,9 @@
             DO x = 1, N
               DO y = 1, N
                 b(x, y + 1) = b(x, y) + a(x, y)
-                num_teams = omp_get_num_teams()
+                IF (omp_get_team_num() .eq. 0) THEN
+                   num_teams = omp_get_num_teams()
+                END IF
               END DO
             END DO
             !$omp end target teams distribute

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_collapse.c
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_collapse.c
@@ -73,8 +73,7 @@ int test_collapse2() {
   for (int x = 0; x < ARRAY_SIZE; ++x) {
     for (int y = 0; y < ARRAY_SIZE; ++y) {
       for (int z = 0; z < ARRAY_SIZE; ++z) {
-#pragma omp master
-	{
+	if (omp_get_team_num() == 0) {
 	  num_teams = omp_get_num_teams();
 	}
 	b[x][y][z + 1] = b[x][y][z] + a[x][y][z];

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_default_none.c
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_default_none.c
@@ -43,8 +43,9 @@ int main() {
 	privatized++;
       }
       d[x] = c[x] * privatized;
-#pragma omp master
-      num_teams = omp_get_num_teams();
+      if (omp_get_team_num() == 0) {
+	num_teams = omp_get_num_teams();
+      }
     }
   }
 
@@ -61,10 +62,11 @@ int main() {
   {
 #pragma omp target teams distribute default(none) private(x) shared(share, b, num_teams) defaultmap(tofrom:scalar)
     for (x = 0; x < 1024; ++x) {
-#pragma omp atomic
+#pragma omp atomic update
       share = share + b[x];
-#pragma omp master
-      num_teams = omp_get_num_teams();
+      if (omp_get_team_num() == 0) {
+	num_teams = omp_get_num_teams();
+      }
     }
   }
 


### PR DESCRIPTION
This PR addresses issue #16. The following tests were affected:
- `test_target_teams_distribute.c`
- `test_target_teams_distribute_collapse[.c|.F90]`
- `test_target_teams_distribute_default_none.c`

Since `omp master` doesn't bind to `omp teams`, we can't use it to protect num_teams from data races. I resolved this issue by changing `test_target_teams_distribute` to use an array instead of a scalar, properly mapped, and for the rest of the tests using a conditional: `omp_get_team_num == 0`.