### PR TITLE
Fixing the lack of OMPVV_REPORT_AND_RETURN() macro on these two tests

### DIFF
--- a/tests/4.5/target_data/test_target_data_map_pointer_translation.c
+++ b/tests/4.5/target_data/test_target_data_map_pointer_translation.c
@@ -143,5 +143,5 @@ int main() {
 
   OMPVV_TEST_AND_SET_VERBOSE(errors, test_map_same_function());
   OMPVV_TEST_AND_SET_VERBOSE(errors, test_map_different_function());
-  return errors;
+  OMPVV_REPORT_AND_RETURN(errors);
 }

--- a/tests/4.5/target_enter_exit_data/test_target_enter_exit_data_map_pointer_translation.c
+++ b/tests/4.5/target_enter_exit_data/test_target_enter_exit_data_map_pointer_translation.c
@@ -137,5 +137,5 @@ int main() {
 
   OMPVV_TEST_AND_SET_VERBOSE(errors, test_map_same_function());
   OMPVV_TEST_AND_SET_VERBOSE(errors, test_map_different_function());
-  return errors;
+  OMPVV_REPORT_AND_RETURN(errors);
 }


### PR DESCRIPTION
Short fix. Needed to use the macro