### PR TITLE
 Adding the configuration for AOMP

### DIFF
--- a/sys/make/make.def
+++ b/sys/make/make.def
@@ -71,6 +71,35 @@ ifeq ($(CC), clang)
   CLINKFLAGS += -lm -O3 -fopenmp $(COFFLOADING)
 endif
 
+# AOMP compiler
+ifeq ($(CC), aomp)
+  $(warning "AOMP is still experimental. AOMP uses clang front end, make sure the correct clang is selected")
+  INSTALLED_GPU  = $(shell $(AOMP)/bin/mygpu -d gfx900)
+  AOMP_GPU       ?= $(INSTALLED_GPU)
+  AOMP_CPUTARGET ?= x86_64-pc-linux-gnu
+  ifeq (sm_,$(findstring sm_,$(AOMP_GPU)))
+    $(warning "AOMP GPU NOT FOUND. USING HOST")
+    AOMP_GPUTARGET = nvptx64-nvidia-cuda
+  else
+    AOMP_GPUTARGET = amdgcn-amd-amdhsa
+  endif
+
+  ifeq (sm_,$(findstring sm_,$(AOMP_GPU)))
+    CUDA_PATH  ?= /usr/local/cuda
+    UNAMEP = $(shell uname -p)
+    CLINKFLAGS += -L$(CUDA)/targets/$(UNAMEP)-linux/lib -lcudart
+  endif
+
+  override CC = clang
+  COFFLOADING = -target $(AOMP_CPUTARGET) -fopenmp-targets=$(AOMP_GPUTARGET) -Xopenmp-target=$(AOMP_GPUTARGET) -march=$(AOMP_GPU)
+  C_NO_OFFLOADING =
+  CFLAGS += -lm -O3 -fopenmp $(COFFLOADING)
+  #Adding this to fix problem with math.h
+  CFLAGS +=  -D__NO_MATH_INLINES -U__SSE2_MATH__ -U__SSE_MATH__
+  CLINK = clang
+  CLINKFLAGS += -lm -O3 -fopenmp $(COFFLOADING)
+endif
+
 #---------------------------------------------------------------------------
 # C++ compilers
 #---------------------------------------------------------------------------
@@ -107,6 +136,36 @@ ifeq ($(CXX), clang++)
   CXXOFFLOADING = -fopenmp-targets=nvptx64-nvidia-cuda
   CXX_NO_OFFLOADING =
   CXXFLAGS += -std=c++11 -lm -O3 -fopenmp $(CXXOFFLOADING)
+  #Adding this to fix problem with math.h
+  CXXFLAGS +=  -D__NO_MATH_INLINES -U__SSE2_MATH__ -U__SSE_MATH__
+  CXXLINK = clang++
+  CXXLINKFLAGS += -lm -O3 -fopenmp $(CXXOFFLOADING)
+endif
+
+
+# AOMP compiler
+ifeq ($(CXX), aomp)
+  $(warning "AOMP is still experimental. AOMP uses clang front end, make sure the correct clang is selected")
+  INSTALLED_GPU  = $(shell $(AOMP)/bin/mygpu -d gfx900)
+  AOMP_GPU       ?= $(INSTALLED_GPU)
+  AOMP_CPUTARGET ?= x86_64-pc-linux-gnu
+  ifeq (sm_,$(findstring sm_,$(AOMP_GPU)))
+    $(warning "AOMP GPU NOT FOUND. USING HOST")
+    AOMP_GPUTARGET = nvptx64-nvidia-cuda
+  else
+    AOMP_GPUTARGET = amdgcn-amd-amdhsa
+  endif
+
+  ifeq (sm_,$(findstring sm_,$(AOMP_GPU)))
+    CUDA_PATH  ?= /usr/local/cuda
+    UNAMEP = $(shell uname -p)
+    CXXLINKFLAGS += -L$(CUDA)/targets/$(UNAMEP)-linux/lib -lcudart
+  endif
+
+  override CXX = clang++
+  CXXOFFLOADING = -target $(AOMP_CPUTARGET) -fopenmp-targets=$(AOMP_GPUTARGET) -Xopenmp-target=$(AOMP_GPUTARGET) -march=$(AOMP_GPU)
+  CXX_NO_OFFLOADING =
+  CXXFLAGS += -lm -std=c++11 -O3 -fopenmp $(CXXOFFLOADING)
   #Adding this to fix problem with math.h
   CXXFLAGS +=  -D__NO_MATH_INLINES -U__SSE2_MATH__ -U__SSE_MATH__
   CXXLINK = clang++


### PR DESCRIPTION
Adding the aomp as a compiler. 

aomp actually uses clang, but to differentiate it we use CC=aomp CXX=aomp. We then overwrite them with clang and clang++

AOMP infrastructure has some way to check for the available hardware, I took this from one of their makefile. Adding Ron Lieberman to check if this is all right. 