### PR TITLE
Fixing test that are not compliant with macro usage

### DIFF
--- a/tests/4.5/application_kernels/mmm_target.c
+++ b/tests/4.5/application_kernels/mmm_target.c
@@ -24,38 +24,38 @@ int main (int argc, char *argv[])
 {
   OMPVV_TEST_OFFLOADING;
   int tid, nthreads, i, j, k;
-  int	*a = (int*)malloc(sizeof(int) * rowA * colA);           // matrix A to be multiplied
-  int	*b = (int*)malloc(sizeof(int) * colA * colB);           // matrix B to be multiplied 
-  int	*c = (int*)malloc(sizeof(int) * rowA * colB);           // result matrix C 
+  int	*a = (int*) malloc(sizeof(int) * rowA * colA);           // matrix A to be multiplied
+  int	*b = (int*) malloc(sizeof(int) * colA * colB);           // matrix B to be multiplied 
+  int	*c = (int*) malloc(sizeof(int) * rowA * colB);           // result matrix C 
 
   // Initialize matrices
-  for (i=0; i<rowA; i++)
-    for (j=0; j<colA; j++)
-      a[i*rowA+j]= 10; // i+j;
-  for (i=0; i<colA; i++)
-    for (j=0; j<colB; j++)
-      b[i*colA+j]= 50; //i*j;
-  for (i=0; i<rowA; i++)
-    for (j=0; j<colB; j++)
-      c[i*rowA+j]= 0;
+  for (i = 0; i < rowA; i++)
+    for (j = 0; j < colA; j++)
+      a[i*rowA+j] = 10; // i+j;
+  for (i = 0; i < colA; i++)
+    for (j = 0; j < colB; j++)
+      b[i*colA+j] = 50; //i*j;
+  for (i = 0; i < rowA; i++)
+    for (j = 0; j < colB; j++)
+      c[i*rowA+j] = 0;
 
-  int DimA=rowA*colA;
-  int DimB=colB*colA;
-  int DimC=rowA*colA;
+  int DimA = rowA*colA;
+  int DimB = colB*colA;
+  int DimC = rowA*colA;
 
 #pragma omp target map(to: a[0:DimA],b[0:DimB]) map(from: c[0:DimC])
   {
-    for (i=0; i<rowA; i++)
-      for(j=0; j<colB; j++)
-        for(k=0; k<colA; k++)
+    for (i = 0; i < rowA; i++)
+      for(j = 0; j < colB; j++)
+        for(k = 0; k < colA; k++)
           c[i*rowA+j] = a[i*rowA+j] * b[k*colA+j];
   }//end-target
 
   // Check results
-  int error=0;
-  for (i=0; i<rowA; i++)
+  int error = 0;
+  for (i = 0; i < rowA; i++)
   {
-    for (j=0; j<colB; j++) {
+    for (j = 0; j < colB; j++) {
       OMPVV_TEST_AND_SET(error, 500 != c[i*rowA+j]);
       OMPVV_ERROR_IF(500 != c[i*rowA+j], "Error: [%d][%d] should be 500 is %d",i,j,c[i*rowA+j]);
     }

--- a/tests/4.5/application_kernels/mmm_target.c
+++ b/tests/4.5/application_kernels/mmm_target.c
@@ -1,94 +1,66 @@
-/******************************************************************************
-* DESCRIPTION:  
-*   OpenMp Example - Matrix Multiply - C Version
-*   Demonstrates a matrix multiply using OpenMP. Threads share row iterations
-******************************************************************************/
+//===--- mmm_target.c--- test that implements MM on a target region --------===//
+//
+// OpenMP API Version 4.5 Nov 2015
+//
+//  DESCRIPTION:  
+//    OpenMp Example - Matrix Multiply - C Version
+//    Demonstrates a matrix multiply using OpenMP. Threads share row iterations
+//  
+//  Last modified by Jose M Monsalve Diaz, December 25, 2019
+//
+////===----------------------------------------------------------------------===//
 
 #include <omp.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/time.h>
+#include "ompvv.h"
 
 #define rowA 100        
 #define colA 100        
 #define colB 100        
 
-struct Time{
-
-    struct timeval tmStart;
-
-    struct timeval tmEnd;
-};
-
-void startTime(struct Time * time){
-    gettimeofday(&time->tmStart, NULL);
-}
-
-void endTime(struct Time * time){ //Report time in seconds
-    gettimeofday(&time->tmEnd, NULL);
-    unsigned long long seconds =(time->tmEnd.tv_sec - time->tmStart.tv_sec) ;
-    unsigned long long milliseconds = (time->tmEnd.tv_usec - time->tmStart.tv_usec) / 1000;
-
-    unsigned long long totalMilliseconds =1000*seconds + milliseconds;
-    int totalSeconds =(int)totalMilliseconds/1000;
-
-    printf("Total time for A[%d][%d] X B[%d][%d] on device using target directive only:%d \n",rowA,colA,colA,colB,totalSeconds);
-
-}
-
-
 int main (int argc, char *argv[]) 
 {
+  OMPVV_TEST_OFFLOADING;
   int tid, nthreads, i, j, k;
-  int	*a = (int*)malloc(sizeof(int) * rowA * colA);           /* matrix A to be multiplied */
-  int	*b = (int*)malloc(sizeof(int) * colA * colB);           /* matrix B to be multiplied */
-  int	*c = (int*)malloc(sizeof(int) * rowA * colB);           /* result matrix C */
-  
-  
-    /*** Initialize matrices ***/
-    for (i=0; i<rowA; i++)
-      for (j=0; j<colA; j++)
-        a[i*rowA+j]= 10; // i+j;
-    for (i=0; i<colA; i++)
-      for (j=0; j<colB; j++)
-        b[i*colA+j]= 50; //i*j;
-    for (i=0; i<rowA; i++)
-      for (j=0; j<colB; j++){
-        c[i*rowA+j]= 0;
-      }
-   
-  
+  int	*a = (int*)malloc(sizeof(int) * rowA * colA);           // matrix A to be multiplied
+  int	*b = (int*)malloc(sizeof(int) * colA * colB);           // matrix B to be multiplied 
+  int	*c = (int*)malloc(sizeof(int) * rowA * colB);           // result matrix C 
+
+  // Initialize matrices
+  for (i=0; i<rowA; i++)
+    for (j=0; j<colA; j++)
+      a[i*rowA+j]= 10; // i+j;
+  for (i=0; i<colA; i++)
+    for (j=0; j<colB; j++)
+      b[i*colA+j]= 50; //i*j;
+  for (i=0; i<rowA; i++)
+    for (j=0; j<colB; j++)
+      c[i*rowA+j]= 0;
+
   int DimA=rowA*colA;
   int DimB=colB*colA;
   int DimC=rowA*colA;
-  struct Time * time= (struct Time *)malloc(sizeof(struct Time));
-  startTime(time);
-  
+
 #pragma omp target map(to: a[0:DimA],b[0:DimB]) map(from: c[0:DimC])
-{
+  {
     for (i=0; i<rowA; i++)
       for(j=0; j<colB; j++)
         for(k=0; k<colA; k++)
           c[i*rowA+j] = a[i*rowA+j] * b[k*colA+j];
-}//end-target
-  
-  endTime(time);
-  
-  /*** Print results ***/
+  }//end-target
+
+  // Check results
   int error=0;
   for (i=0; i<rowA; i++)
   {
-    for (j=0; j<colB; j++)
-      if( 500 != c[i*rowA+j]){
-        printf("Error: [%d][%d] should be 500 is %d\n",i,j,c[i*rowA+j]);
-        error++;
-     }
-   
+    for (j=0; j<colB; j++) {
+      OMPVV_TEST_AND_SET(error, 500 != c[i*rowA+j]);
+      OMPVV_ERROR_IF(500 != c[i*rowA+j], "Error: [%d][%d] should be 500 is %d",i,j,c[i*rowA+j]);
+    }
   }
-  if(error)
-    printf("Test NOT PASSED\n");
-  else
-    printf ("Test PASSED.\n");
-  
+
+  OMPVV_REPORT_AND_RETURN(error);
 }
 

--- a/tests/4.5/application_kernels/mmm_target_parallel_for_simd.c
+++ b/tests/4.5/application_kernels/mmm_target_parallel_for_simd.c
@@ -1,95 +1,67 @@
-/******************************************************************************
-* DESCRIPTION:  
-*   OpenMp Example - Matrix Multiply - C Version
-*   Demonstrates a matrix multiply using OpenMP. Threads share row iterations
-******************************************************************************/
-
+//===--- mmm_target_parallel_for_simd.c--- MM on a target parallel for simd--===//
+//
+// OpenMP API Version 4.5 Nov 2015
+//
+//  DESCRIPTION:  
+//    OpenMp Example - Matrix Multiply - C Version
+//    Demonstrates a matrix multiply using OpenMP. Threads share row iterations
+//  
+//  Last modified by Jose M Monsalve Diaz, December 25, 2019
+//
+////===----------------------------------------------------------------------===//
 #include <omp.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/time.h>
+#include "ompvv.h"
 
 #define rowA 500        
 #define colA 500        
 #define colB 500        
 
-struct Time{
-
-    struct timeval tmStart;
-
-    struct timeval tmEnd;
-};
-
-void startTime(struct Time * time){
-    gettimeofday(&time->tmStart, NULL);
-}
-
-void endTime(struct Time * time){ //Report time in seconds
-    gettimeofday(&time->tmEnd, NULL);
-    unsigned long long seconds =(time->tmEnd.tv_sec - time->tmStart.tv_sec) ;
-    unsigned long long milliseconds = (time->tmEnd.tv_usec - time->tmStart.tv_usec) / 1000;
-
-    unsigned long long totalMilliseconds =1000*seconds + milliseconds;
-    int totalSeconds =(int)totalMilliseconds/1000;
-
-    printf("Total time for A[%d][%d] X B[%d][%d]with target+distributed parallel for+simd:%d \n",rowA,colA,colA,colB,totalSeconds);
-
-}
-
 
 int main (int argc, char *argv[]) 
 {
+  OMPVV_TEST_OFFLOADING;
   int tid, nthreads, i, j, k;
-  int	*a = (int*)malloc(sizeof(int) * rowA * colA);           /* matrix A to be multiplied */
-  int	*b = (int*)malloc(sizeof(int) * colA * colB);           /* matrix B to be multiplied */
-  int	*c = (int*)malloc(sizeof(int) * rowA * colB);           /* result matrix C */
-  
-  
-    /*** Initialize matrices ***/
-    for (i=0; i<rowA; i++)
-      for (j=0; j<colA; j++)
-        a[i*rowA+j]= 10; // i+j;
-    for (i=0; i<colA; i++)
-      for (j=0; j<colB; j++)
-        b[i*colA+j]= 50; //i*j;
-    for (i=0; i<rowA; i++)
-      for (j=0; j<colB; j++){
-        c[i*rowA+j]= 0;
-      }
-   
-  
-  int DimA=rowA*colA;
-  int DimB=colB*colA;
-  int DimC=rowA*colA;
-  struct Time * time= (struct Time *)malloc(sizeof(struct Time));
-  startTime(time);
-  
-#pragma omp target map(to: a[0:DimA],b[0:DimB]) map(from: c[0:DimC])
-{
-#pragma omp teams distribute parallel for simd collapse(2) private(k)
-    for (i=0; i<rowA; i++)
-      for(j=0; j<colB; j++)
-        for(k=0; k<colA; k++)
-          c[i*rowA+j] = a[i*rowA+j] * b[k*colA+j];
-}//end-target
-  
-  endTime(time);
-  
-  /*** Print results ***/
-  int error=0;
-  for (i=0; i<rowA; i++)
+  int	*a = (int*) malloc(sizeof(int) * rowA * colA);           // matrix A to be multiplied
+  int	*b = (int*) malloc(sizeof(int) * colA * colB);           // matrix B to be multiplied 
+  int	*c = (int*) malloc(sizeof(int) * rowA * colB);           // result matrix C 
+
+  // Initialize matrices
+  for (i = 0; i < rowA; i++)
+    for (j = 0; j < colA; j++)
+      a[i*rowA+j] = 10; // i+j;
+  for (i = 0; i < colA; i++)
+    for (j = 0; j < colB; j++)
+      b[i*colA+j] = 50; //i*j;
+  for (i = 0; i < rowA; i++)
+    for (j = 0; j < colB; j++)
+      c[i*rowA+j] = 0;
+
+  int DimA = rowA*colA;
+  int DimB = colB*colA;
+  int DimC = rowA*colA;
+
+#pragma omp target map(to: a[0:DimA], b[0:DimB]) map(from: c[0:DimC])
   {
-    for (j=0; j<colB; j++)
-      if( 500 != c[i*rowA+j]){
-        printf("Error: [%d][%d] should be 500 is %d\n",i,j,c[i*rowA+j]);
-        error++;
-     }
-   
+#pragma omp teams distribute parallel for simd collapse(2) private(k)
+    for (i = 0; i < rowA; i++)
+      for(j = 0; j < colB; j++)
+        for(k = 0; k < colA; k++)
+          c[i*rowA+j] = a[i*rowA+j] * b[k*colA+j];
+  }//end-target
+
+  // Check results
+  int error = 0;
+  for (i = 0; i < rowA; i++)
+  {
+    for (j = 0; j < colB; j++) {
+      OMPVV_TEST_AND_SET(error, 500 != c[i*rowA+j]);
+      OMPVV_ERROR_IF(500 != c[i*rowA+j], "Error: [%d][%d] should be 500 is %d",i,j,c[i*rowA+j]);
+    }
   }
-  if(error)
-    printf("Test NOT PASSED\n");
-  else
-    printf ("Test PASSED.\n");
-  
+
+  OMPVV_REPORT_AND_RETURN(error);
 }
 

--- a/tests/4.5/target/test_target_device.c
+++ b/tests/4.5/target/test_target_device.c
@@ -1,3 +1,17 @@
+//===--- test_target_map_devices.c --- target map to multiple devces ---------===//
+//
+// OpenMP API Version 4.5 Nov 2015
+//
+//  This test checks for data mapping on multiple devices when using the target
+//  directive. It makes sure that data mapping is happening on each device
+//  through the use of omp_set_default_device as well as the device() clause
+//
+//  Since OpenMP 4.5 does not have an API call to obtain the current device, 
+//  this test does not guarantee that the execution devices are different. 
+//  
+//  Last modified by Jose M Monsalve Diaz, December 25, 2019
+//
+////===----------------------------------------------------------------------===//
 #include <assert.h>
 #include <omp.h>
 #include <stdio.h>

--- a/tests/4.5/target_data/test_target_data_map_devices.c
+++ b/tests/4.5/target_data/test_target_data_map_devices.c
@@ -1,34 +1,47 @@
+//===--- test_target_data_map_devices.c--- target data map to multiple dev--===//
+//
+// OpenMP API Version 4.5 Nov 2015
+//
+//  This test checks for data mapping on multiple devices when using the target
+//  data directive. It makes sure that data mapping is happening on each device
+//  through the use of omp_set_default_device as well as the device() clause
+//
+//  Since OpenMP 4.5 does not have an API call to obtain the current device, 
+//  this test does not guarantee that the execution devices are different. 
+//  
+//  Last modified by Jose M Monsalve Diaz, December 25, 2019
+//
+////===----------------------------------------------------------------------===//
 #include <assert.h>
 #include <omp.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include "ompvv.h"
 
 #define N 1000
 
 // Test for OpenMP 4.5 target data to multiple devices using API
 int test_map_set_default_dev() {
+  OMPVV_INFOMSG("test_set_default_device");
 
-  puts("test_map_set_default_dev");
-
-  // Get number of devices 
+  // Get number of devices
   int num_dev = omp_get_num_devices();
-  printf("num_devices: %d\n", num_dev);
+  OMPVV_INFOMSG("num_devices: %d", num_dev);
 
   int def_dev = omp_get_default_device();
-  printf("initial device: %d\n", omp_get_initial_device());
-  printf("default device: %d\n", def_dev);
+  OMPVV_INFOMSG("initial device: %d", omp_get_initial_device());
+  OMPVV_INFOMSG("default device: %d", def_dev);
 
-  int sum[num_dev], errors = 0, isHost = 0;
-  int* h_matrix = (int*) malloc(num_dev*N*sizeof(int));
+  int sum[num_dev], errors = 0;
+  int* h_matrix = (int*) malloc(num_dev * N * sizeof(int));
 
   for (int dev = 0; dev < num_dev; ++dev) {
     omp_set_default_device(dev);
-#pragma omp target data map(from: h_matrix[dev*N:N]) map(tofrom: errors)
+#pragma omp target data map(from: h_matrix[dev*N:N])
     {
-      errors = dev == omp_get_default_device();
-#pragma omp target map(from: h_matrix[dev*N:N]) map(tofrom: isHost)
+      OMPVV_TEST_AND_SET_VERBOSE(errors, dev != omp_get_default_device());
+#pragma omp target map(alloc: h_matrix[dev*N:N])
       {
-        isHost = omp_is_initial_device();
         for (int i = 0; i < N; ++i)
           h_matrix[dev*N + i] = dev;
       } // end target
@@ -36,18 +49,12 @@ int test_map_set_default_dev() {
   }
 
   // checking results 
-  errors = 0;
   for (int dev = 0; dev < num_dev; ++dev) {
     sum[dev] = h_matrix[dev*N + 0];
     for (int i = 1; i < N; ++i)
       sum[dev] += h_matrix[dev*N + i];
-    errors |= (dev * N != sum[dev]);
+    OMPVV_TEST_AND_SET_VERBOSE(errors, (dev * N != sum[dev]));
   }
-
-  if (!errors)
-    printf("Test passed on %s\n", (isHost ? "host" : "device"));
-  else
-    printf("Test failed on %s: num_devices = %d\n", (isHost ? "host" : "device"), num_dev);
 
   omp_set_default_device(def_dev);
 
@@ -57,24 +64,23 @@ int test_map_set_default_dev() {
 // Test for OpenMP 4.5 target data to multiple devices using directives
 int test_map_device() {
 
-  puts("test_map_device");
+  OMPVV_INFOMSG("test_map_device");
 
   // Get number of devices 
   int num_dev = omp_get_num_devices();
-  printf("num_devices: %d\n", num_dev);
+  OMPVV_INFOMSG("num_devices: %d", num_dev);
 
-  printf("initial device: %d\n", omp_get_initial_device());
-  printf("default device: %d\n", omp_get_default_device());
+  OMPVV_INFOMSG("initial device: %d", omp_get_initial_device());
+  OMPVV_INFOMSG("default device: %d", omp_get_default_device());
 
-  int sum[num_dev], errors = 0, isHost = 0;
-  int* h_matrix = (int*) malloc(num_dev*N*sizeof(int));
+  int sum[num_dev], errors = 0;
+  int* h_matrix = (int*) malloc(num_dev * N * sizeof(int));
 
   for (int dev = 0; dev < num_dev; ++dev) {
 #pragma omp target data map(from: h_matrix[dev*N:N]) device(dev)
     {
-#pragma omp target map(from: h_matrix[dev*N:N]) device(dev) map(tofrom: isHost)
+#pragma omp target map(alloc: h_matrix[dev*N:N]) device(dev)
       {
-        isHost = omp_is_initial_device();
         for (int i = 0; i < N; ++i)
           h_matrix[dev*N + i] = dev;
       } // end target
@@ -87,91 +93,18 @@ int test_map_device() {
     sum[dev] = h_matrix[dev*N + 0];
     for (int i = 1; i < N; ++i)
       sum[dev] += h_matrix[dev*N + i];
-    errors |= (dev * N != sum[dev]);
+    OMPVV_TEST_AND_SET_VERBOSE(errors, (dev * N != sum[dev]));
   }
-
-  if (!errors)
-    printf("Test passed on %s\n", (isHost ? "host" : "device"));
-  else
-    printf("Test failed on %s: num_devices = %d\n", (isHost ? "host" : "device"), num_dev);
 
   return errors;
 }
 
-// We are commenting this code out because passing more devices that available
-// is not supported by the specifications. This test is passing on clang/20170629,
-// xl/20170727-beta and gcc/7.1.1-20170802 but produces a side effect runtime error
-// 1587-160 on xl and clang. Gcc produces no error
-
-//// Test for OpenMP 4.5 target data to more than available devices using API
-//int test_more_devices() {
-//
-//  puts("test_more_devices");
-//
-//  // Get number of devices 
-//  int real_num_dev = omp_get_num_devices();
-//  int num_dev = real_num_dev + 2;
-//  printf("num_devices: %d, real_num_devices: %d\n", num_dev, real_num_dev);
-//
-//  int def_dev = omp_get_default_device();
-//  printf("initial device: %d\n", omp_get_initial_device());
-//  printf("default device: %d\n", def_dev);
-//
-//  int sum[num_dev], errors = 0, extra_on_host = 0, isHost = 0;
-//  int* h_matrix = (int*) malloc(num_dev*N*sizeof(int));
-//
-//  // omp_set_default_device is implementation dependent 
-//  for (int dev = 0; dev < num_dev; ++dev) {
-//    omp_set_default_device(dev);
-//    int dev_tmp = omp_get_default_device();
-//#pragma omp target data map(from: h_matrix[dev_tmp*N:N])
-//    {
-//      errors = dev == dev_tmp;
-//#pragma omp target map(from: h_matrix[dev_tmp*N:N])    \
-//        map(tofrom: extra_on_host) map(tofrom: isHost)
-//      {
-//        isHost = omp_is_initial_device();
-//        if (!isHost) {
-//          for (int i = 0; i < N; ++i)
-//            h_matrix[dev_tmp*N + i] = dev;
-//        } else {
-//          // allows implementations that map extra devices to the host 
-//          extra_on_host = 1;
-//          for (int i = 0; i < N; ++i)
-//            h_matrix[dev_tmp*N + i] = dev;
-//        }
-//      } // end target
-//    } // end target data
-//  }
-//
-//  // checking results 
-//  errors = 0;
-//  for (int dev = 0; dev < num_dev; ++dev) {
-//    sum[dev] = h_matrix[dev*N + 0];
-//    for (int i = 1; i < N; ++i)
-//      sum[dev] += h_matrix[dev*N + i];
-//    errors |= (dev*N != sum[dev]);
-//    if (errors)
-//      printf("Error at dev=%d\n", dev);
-//  }
-//
-//  if (!errors)
-//    printf("Test passed on %s\n", (isHost ? "host" : "device"));
-//  else
-//    printf("Test failed on %s: num_devices = %d, real_num_dev = %d, extra_on_host = %d\n", (isHost ? "host" : "device"), num_dev, real_num_dev, extra_on_host);
-//
-//  omp_set_default_device(def_dev);
-//
-//  return errors;
-//}
-
 int main() {
-
+  OMPVV_TEST_OFFLOADING;
   int errors = 0;
 
-  errors += test_map_set_default_dev();
-  errors += test_map_device();
-  //errors += test_more_devices();
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_map_set_default_dev());
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_map_device());
 
-  return errors;
+  OMPVV_REPORT_AND_RETURN(errors);
 }


### PR DESCRIPTION
These are changes to old tests that are not compliant with macro usage. In this PR we have 5 tests:

* tests/4.5/application_kernels/linked_list.c
* tests/4.5/application_kernels/mmm_target.c
* tests/4.5/application_kernels/mmm_target_parallel_for_simd.c
*  tests/4.5/target/test_target_device.c
*  tests/4.5/target_data/test_target_data_map_devices.c

More to come in a new PR

This is to make some progress in issue #10 