### PR TITLE
Fixing defaultmap tests which are suppose to be firstprivate

### DIFF
--- a/tests/4.5/target/test_target_defaultmap.F90
+++ b/tests/4.5/target/test_target_defaultmap.F90
@@ -26,7 +26,6 @@
             INTEGER :: errors_bf, errors_af
           
             ! we try with all the scalars
-            CHARACTER :: scalar_char
             BYTE :: scalar_byte
             INTEGER(kind = 2) :: scalar_short
             INTEGER(kind = 4) :: scalar_int
@@ -37,12 +36,10 @@
             LOGICAL(kind = 4) :: scalar_logical_kind4
             LOGICAL(kind = 8) :: scalar_logical_kind8
             COMPLEX :: scalar_complex
-            COMPLEX(kind = 16) :: scalar_double_complex
             
             OMPVV_INFOMSG("test_defaultmap_on")
             OMPVV_GET_ERRORS(errors_bf)
 
-            scalar_char = 'a'
             scalar_byte = 8
             scalar_short = 23
             scalar_int = 56
@@ -53,11 +50,9 @@
             scalar_logical_kind4 = .true.
             scalar_logical_kind8 = .true.
             scalar_complex = (1, 1)
-            scalar_double_complex = (1e+10, 1e+10)
           
             ! Map the same array to multiple devices. initialize with device number
             !$omp target defaultmap(tofrom: scalar)
-              scalar_char = 'b'
               scalar_byte = 5
               scalar_short = 83
               scalar_int = 49
@@ -68,10 +63,8 @@
               scalar_logical_kind4 = .false.
               scalar_logical_kind8 = .false.
               scalar_complex = (5, 5)
-              scalar_double_complex = (5e+9, 5e+9)
             !$omp end target 
           
-            OMPVV_TEST_VERBOSE(scalar_char /= 'b')
             OMPVV_TEST_VERBOSE(scalar_byte /= 5)
             OMPVV_TEST_VERBOSE(scalar_short /= 83)
             OMPVV_TEST_VERBOSE(scalar_int /= 49)
@@ -82,7 +75,6 @@
             OMPVV_TEST_VERBOSE(scalar_logical_kind4 .NEQV. .false.)
             OMPVV_TEST_VERBOSE(LOGICAL(scalar_logical_kind8 .NEQV. .false., kind = 4))
             OMPVV_TEST_VERBOSE(scalar_complex /= (5, 5))
-            OMPVV_TEST_VERBOSE(scalar_double_complex /= (5e+9, 5e+9))
 
             OMPVV_GET_ERRORS(errors_af)
             test_defaultmap_on = errors_bf - errors_af
@@ -90,13 +82,11 @@
 
           INTEGER FUNCTION test_defaultmap_off()
             INTEGER :: errors_bf, errors_af, i, tmp1, tmp2
-            LOGICAL :: isHost, sharedEnvWarning
             CHARACTER(len=400) :: longMessage
             CHARACTER(len=100) :: shortMessage
-            LOGICAL:: firstprivateCheck(12)
+            LOGICAL:: firstprivateCheck(10)
             
             ! we try with all the scalars
-            CHARACTER :: scalar_char
             BYTE :: scalar_byte
             INTEGER(kind = 2) :: scalar_short
             INTEGER(kind = 4) :: scalar_int
@@ -107,19 +97,10 @@
             LOGICAL(kind = 4) :: scalar_logical_kind4
             LOGICAL(kind = 8) :: scalar_logical_kind8
             COMPLEX :: scalar_complex
-            COMPLEX(kind = 16) :: scalar_double_complex
             
             OMPVV_INFOMSG("test_defaultmap_off")
             OMPVV_GET_ERRORS(errors_bf)
             
-            OMPVV_TEST_AND_SET_SHARED_ENVIRONMENT(sharedEnvWarning)
-           
-            longMessage = "Shared memory environment. Scalars&
-              &are not copied over but modified.&
-              &This part of the tests is inconclusive"
-            OMPVV_WARNING_IF(sharedEnvWarning, longMessage)
-
-            scalar_char = 'a'
             scalar_byte = 8
             scalar_short = 23
             scalar_int = 56
@@ -130,30 +111,22 @@
             scalar_logical_kind4 = .true.
             scalar_logical_kind8 = .true.
             scalar_complex = (1, 1)
-            scalar_double_complex = (1e+10, 1e+10)
             
-            isHost = .false.
             ! Map the scalar variables without defaultmap
-            !$omp target map(from: isHost) map(tofrom: firstprivateCheck)
-              ! make sure it offloaded
-              isHost = omp_is_initial_device()
-
+            !$omp target map(tofrom: firstprivateCheck)
               ! checking for firstprivate copy
-              firstprivateCheck(1)  = scalar_char == 'a'
-              firstprivateCheck(2)  = scalar_byte == 8
-              firstprivateCheck(3)  = scalar_short == 23
-              firstprivateCheck(4)  = scalar_int == 56
-              firstprivateCheck(5)  = scalar_long_int == 90000
-              firstprivateCheck(6)  = scalar_float  == 4.5e+3
-              firstprivateCheck(7)  = scalar_double  == 4.9e+10
-              firstprivateCheck(8)  = scalar_logical .EQV. .true.
-              firstprivateCheck(9)  = scalar_logical_kind4 .EQV. .true.
-              firstprivateCheck(10) = scalar_logical_kind8 .EQV. .true.
-              firstprivateCheck(11) = scalar_complex == (1, 1)
-              firstprivateCheck(12) = scalar_double_complex == (1e+10, 1e+10)
+              firstprivateCheck(1)  = scalar_byte == 8
+              firstprivateCheck(2)  = scalar_short == 23
+              firstprivateCheck(3)  = scalar_int == 56
+              firstprivateCheck(4)  = scalar_long_int == 90000
+              firstprivateCheck(5)  = scalar_float  == 4.5e+3
+              firstprivateCheck(6)  = scalar_double  == 4.9e+10
+              firstprivateCheck(7)  = scalar_logical .EQV. .true.
+              firstprivateCheck(8)  = scalar_logical_kind4 .EQV. .true.
+              firstprivateCheck(9)  = scalar_logical_kind8 .EQV. .true.
+              firstprivateCheck(10) = scalar_complex == (1, 1)
 
               ! Attempting value change
-              scalar_char = 'b'
               scalar_byte = 80
               scalar_short = 83
               scalar_int = 49
@@ -164,11 +137,10 @@
               scalar_logical_kind4 = .false.
               scalar_logical_kind8 = .false.
               scalar_complex = (5, 5)
-              scalar_double_complex = (5e+9, 5e+9)
             !$omp end target
 
             ! Check for the firstprivate values
-            DO i = 1,12
+            DO i = 1,10
               OMPVV_GET_ERRORS(tmp1)
               OMPVV_TEST_AND_SET_VERBOSE(tmp2, .not. firstprivateCheck(i))
               write(shortMessage, '(A,I0)') "Error in firstprivate&
@@ -176,34 +148,16 @@
               OMPVV_ERROR_IF(tmp1 /= tmp2, shortMessage)
             END DO 
               
-            ! If it is initial device then we will modify the original memory region
-            IF (isHost .OR. sharedEnvWarning) THEN
-              OMPVV_TEST_VERBOSE(scalar_char /= 'b')
-              OMPVV_TEST_VERBOSE(scalar_byte /= 80)
-              OMPVV_TEST_VERBOSE(scalar_short /= 83)
-              OMPVV_TEST_VERBOSE(scalar_int /= 49)
-              OMPVV_TEST_VERBOSE(scalar_long_int /= 12345)
-              OMPVV_TEST_VERBOSE(scalar_float  /= 3.0e+5)
-              OMPVV_TEST_VERBOSE(scalar_double  /= 9.5e+9)
-              OMPVV_TEST_VERBOSE(scalar_logical .NEQV. .false.)
-              OMPVV_TEST_VERBOSE(scalar_logical_kind4 .NEQV. .false.)
-              OMPVV_TEST_VERBOSE(LOGICAL(scalar_logical_kind8 .NEQV. .false., kind = 4))
-              OMPVV_TEST_VERBOSE(scalar_complex /= (5, 5))
-              OMPVV_TEST_VERBOSE(scalar_double_complex /= (5e+9, 5e+9))
-            else 
-              OMPVV_TEST_VERBOSE(scalar_char /= 'a')
-              OMPVV_TEST_VERBOSE(scalar_byte /= 8)
-              OMPVV_TEST_VERBOSE(scalar_short /= 23)
-              OMPVV_TEST_VERBOSE(scalar_int /= 56)
-              OMPVV_TEST_VERBOSE(scalar_long_int /= 90000)
-              OMPVV_TEST_VERBOSE(scalar_float  /= 4.5e+3)
-              OMPVV_TEST_VERBOSE(scalar_double  /= 4.9e+10)
-              OMPVV_TEST_VERBOSE(scalar_logical .NEQV. .true.)
-              OMPVV_TEST_VERBOSE(scalar_logical_kind4 .NEQV. .true.)
-              OMPVV_TEST_VERBOSE(LOGICAL(scalar_logical_kind8 .NEQV. .true., kind = 4))
-              OMPVV_TEST_VERBOSE(scalar_complex /= (1, 1))
-              OMPVV_TEST_VERBOSE(scalar_double_complex /= (1e+10, 1e+10))
-            END IF
+            OMPVV_TEST_VERBOSE(scalar_byte /= 8)
+            OMPVV_TEST_VERBOSE(scalar_short /= 23)
+            OMPVV_TEST_VERBOSE(scalar_int /= 56)
+            OMPVV_TEST_VERBOSE(scalar_long_int /= 90000)
+            OMPVV_TEST_VERBOSE(scalar_float  /= 4.5e+3)
+            OMPVV_TEST_VERBOSE(scalar_double  /= 4.9e+10)
+            OMPVV_TEST_VERBOSE(scalar_logical .NEQV. .true.)
+            OMPVV_TEST_VERBOSE(scalar_logical_kind4 .NEQV. .true.)
+            OMPVV_TEST_VERBOSE(LOGICAL(scalar_logical_kind8 .NEQV. .true., kind = 4))
+            OMPVV_TEST_VERBOSE(scalar_complex /= (1, 1))
 
             OMPVV_GET_ERRORS(errors_af)
             test_defaultmap_off = errors_bf - errors_af

--- a/tests/4.5/target/test_target_defaultmap.F90
+++ b/tests/4.5/target/test_target_defaultmap.F90
@@ -81,7 +81,7 @@
           END FUNCTION test_defaultmap_on
 
           INTEGER FUNCTION test_defaultmap_off()
-            INTEGER :: errors_bf, errors_af, i, tmp1, tmp2
+            INTEGER :: errors_bf, errors_af, i, tmp1 = 0, tmp2 = 0
             CHARACTER(len=400) :: longMessage
             CHARACTER(len=100) :: shortMessage
             LOGICAL:: firstprivateCheck(10)

--- a/tests/4.5/target/test_target_defaultmap.c
+++ b/tests/4.5/target/test_target_defaultmap.c
@@ -52,11 +52,9 @@ int test_defaultmap_off() {
     double scalar_double = 10.45;
     enum { VAL1 = 1, VAL2, VAL3, VAL4} scalar_enum = VAL1;
     
-    int isHost = 0; 
     // Map the same array to multiple devices. initialize with device number
-  #pragma omp target map(from: isHost)
+  #pragma omp target 
     {
-      isHost = omp_is_initial_device();
       scalar_char = 'b';
       scalar_short = 20;
       scalar_int = 33;
@@ -65,23 +63,12 @@ int test_defaultmap_off() {
       scalar_enum = VAL4;
     } // end of omp target 
     
-    // If it is initial device then we will modify the original memory region
-    if (isHost) {
-      OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_char != 'b');
-      OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_short != 20);
-      OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_int != 33);
-      OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_float != 6.5f);
-      OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_double != 20.45);
-      OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_enum != VAL4);
-    } else {
-      OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_char != 'a');
-      OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_short != 10);
-      OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_int != 11);
-      OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_float != 5.5f);
-      OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_double != 10.45);
-      OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_enum != VAL1);
-    }
-
+    OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_char != 'a');
+    OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_short != 10);
+    OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_int != 11);
+    OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_float != 5.5f);
+    OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_double != 10.45);
+    OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_enum != VAL1);
     
     return errors;
 }

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_defaultmap.c
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_defaultmap.c
@@ -183,18 +183,6 @@ int test_defaultmap_off() {
   OMPVV_INFOMSG("test_defaultmap_off");
 
   int errors = 0;
-  int* devtest = (int *)malloc(sizeof(int));
-
-  // Checking for sharedmemory environment
-  devtest[0] = 1;
-#pragma omp target enter data map(to: devtest[0:1])
-#pragma omp target map(alloc: devtest[0:1])
-  {
-    devtest[0] = 0;
-  }
-
-  OMPVV_WARNING_IF(devtest[0] == 0, "Shared memory environment. Scalars are not copied over but modified. This part of the tests is inconclusive");
-
 
   // we try with all the scalars
   char scalar_char = 'a';
@@ -401,16 +389,12 @@ int test_defaultmap_off() {
     }
   }
 
-  // If not shared memory, test if the scalars were not modified
-  if (devtest[0] == 1) {
-    OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_char != scalar_char_copy);
-    OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_short != scalar_short_copy);
-    OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_int != scalar_int_copy);
-    OMPVV_TEST_AND_SET_VERBOSE(errors, fabs(scalar_float - scalar_float_copy) > .00001);
-    OMPVV_TEST_AND_SET_VERBOSE(errors, fabs(scalar_double - scalar_double_copy) > .000000001);
-    OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_enum != scalar_enum_copy);
-  }
-
+  OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_char != scalar_char_copy);
+  OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_short != scalar_short_copy);
+  OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_int != scalar_int_copy);
+  OMPVV_TEST_AND_SET_VERBOSE(errors, fabs(scalar_float - scalar_float_copy) > .00001);
+  OMPVV_TEST_AND_SET_VERBOSE(errors, fabs(scalar_double - scalar_double_copy) > .000000001);
+  OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_enum != scalar_enum_copy);
 
   return errors;
 }

--- a/tests/4.5/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_defaultmap.c
+++ b/tests/4.5/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_defaultmap.c
@@ -79,7 +79,7 @@ int test_defaultmap_on() {
   return errors;
 }
 
-int test_defaultmap_off(int isOffloading, int isShared) {
+int test_defaultmap_off() {
   OMPVV_INFOMSG("test_defaultmap_off");
   
   int errors = 0;
@@ -119,7 +119,7 @@ int test_defaultmap_off(int isOffloading, int isShared) {
     OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_enum_cpy[i] != VAL1);
   }
   // Map the same array to multiple devices. initialize with device number
-#pragma omp target teams distribute parallel for map(from: isOffloading)
+#pragma omp target teams distribute parallel for 
   for (i = 0; i < ITERATIONS; ++i) {
       scalar_char = 'b';
       scalar_short = 20;
@@ -129,37 +129,21 @@ int test_defaultmap_off(int isOffloading, int isShared) {
       scalar_enum = VAL4;
   } // end of omp target 
   
-  // If it is initial device then we will modify the original memory region
-  if (!isOffloading || isShared) {
-    OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_char != 'b');
-    OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_short != 20);
-    OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_int != 33);
-    OMPVV_TEST_AND_SET_VERBOSE(errors, fabs(scalar_float - 6.5f) > 0.0001);
-    OMPVV_TEST_AND_SET_VERBOSE(errors, fabs(scalar_double - 20.45) > 0.0001);
-    OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_enum != VAL4);
-  } else {
-    OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_char != 'a');
-    OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_short != 10);
-    OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_int != 11);
-    OMPVV_TEST_AND_SET_VERBOSE(errors, fabs(scalar_float - 5.5f) > 0.0001);
-    OMPVV_TEST_AND_SET_VERBOSE(errors, fabs(scalar_double - 10.45) > 0.0001);
-    OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_enum != VAL1);
-  }
+  OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_char != 'a');
+  OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_short != 10);
+  OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_int != 11);
+  OMPVV_TEST_AND_SET_VERBOSE(errors, fabs(scalar_float - 5.5f) > 0.0001);
+  OMPVV_TEST_AND_SET_VERBOSE(errors, fabs(scalar_double - 10.45) > 0.0001);
+  OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_enum != VAL1);
   
   return errors;
 }
 int main() {
-  int isOffloading, isShared;
-  OMPVV_TEST_AND_SET_OFFLOADING(isOffloading);
-  OMPVV_TEST_AND_SET_SHARED_ENVIRONMENT(isShared);
-
-
-  OMPVV_WARNING_IF(!isOffloading, "Test running on host. Do not test defaultmap");
-  OMPVV_WARNING_IF(isOffloading && isShared, "Test running on shared data environment. Do not test defaultmap");
+  OMPVV_TEST_OFFLOADING;
 
   int errors = 0;
   OMPVV_TEST_AND_SET_VERBOSE(errors, test_defaultmap_on());
-  OMPVV_TEST_AND_SET_VERBOSE(errors, test_defaultmap_off(isOffloading, isShared));
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_defaultmap_off());
 
   OMPVV_REPORT_AND_RETURN(errors);
 }


### PR DESCRIPTION
Attempting to tackle issue #41 

There are three fixes:
1. Remove the KIND 16 from the tests 
2. Remove the char from the fortran tests since specs say:
```
1.2.6:
For Fortran: A scalar variable with intrinsic type, as defined by the base language, excluding character type.
```
3. defaultmap tests should not test for shared memory env since the default behavior is `firstprivate`. Therefore, it should always be an independent copy. 

