### PR TITLE
New feature/adding online report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ results_report
 ompvv/*.mod
 results.json
 results.csv
+recent_online_report_tags

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ RESULTS_JSON_OUTPUT_FILE=results.json
 RESULTS_CSV_OUTPUT_FILE=results.csv
 RESULTS_HTML_OUTPUT_FOLDER=results_report
 RESULTS_HTML_REPORT_TEMPLATE=$(CURDIR)/sys/results_template
-ONLINE_REPORT_CONNECTION=$(CURDIR)/sys/scripts/onlineConnection.py
+REPORT_ONLINE_CONNECTION=$(CURDIR)/sys/scripts/onlineConnection.py
 
 ##################################################
 # Source files
@@ -380,35 +380,35 @@ report_html: $(RESULTS_JSON_OUTPUT_FILE) $(RESULTS_CSV_OUTPUT_FILE)
 
 	@echo " === REPORT DONE === "
 
-ifdef ONLINE_REPORT_TAG
+ifdef REPORT_ONLINE_TAG
   # Check if the lenght is appropriate
-  ifneq ("$(shell echo ${ONLINE_REPORT_TAG} | wc -m | grep -oh '[0-9]\+')", "10")
-    $(error "ONLINE_REPORT_TAG is a 9 digit hex value. Not 9 digits")
+  ifneq ("$(shell echo ${REPORT_ONLINE_TAG} | wc -m | grep -oh '[0-9]\+')", "10")
+    $(error "REPORT_ONLINE_TAG is a 9 digit hex value. Not 9 digits")
   endif
   # Check if it's a hex value
-  ifneq ("$(shell echo ${ONLINE_REPORT_TAG} | grep '[^a-f0-9]')" , "")
-    $(error "ONLINE_REPORT_TAG is a 9 digit hex value. Not a Hex")
+  ifneq ("$(shell echo ${REPORT_ONLINE_TAG} | grep '[^a-f0-9]')" , "")
+    $(error "REPORT_ONLINE_TAG is a 9 digit hex value. Not a Hex")
   endif
 endif
 
-ifdef ONLINE_REPORT_APPEND
+ifdef REPORT_ONLINE_APPEND
   # Check if the lenght is appropriate
-  ifndef ONLINE_REPORT_TAG
-    $(error "In order to append to an online report, it is necessary to have an ONLINE_REPORT_TAG")
+  ifndef REPORT_ONLINE_TAG
+    $(error "In order to append to an online report, it is necessary to have an REPORT_ONLINE_TAG")
   endif
 endif
 .PHONY: report_online
 report_online: $(RESULTS_JSON_OUTPUT_FILE)
-	@echo " === SUBMITTING ONLINE REPORT === "; \
-		FLAGS=""; \
-		if [ "${ONLINE_REPORT_TAG}" != "" ]; then \
-			FLAGS=$$FLAGS + " -t"; \
+	@echo " === SUBMITTING ONLINE REPORT === ";
+	@FLAGS=""; \
+		if [ "${REPORT_ONLINE_TAG}" != "" ]; then \
+			FLAGS="$$FLAGS -t ${REPORT_ONLINE_TAG}"; \
 		fi; \
-		if [ "1" == "${ONLINE_REPORT_APPEND}" ]; then \
-			FLAGS=$$FLAGS + " -a"; \
+		if [ "1" == "${REPORT_ONLINE_APPEND}" ]; then \
+			FLAGS="$$FLAGS -a"; \
 		fi; \
-		date >> recent_online_report_tags; \
-		${ONLINE_REPORT_CONNECTION} $$FLAGS ${RESULTS_JSON_OUTPUT_FILE} | tee -a recent_online_report_tags;
+		date >> recent_REPORT_ONLINE_tags; \
+		${REPORT_ONLINE_CONNECTION} $$FLAGS ${RESULTS_JSON_OUTPUT_FILE} | tee -a recent_REPORT_ONLINE_tags;
 	@echo " This tool is for visualization purposes. "
 	@echo " Our data retention policy is of 1 month. "
 	@echo " After this time, we do not guarantee this link will work anymore"
@@ -454,8 +454,8 @@ help:
 	@echo "  OMP_VERSION=[e.g. 4.5]    This specifies which version of the specs we are targeting. This version should have its folder in tests/[version]"
 	@echo "                            default value is 4.5"
 	@echo "                            WARNING: WHEN CHANGING VERSIONS START FROM A CLEAN BUILD. OTHERWISE BINARIES and LOG folders may collide."
-	@echo "  ONLINE_REPORT_TAG=1       Allows to control the 9 digit hex value that refers to an already existing online report"
-	@echo "  ONLINE_REPORT_APPEND=1    Allows to append to an already existing report. It requires a tag for a reeport (9 digit hex value)"
+	@echo "  REPORT_ONLINE_TAG=1       Allows to control the 9 digit hex value that refers to an already existing online report"
+	@echo "  REPORT_ONLINE_APPEND=1    Allows to append to an already existing report. It requires a tag for a reeport (9 digit hex value)"
 	@echo ""
 	@echo " === RULES ==="
 	@echo "  all"

--- a/sys/scripts/API/sollve_api.py
+++ b/sys/scripts/API/sollve_api.py
@@ -236,8 +236,8 @@ class SOLLVE_API_01_requests(SOLLVE_API_01):
     except Exception as err: 
       print(f"Error obtaining tag [{type(err).__name__}]: {err}",file=sys.stderr)
 
-# try:
-#   import requests
-#   api = SOLLVE_API_01_requests()
-# except:
-api = SOLLVE_API_01_curl()
+try:
+  import requests
+  api = SOLLVE_API_01_requests()
+except:
+  api = SOLLVE_API_01_curl()

--- a/sys/scripts/API/sollve_api.py
+++ b/sys/scripts/API/sollve_api.py
@@ -3,6 +3,7 @@ import sys
 import json
 import traceback
 import os
+import subprocess
 
 ### SOLLVE_API_RELATED
 class SOLLVE_API_01(metaclass=abc.ABCMeta):
@@ -58,25 +59,104 @@ class SOLLVE_API_01(metaclass=abc.ABCMeta):
 
 ## This class if requests is not installed in the system
 class SOLLVE_API_01_curl(SOLLVE_API_01):
+  def __init__(self):
+    super().__init__()
+    self.print_log("Using the CURL Back end", 1)
+    #check if curl exists
+    stream = os.popen('which curl')
+    if (len(stream.read()) != 0):
+      print("We are using CURL because we could not find the `requests` package")
+      print("Error handling is limted. Please consider installing `requests` through")
+      print("    pip install requests")
+    else:
+      raise Exception("""
+            We could not find curl or the 'requests' python module in your system.
+            To obtain requests use pip install requests
+            """)
   def create_tag(self):
     self.print_log("create_tag curl")
+    stream = subprocess.Popen(['curl', '-s', '--show-error', self.CREATE_TAG_URL], stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+    errors = stream.stderr.read()
+    if len(errors) != 0:
+      print(f"Error creating tag {errors}", file=sys.stderr)
+    else:
+      return str(stream.stdout.read().decode('utf-8'))
 
   def obtain_result(self, tag):
     self.print_log("obtain_result curl")
+    stream = subprocess.Popen(['curl', '-s', '--show-error', self.OBTAIN_RESULT_URL+tag], stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+    errors = stream.stderr.read()
+    if len(errors) != 0:
+      print(f"Error creating tag {errors}", file=sys.stderr)
+    else:
+      # This method return scaped double quotes and other characters
+      val = stream.stdout.read().decode('unicode_escape')
+      # We need to remove any leading or ending spaces
+      val = val.lstrip().rstrip()
+      # Sometimes text comes with double quotes. Remove them
+      val = val[1:] if val[0] == '"' else val
+      val = val[:-1] if val[-1] == '"' else val
+      return val
 
   def update_result(self, tag, jsonLog):
     self.print_log("update_result curl")
+    command = ['curl', '-s', '--show-error', '-X POST', '-H "Content-Type: application/json"', f'-d @{jsonLog}', self.UPDATE_RESULT_URL+tag]
+    command = " ".join(command)
+    stream = subprocess.Popen(command, shell=True, stderr=subprocess.PIPE, stdout=subprocess.PIPE,)
+    errors = stream.stderr.read()
+    if len(errors) != 0:
+      print(f"Error creating tag {errors}", file=sys.stderr)
+    else:
+      # This method return scaped double quotes and other characters
+      val = stream.stdout.read().decode('unicode_escape')
+      # We need to remove any leading or ending spaces
+      val = val.lstrip().rstrip()
+      if "true" in val:
+        return True
+      else:
+        return False
 
   def append_result(self, tag, jsonLog):
     self.print_log("append_result curl")
+    command = ['curl', '-s', '--show-error', '-X POST', '-H "Content-Type: application/json"', f'-d @{jsonLog}', self.APPEND_RESULT_URL+tag]
+    command = " ".join(command)
+    stream = subprocess.Popen(command, shell=True, stderr=subprocess.PIPE, stdout=subprocess.PIPE,)
+    errors = stream.stderr.read()
+    if len(errors) != 0:
+      print(f"Error creating tag {errors}", file=sys.stderr)
+    else:
+      # This method return scaped double quotes and other characters
+      val = stream.stdout.read().decode('unicode_escape')
+      # We need to remove any leading or ending spaces
+      val = val.lstrip().rstrip()
+      if "true" in val:
+        return True
+      else:
+        return False
 
   def delete_result(self,tag):
     self.print_log("delete_result curl")
+    command = ['curl', '-s', '--show-error', '-X DELETE', self.DELETE_RESULT_URL+tag]
+    command = " ".join(command)
+    stream = subprocess.Popen(command, shell=True, stderr=subprocess.PIPE, stdout=subprocess.PIPE,)
+    errors = stream.stderr.read()
+    if len(errors) != 0:
+      print(f"Error creating tag {errors}", file=sys.stderr)
+    else:
+      # This method return scaped double quotes and other characters
+      val = stream.stdout.read().decode('unicode_escape')
+      # We need to remove any leading or ending spaces
+      val = val.lstrip().rstrip()
+      if "true" in val:
+        return True
+      else:
+        return False
 
 
 ## This class if request is installed in the system
 class SOLLVE_API_01_requests(SOLLVE_API_01):
   def create_tag(self):
+    self.print_log("Using the requests module back end", 1)
     self.print_log("create_tag requests")
     try:
       response = requests.get(self.CREATE_TAG_URL)
@@ -110,10 +190,10 @@ class SOLLVE_API_01_requests(SOLLVE_API_01):
           print(f"Error reading json file {jsonLog}. [{type(err).__name__}] {err}")
         response = requests.post(self.UPDATE_RESULT_URL+tag, headers={'Content-Type': 'application/json'}, json=json_data)
         if (response.status_code == 200):
-          if ("false" in response.text):
-            return False
-          else:
+          if ("true" in response.text):
             return True
+          else:
+            return False
         else:
           raise requests.exceptions.HTTPError(f"Status code not as expected {response.status_code}")
     except Exception as err: 
@@ -131,10 +211,10 @@ class SOLLVE_API_01_requests(SOLLVE_API_01):
           print(f"Error reading json file {jsonLog}. [{type(err).__name__}] {err}")
         response = requests.post(self.APPEND_RESULT_URL+tag, headers={'Content-Type': 'application/json'}, json=json_data)
         if (response.status_code == 200):
-          if ("false" in response.text):
-            return False
-          else:
+          if ("true" in response.text):
             return True
+          else:
+            return False
         else:
           raise requests.exceptions.HTTPError(f"Status code not as expected {response.status_code}")
     except Exception as err: 
@@ -147,17 +227,17 @@ class SOLLVE_API_01_requests(SOLLVE_API_01):
     try:
       response = requests.delete(self.DELETE_RESULT_URL+tag)
       if (response.status_code == 200):
-        if ("false" in response.text):
-          return False
-        else:
+        if ("true" in response.text):
           return True
+        else:
+          return False
       else:
         raise requests.exceptions.HTTPError(f"Status code not as expected {response.status_code}")
     except Exception as err: 
       print(f"Error obtaining tag [{type(err).__name__}]: {err}",file=sys.stderr)
 
-try:
-  import requests
-  api = SOLLVE_API_01_requests()
-except:
-  api = SOLLVE_API_01_curl()
+# try:
+#   import requests
+#   api = SOLLVE_API_01_requests()
+# except:
+api = SOLLVE_API_01_curl()

--- a/sys/scripts/API/sollve_api.py
+++ b/sys/scripts/API/sollve_api.py
@@ -14,6 +14,7 @@ class SOLLVE_API_01(metaclass=abc.ABCMeta):
   UPDATE_RESULT_URL = None
   APPEND_RESULT_URL = None
   DELETE_RESULT_URL = None
+  RESULT_REPORT_URL = None
   DEBUG = -1
 
   def __init__(self):
@@ -25,6 +26,7 @@ class SOLLVE_API_01(metaclass=abc.ABCMeta):
     self.UPDATE_RESULT_URL=self.URL+self.VER+'/update_result/'
     self.APPEND_RESULT_URL=self.URL+self.VER+'/append_result/'
     self.DELETE_RESULT_URL=self.URL+self.VER+'/delete_result/'
+    self.RESULT_REPORT_URL="https://crpl.cis.udel.edu/ompvvsollve/result_report/results.html"
 
   @abc.abstractmethod
   def create_tag(self):
@@ -155,14 +157,17 @@ class SOLLVE_API_01_curl(SOLLVE_API_01):
 
 ## This class if request is installed in the system
 class SOLLVE_API_01_requests(SOLLVE_API_01):
-  def create_tag(self):
+  def __init__(self):
+    super().__init__()
     self.print_log("Using the requests module back end", 1)
+    
+  def create_tag(self):
     self.print_log("create_tag requests")
     try:
       response = requests.get(self.CREATE_TAG_URL)
       # Connection went well
       if (response.status_code == 200):
-        return response.te
+        return response.text
       else:
         raise requests.exceptions.HTTPError(f"Status code not as expected {response.status_code}")
     except Exception as err: 

--- a/sys/scripts/API/sollve_api.py
+++ b/sys/scripts/API/sollve_api.py
@@ -1,0 +1,163 @@
+import abc
+import sys
+import json
+import traceback
+import os
+
+### SOLLVE_API_RELATED
+class SOLLVE_API_01(metaclass=abc.ABCMeta):
+  URL = None
+  VER = None
+  CREATE_TAG_URL = None
+  OBTAIN_RESULT_URL = None
+  UPDATE_RESULT_URL = None
+  APPEND_RESULT_URL = None
+  DELETE_RESULT_URL = None
+  DEBUG = -1
+
+  def __init__(self):
+    self.print_log("Creating SOLLVE_API_O1", 4)
+    self.URL="https://crpl.cis.udel.edu/ompvvsollve/result_report/api/"
+    self.VER="0.1"
+    self.CREATE_TAG_URL=self.URL+self.VER+'/create_tag'
+    self.OBTAIN_RESULT_URL=self.URL+self.VER+'/obtain_result/'
+    self.UPDATE_RESULT_URL=self.URL+self.VER+'/update_result/'
+    self.APPEND_RESULT_URL=self.URL+self.VER+'/append_result/'
+    self.DELETE_RESULT_URL=self.URL+self.VER+'/delete_result/'
+
+  @abc.abstractmethod
+  def create_tag(self):
+    pass
+
+  @abc.abstractmethod
+  def obtain_result(self, tag):
+    pass
+
+  @abc.abstractmethod
+  def update_result(self, tag, jsonLog):
+    pass
+
+  @abc.abstractmethod
+  def append_result(self, tag, jsonLog):
+    pass
+
+  @abc.abstractmethod
+  def delete_result(self,tag):
+    pass
+
+  def enable_debug(self, level=1):
+    self.DEBUG = level
+
+  def disable_debug(self):
+    self.DEBUG = -1
+
+  def print_log(self, msg:str, level=1):
+    if (self.DEBUG > level):
+      print("=[DEBUG]= "+msg)
+
+
+## This class if requests is not installed in the system
+class SOLLVE_API_01_curl(SOLLVE_API_01):
+  def create_tag(self):
+    self.print_log("create_tag curl")
+
+  def obtain_result(self, tag):
+    self.print_log("obtain_result curl")
+
+  def update_result(self, tag, jsonLog):
+    self.print_log("update_result curl")
+
+  def append_result(self, tag, jsonLog):
+    self.print_log("append_result curl")
+
+  def delete_result(self,tag):
+    self.print_log("delete_result curl")
+
+
+## This class if request is installed in the system
+class SOLLVE_API_01_requests(SOLLVE_API_01):
+  def create_tag(self):
+    self.print_log("create_tag requests")
+    try:
+      response = requests.get(self.CREATE_TAG_URL)
+      # Connection went well
+      if (response.status_code == 200):
+        return response.te
+      else:
+        raise requests.exceptions.HTTPError(f"Status code not as expected {response.status_code}")
+    except Exception as err: 
+      print(f"Error obtaining tag [{type(err).__name__}]: {err}",file=sys.stderr)
+
+
+  def obtain_result(self, tag):
+    self.print_log("obtain_result requests")
+    try:
+      response = requests.get(self.OBTAIN_RESULT_URL+tag)
+      if (response.status_code == 200):
+        return response.json()
+      else:
+        raise requests.exceptions.HTTPError(f"Status code not as expected {response.status_code}")
+    except Exception as err: 
+      print(f"Error obtaining tag [{type(err).__name__}]: {err}",file=sys.stderr)
+
+  def update_result(self, tag, jsonLog):
+    self.print_log("update_result requests")
+    try:
+      with open(jsonLog) as f:
+        try:
+          json_data = json.load(f)
+        except Exception as err:
+          print(f"Error reading json file {jsonLog}. [{type(err).__name__}] {err}")
+        response = requests.post(self.UPDATE_RESULT_URL+tag, headers={'Content-Type': 'application/json'}, json=json_data)
+        if (response.status_code == 200):
+          if ("false" in response.text):
+            return False
+          else:
+            return True
+        else:
+          raise requests.exceptions.HTTPError(f"Status code not as expected {response.status_code}")
+    except Exception as err: 
+      print(f"Error obtaining tag [{type(err).__name__}]: {err}",file=sys.stderr)
+      print(traceback.format_exc())
+    return False
+
+  def append_result(self, tag, jsonLog):
+    self.print_log("append_result requests")
+    try:
+      with open(jsonLog) as f:
+        try:
+          json_data = json.load(f)
+        except Exception as err:
+          print(f"Error reading json file {jsonLog}. [{type(err).__name__}] {err}")
+        response = requests.post(self.APPEND_RESULT_URL+tag, headers={'Content-Type': 'application/json'}, json=json_data)
+        if (response.status_code == 200):
+          if ("false" in response.text):
+            return False
+          else:
+            return True
+        else:
+          raise requests.exceptions.HTTPError(f"Status code not as expected {response.status_code}")
+    except Exception as err: 
+      print(f"Error obtaining tag [{type(err).__name__}]: {err}",file=sys.stderr)
+      print(traceback.format_exc())
+    return False
+
+  def delete_result(self,tag):
+    self.print_log("delete_result requests")
+    try:
+      response = requests.delete(self.DELETE_RESULT_URL+tag)
+      if (response.status_code == 200):
+        if ("false" in response.text):
+          return False
+        else:
+          return True
+      else:
+        raise requests.exceptions.HTTPError(f"Status code not as expected {response.status_code}")
+    except Exception as err: 
+      print(f"Error obtaining tag [{type(err).__name__}]: {err}",file=sys.stderr)
+
+try:
+  import requests
+  api = SOLLVE_API_01_requests()
+except:
+  api = SOLLVE_API_01_curl()

--- a/sys/scripts/onlineConnection.py
+++ b/sys/scripts/onlineConnection.py
@@ -94,6 +94,11 @@ def main():
       print_log("User rejected deletion",1)
       return
 
+  # Obtaining the tag
+  tag = None
+  if (args.tag):
+    tag = args.tag[0]
+
   # Obtaining the json file to be processed
   if (args.jsonLogFile):
     jsonLogFile = args.jsonLogFile
@@ -102,16 +107,15 @@ def main():
 
       ## For obtain
       if (args.obtain_file):
-        result = api.obtain_result(args.tag[0])
+        result = api.obtain_result(tag)
         with open(logFile, "w") as f:
           json.dump(json.loads(result), f, indent=2)
 
       ## For update
       if not (args.append or args.remove or args.obtain_file):
-        if (not args.tag):
+        if (not tag):
           tag = api.create_tag()
-        else:
-          tag = args.tag[0]
+
         if os.path.exists(logFile):
           if (not api.update_result(tag, logFile)):
             print("Something went wrong with the update")
@@ -121,15 +125,20 @@ def main():
       ## For append
       if (args.append):
         if os.path.exists(logFile):
-          api.append_result(args.tag[0], logFile)
+          api.append_result(tag, logFile)
         else:
           print(f"The file {logFile} does not exists")
   elif (not args.remove):
     parser.print_usage()
+    return
 
   ## For remove
   if (args.remove):
-    result = api.delete_result(args.tag[0])
+    result = api.delete_result(tag)
+
+  if (not args.remove):
+    print(f" Your report tag is {tag}. Do not lose this number")
+    print(f" Visit your report at:\n    {api.RESULT_REPORT_URL}?result_report={tag}")
 
 if __name__ == "__main__":
     main()

--- a/sys/scripts/onlineConnection.py
+++ b/sys/scripts/onlineConnection.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argparse, glob, sys
 import json
 import os

--- a/sys/scripts/onlineConnecton.py
+++ b/sys/scripts/onlineConnecton.py
@@ -1,0 +1,133 @@
+import argparse, glob, sys
+import json
+import os
+import traceback
+from API.sollve_api import api
+
+### HELPER FUNCTIIONS
+DEBUG = -1
+def print_log(msg:str, level):
+  if (DEBUG > level):
+    print("=[DEBUG]= "+msg)
+
+if sys.version_info[0] < 3:
+    raise Exception("Python 3 or a more recent version is required.")
+
+def confirm(prompt=None, resp=False):
+  """prompts for yes or no response from the user. Returns True for yes and
+  False for no.
+
+  'resp' should be set to the default value assumed by the caller when
+  user simply types ENTER.
+
+  >>> confirm(prompt='Create Directory?', resp=True)
+  Create Directory? [y]|n: 
+  True
+  >>> confirm(prompt='Create Directory?', resp=False)
+  Create Directory? [n]|y: 
+  False
+  >>> confirm(prompt='Create Directory?', resp=False)
+  Create Directory? [n]|y: y
+  True
+
+  """
+  
+  if prompt is None:
+      prompt = 'Confirm'
+
+  if resp:
+      prompt = '%s [%s]|%s: ' % (prompt, 'y', 'n')
+  else:
+      prompt = '%s [%s]|%s: ' % (prompt, 'n', 'y')
+      
+  while True:
+      ans = input(prompt)
+      if not ans:
+          return resp
+      if ans not in ['y', 'Y', 'n', 'N']:
+          print('please enter y or n.')
+          continue
+      if ans == 'y' or ans == 'Y':
+          return True
+      if ans == 'n' or ans == 'N':
+          return False
+
+### Program
+def main():
+
+  ''' Arguments parsing'''
+  parser = argparse.ArgumentParser(description="""
+  Connection manager with SOLLVE online visualization tool
+      This script connects to our result visualziation tool. There are three
+      use modes. The first one is to create a new visualization
+  """)
+  parser.add_argument('jsonLogFile', metavar="JSONFILE", type=str, nargs='*', help='the json formatted log file to be sent')
+  parser.add_argument('-t', '--tag', dest='tag', type=str, nargs=1, help='Already existing tag to be appended, removed or updated')
+  parser.add_argument('-d', '--debug', dest='debug', type=int, help='VERBOSE. Show debugging information for this script')
+  parse_group = parser.add_mutually_exclusive_group() 
+  parse_group.add_argument('-a', '--append', dest='append', action='store_true', help="Uses the tag to append to its already existing results")
+  parse_group.add_argument('-r', '--remove', dest='remove', action='store_true', help="Remove the set of results completely [NON-REVERSIBLE]")
+  parse_group.add_argument('-o', '--obtain', dest='obtain_file', action='store_true', help="uses the tag to obtain the JSON file from server")
+  parser.add_argument('-f', '--force', dest='force_no_confirm', action='store_true', help="Allows to avoid any confirmation message (see remove)")
+
+  # Obtaining the arguments from command line
+  args = parser.parse_args()
+  print_log("Using arguments = " + str(args), 3)
+
+  # Enable debug mode and setting debug level
+  if (args.debug):
+    global DEBUG 
+    DEBUG = args.debug
+    api.enable_debug(DEBUG)
+
+  # Checking if a tag was specified with the append, delete or obtain options
+  if (args.append or args.remove or args.obtain_file) and args.tag is None:
+    print("A tag is required with the --append, --delete or --obtain options", file=sys.stderr)
+    return
+  
+  # Make sure the user wants to remove. This is irreversible
+  if (args.remove and not args.force_no_confirm):
+    confirmed = confirm("[WARNING] Are you sure you want to delete this tag from the servers? This is irreversible")
+    if (not confirmed):
+      print_log("User rejected deletion",1)
+      return
+
+  # Obtaining the json file to be processed
+  if (args.jsonLogFile):
+    jsonLogFile = args.jsonLogFile
+    for logFile in jsonLogFile: 
+      print_log("Using Log file " + logFile, 1)
+
+      ## For obtain
+      if (args.obtain_file):
+        result = api.obtain_result(args.tag[0])
+        with open(logFile, "w") as f:
+          json.dump(json.loads(result), f, indent=2)
+
+      ## For update
+      if not (args.append or args.remove or args.obtain_file):
+        if (not args.tag):
+          tag = api.create_tag()
+        else:
+          tag = args.tag[0]
+        if os.path.exists(logFile):
+          if (not api.update_result(tag, logFile)):
+            print("Something went wrong with the update")
+        else:
+          print(f"The file {logFile} does not exists")
+
+      ## For append
+      if (args.append):
+        if os.path.exists(logFile):
+          api.append_result(args.tag[0], logFile)
+        else:
+          print(f"The file {logFile} does not exists")
+  elif (not args.remove):
+    parser.print_usage()
+
+  ## For remove
+  if (args.remove):
+    result = api.delete_result(args.tag[0])
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I have created the necessary infrastructure for online reports submissions from the makefile.

Here is how it works:

1. I have created a back end RESTful API that lives in our server which allows us to upload JSON files into the server. This API allows creating new reports that are named by a 9 digit hex tag (obtained through RSA-1 hashing). With this tag it is possible to upload, append and remove the result from the server.  It also allows to obtain a JSON file with results.
2. I took the already existing report html file and modified it to obtain the JSON file directly from the API, and hosted it in our website under https://crpl.cis.udel.edu/ompvvsollve/result_report/results.html . It obtains the tag as a get parameter of the URL:  https://crpl.cis.udel.edu/ompvvsollve/result_report/results.html?result_report=<TAG HERE>
3. I created a front end script to be distributed with our testsuite called `onlineConnection.py`. This uses all the API operations and allows us to submit reports directly. 
4. Then I modified the makefile to use this script with the make rule report_online. This will automatically upload the json file to our servers through the `onlineConnection.py` script, create a tag, and returns an URL that the user can use to visualize the report. 
5. I have also added the option to REPORT_ONLINE_APPEND and REPORT_ONLINE_TAG which allows the user to continue using the same report for multiple runs (or multiple systems). 

I recommend we push this PR after #39 . While it is not a direct dependency, the other PR allows tracking of the code (git commit) that generated the report, making it possible for users to do some sort of versioning of the tests. (this is not intended to replace our versioning mechanism) 