### PR TITLE
New test/test target teams distribute dist schedule

### DIFF
--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_dist_schedule.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_dist_schedule.F90
@@ -1,0 +1,41 @@
+!===------ test_target_teams_distribute_dist_schedule.F90 ----------------===//
+! 
+! OpenMP API Version 4.5 Nov 2015
+! 
+! This test checks that the dist_schedule clause (which must have kind 
+! static) correctly causes CHUNK_SIZE iterations to be split among the
+! number of teams the test is run with, in a round-robin faction in order
+! of the team number, when a chunk size is given. The test also confirms
+! that when no chunk size is given, that each team receives no more than
+! one chunk.
+!
+!===----------------------------------------------------------------------===//
+
+#include "ompvv.F90"
+
+#define N 1024
+#define CHUNK_SIZE 64
+
+PROGRAM main
+  USE iso_fortran_env
+  USE ompvv_lib
+  implicit none
+
+  OMPVV_TEST_OFFLOADING
+
+  OMPVV_TEST_SHARED_ENVIRONMENT
+
+  OMPVV_TEST_VERBOSE(test_function() .ne. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION test_dist_schedule() 
+    INTEGER:: errors
+    test_function = 1;
+    !$omp target map(from: errors)
+    test_function = 0;
+    !$omp end target
+    test_dist_schedule = errors
+  END FUNCTION test_dist_schedule
+END PROGRAM main

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_dist_schedule.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_dist_schedule.F90
@@ -55,7 +55,7 @@ CONTAINS
     IF (num_teams .eq. 1) THEN
        OMPVV_WARNING("Cannot test because num_teams was 1.")
     ELSE IF (num_teams .lt. 1) THEN
-       OMPVV_ERROR("omp_get_num_teams(0 returned less than 1.")
+       OMPVV_ERROR("omp_get_num_teams() returned less than 1.")
        errors = errors + 1
     ELSE
        DO x = 1, N

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_dist_schedule.c
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_dist_schedule.c
@@ -38,7 +38,7 @@ int test_dist_schedule() {
     a[i] = omp_get_team_num();
   }
 
-  if (num_teams < 1) {
+  if (num_teams == 1) {
     OMPVV_WARNING("Cannot test dist_schedule(static, chunk_size) because num_teams was 1.");
   } else if (num_teams < 1) {
     OMPVV_ERROR("omp_get_num_teams() returned a value less than 1.");

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_dist_schedule.c
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_dist_schedule.c
@@ -1,0 +1,74 @@
+//===------ test_target_teams_distribute_dist_schedule.c ------------------===//
+// 
+// OpenMP API Version 4.5 Nov 2015
+// 
+// This test checks that the dist_schedule clause (which must have kind 
+// static) correctly causes CHUNK_SIZE iterations to be split among the
+// number of teams the test is run with, in a round-robin faction in order
+// of the team number, when a chunk size is given. The test also confirms
+// that when no chunk size is given, that each team receives no more than
+// one chunk.
+// 
+//===----------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+#define CHUNK_SIZE 64
+
+int test_dist_schedule() {
+  int errors = 0;
+  int num_teams_a, num_teams_b;
+  int a[N];
+  int b[N];
+  int a_check[N];
+  int b_check[N];
+
+  for (int i = 0; i < N; ++i) {
+    a[i] = -1;
+    b[i] = -1;
+  }
+
+#pragma omp target teams distribute map(from: num_teams_a) map(tofrom: a[0:N]) dist_schedule(static, CHUNK_SIZE)
+  for (int i = 0; i < N; ++i) {
+    if (omp_get_team_num() == 0) {
+      num_teams_a = omp_get_num_teams();
+    }
+    a[i] = omp_get_team_num();
+  }
+
+  for (int i = 0; i < N; ++i) {
+    printf("%d ", a[i]);
+  }
+  printf("\n\n");
+
+#pragma omp target teams distribute map(from: num_teams_b) map(tofrom: b[0:N]) dist_schedule(static)
+  for (int i = 0; i < N; ++i) {
+    if (omp_get_team_num() == 0) {
+      num_teams_b = omp_get_num_teams();
+    }
+    b[i] = omp_get_team_num();
+  }
+
+  for (int i = 0; i < N; ++i) {
+    printf("%d ", b[i]);
+  }
+  printf("\n");
+
+  return errors;
+}
+
+int main() {
+  OMPVV_TEST_OFFLOADING;
+
+  OMPVV_TEST_SHARED_ENVIRONMENT;
+
+  int errors = 0;
+
+  errors = test_dist_schedule();
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}


### PR DESCRIPTION
This test checks the behavior of `dist_schedule(kind [, chunk_size])` on target teams distribute by using reported team num to check that the distribution matches the specified schedule. The clause is tested with and without a chunk size, and for kind `static`, which is the only method availible on this construct.

These tests pass all summit compilers.