### PR TITLE
Adding random behavior to the templogfile to allow multiple executions

### DIFF
--- a/sys/make/make.def
+++ b/sys/make/make.def
@@ -283,4 +283,5 @@ TXTNOC := "\033[0m"
 #---------------------------------------------------------------------------
 # LOGS
 #---------------------------------------------------------------------------
-LOGTEMPFILE ?= _ompvv_temp_result_.exitstatus
+LOGRANDNUM := ${shell echo $$RANDOM}
+LOGTEMPFILE ?= _ompvv_temp_result_.exitstatus.${LOGRANDNUM}


### PR DESCRIPTION
This TEMPLOG is used to obtain the result of execution. We need to make sure it does not collide with multiple executions 