### PR TITLE
Addition of condensed summary to `make report_summary`

### DIFF
--- a/sys/scripts/createSummary.py
+++ b/sys/scripts/createSummary.py
@@ -332,11 +332,20 @@ def main():
   elif args.format and args.format[0].lower() == 'summary':
     num_tests = len(results)
     failures = []
+    acceptable_extensions = (".cpp", ".c", ".f90")				   
+    number_tests_by_file_type = dict.fromkeys( acceptable_extensions, 0)	   
+    number_build_failures_by_file_type = dict.fromkeys( acceptable_extensions, 0) 
+    number_pass_by_file_type = dict.fromkeys( acceptable_extensions, 0)
     for result in results: 
+      extension=result.testName[(result.testName).rindex("."):].lower()
+      number_tests_by_file_type[extension] = number_tests_by_file_type[extension] + 1
       if result.compilerPass != "PASS":
         failures.append("  " + result.testName + " on " + result.compilerName + " (compiler) ")
+        number_build_failures_by_file_type[extension] = number_build_failures_by_file_type[extension] + 1
       elif result.runtimePass != "PASS":
         failures.append("  " + result.testName + " on " + result.compilerName + " (runtime) ")
+      else:
+        number_pass_by_file_type[extension] = number_pass_by_file_type[extension] + 1
     if len(failures) == 0:
       formatedOutput = "PASS\nChecked " + str(num_tests) + " runs"
     else:
@@ -350,6 +359,15 @@ def main():
     outputFile.write(formatedOutput)
   else:
     print(formatedOutput)
+    print("Condensed Summary by file type:")
+    for ext in acceptable_extensions:
+      if number_tests_by_file_type[ext] > 0 :
+        print( "  %s pass rate: %d/%d (%d%%) [ %d build failures ]" 
+               % (ext, number_pass_by_file_type[ext],
+                  number_tests_by_file_type[ext],
+                  number_pass_by_file_type[ext]/number_tests_by_file_type[ext]*100,
+                  number_build_failures_by_file_type[ext] ) )
+
  
 # end of main function definition
   


### PR DESCRIPTION
This adds a few printed out lines at the end of `make report_summary` that look like:
```
Condensed Summary by file type:
 .cpp pass rate: 4/10 (40%) [ 2 build failures ]
 .c pass rate: 63/86 (73%) [ 1 build failures ]
 .f90 pass rate: 1/48 (2%) [ 43 build failures ]
```
(The pass rates will be different for different compilers, of course.)
 
The reason for adding a condensed summary like this is that typically I wanted to just copy and paste a few summary lines about how the compiler was doing into an email, not the whole output. I find this useful, at least.