### PR TITLE
Add Fortran version of basic distribute test and fix some small errors

### DIFF
--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute.F90
@@ -45,24 +45,20 @@ CONTAINS
     END DO
     !$omp end target data
 
-    IF (num_teams(1) .eq. 1) THEN
-       OMPVV_WARNING("Test ran with one team, can't guarantee parallelism of teams")
-    ELSE IF (num_teams(1) .lt. 1) THEN
-       OMPVV_ERROR("omp_get_num_teams() reported a value below one")
-       errors = errors + 1
-    END IF
+    OMPVV_WARNING_IF(num_teams(1) .eq. 1, "Test ran with one team, can't guarantee parallelism of teams")
 
-    DO x = 2, N
-       IF (num_teams(x) .ne. num_teams(x - 1)) THEN
-          OMPVV_ERROR("Test reported an inconsistent number of teams")
-          errors = errors + 1
-       END IF
-       OMPVV_TEST_AND_SET_VERBOSE(errors, a(x) .ne. 1 + b(x))
-       IF (a(x) .ne. 1 + b(x)) THEN
-          errors = errors + 1
-          exit
-       END IF
-    END DO
+    OMPVV_TEST_AND_SET_VERBOSE(errors, num_teams(1) .lt. 1)
+
+    IF (errors .eq. 0) THEN 
+       DO x = 2, N
+          OMPVV_TEST_AND_SET_VERBOSE(errors, num_teams(x) .ne. num_teams(x - 1))
+          OMPVV_ERROR_IF(num_teams(x) .ne. num_teams(x - 1), "Test reported an inconsistent number of teams")
+          OMPVV_TEST_AND_SET_VERBOSE(errors, a(x) .ne. 1 + b(x))
+          IF (errors .gt. 0) THEN
+             exit
+          END IF
+       END DO
+    END IF
 
     test_distribute = errors
   END FUNCTION test_distribute

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute.F90
@@ -1,0 +1,69 @@
+!===--- test_target_teams_distribute.F90 -----------------------------------===//
+!
+! OpenMP API Version 4.5 Nov 2015
+!
+! This test uses the target teams distribute directive and tests to validate
+! that computation inside the region executes properly.
+!
+!//===----------------------------------------------------------------------===//
+
+#include "ompvv.F90"
+
+#define N 1024
+
+PROGRAM test_target_teams_distribute
+  USE iso_fortran_env
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+
+  OMPVV_TEST_OFFLOADING
+
+  OMPVV_TEST_SHARED_ENVIRONMENT
+
+  OMPVV_TEST_VERBOSE(test_distribute() .ne. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION test_distribute()
+    INTEGER,DIMENSION(N):: num_teams, a, b
+    INTEGER:: errors, x
+    errors = 0
+
+    DO x = 1, N
+       a(x) = 1
+       b(x) = x
+       num_teams(x) = -1
+    END DO
+
+    !$omp target data map(tofrom: a(1:N), num_teams(1:N)) map(to: b(1:N))
+    !$omp target teams distribute map(alloc: a(1:N), num_teams(1:N), b(1:N))
+    DO x = 1, N
+       num_teams(x) = omp_get_num_teams();
+       a(x) = a(x) + b(x)
+    END DO
+    !$omp end target data
+
+    IF (num_teams(1) .eq. 1) THEN
+       OMPVV_WARNING("Test ran with one team, can't guarantee parallelism of teams")
+    ELSE IF (num_teams(1) .lt. 1) THEN
+       OMPVV_ERROR("omp_get_num_teams() reported a value below one")
+       errors = errors + 1
+    END IF
+
+    DO x = 2, N
+       IF (num_teams(x) .ne. num_teams(x - 1)) THEN
+          OMPVV_ERROR("Test reported an inconsistent number of teams")
+          errors = errors + 1
+       END IF
+       OMPVV_TEST_AND_SET_VERBOSE(errors, a(x) .ne. 1 + b(x))
+       IF (a(x) .ne. 1 + b(x)) THEN
+          errors = errors + 1
+          exit
+       END IF
+    END DO
+
+    test_distribute = errors
+  END FUNCTION test_distribute
+END PROGRAM test_target_teams_distribute

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute.F90
@@ -37,19 +37,17 @@ CONTAINS
        num_teams(x) = -1
     END DO
 
-    !$omp target data map(tofrom: a(1:N), num_teams(1:N)) map(to: b(1:N))
-    !$omp target teams distribute map(alloc: a(1:N), num_teams(1:N), b(1:N))
+    !$omp target teams distribute map(tofrom: a(1:N), num_teams(1:N)) map(to: b(1:N))
     DO x = 1, N
        num_teams(x) = omp_get_num_teams();
        a(x) = a(x) + b(x)
     END DO
-    !$omp end target data
 
     OMPVV_WARNING_IF(num_teams(1) .eq. 1, "Test ran with one team, can't guarantee parallelism of teams")
 
     OMPVV_TEST_AND_SET_VERBOSE(errors, num_teams(1) .lt. 1)
 
-    IF (errors .eq. 0) THEN 
+    IF (errors .eq. 0) THEN
        DO x = 2, N
           OMPVV_TEST_AND_SET_VERBOSE(errors, num_teams(x) .ne. num_teams(x - 1))
           OMPVV_ERROR_IF(num_teams(x) .ne. num_teams(x - 1), "Test reported an inconsistent number of teams")

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute.F90
@@ -27,6 +27,7 @@ PROGRAM test_target_teams_distribute
 
 CONTAINS
   INTEGER FUNCTION test_distribute()
+    CHARACTER(len=300):: infoMsg
     INTEGER,DIMENSION(N):: num_teams, a, b
     INTEGER:: errors, x
     errors = 0
@@ -57,6 +58,9 @@ CONTAINS
           END IF
        END DO
     END IF
+
+    WRITE(infoMsg, *) "Test passed with", num_teams(1), "teams."
+    OMPVV_INFOMSG_IF(errors .eq. 0, infoMsg)
 
     test_distribute = errors
   END FUNCTION test_distribute

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute.c
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute.c
@@ -12,50 +12,50 @@
 #include <stdlib.h>
 #include "ompvv.h"
 
-#define ARRAY_SIZE 1024
+#define N 1024
 
 int main() {
-  int a[ARRAY_SIZE];
-  int b[ARRAY_SIZE];
-  int num_teams[ARRAY_SIZE];
+  int a[N];
+  int b[N];
+  int num_teams[N];
   int errors = 0;
   int is_offloading;
 
   OMPVV_TEST_AND_SET_OFFLOADING(is_offloading);
+  OMPVV_TEST_SHARED_ENVIRONMENT
+
   // a and b array initialization
-  for (int x = 0; x < ARRAY_SIZE; ++x) {
+  for (int x = 0; x < N; ++x) {
     a[x] = 1;
     b[x] = x;
     num_teams[x] = -1;
   }
 
-#pragma omp target data map(tofrom: a[0:ARRAY_SIZE], num_teams[0:ARRAY_SIZE]) map(to: b[0:ARRAY_SIZE])
+#pragma omp target data map(tofrom: a[0:N], num_teams[0:N]) map(to: b[0:N])
   {
-#pragma omp target teams distribute map(alloc: a[0:ARRAY_SIZE], b[0:ARRAY_SIZE], num_teams[0:ARRAY_SIZE])
-    for (int x = 0; x < ARRAY_SIZE; ++x) {
+#pragma omp target teams distribute map(alloc: a[0:N], b[0:N], num_teams[0:N])
+    for (int x = 0; x < N; ++x) {
       num_teams[x] = omp_get_num_teams();
       a[x] += b[x];
     }
   }
 
-
-  for (int x = 0; x < ARRAY_SIZE; ++x) {
-    if (x > 0 && num_teams[x] != num_teams[x - 1]) {
+  if (num_teams[0] == 1) {
+    OMPVV_WARNING("Test operated with one team.  Parallelism of teams distribute can't be guaranteed.");
+  } else if (num_teams[0] < 1) {
+    OMPVV_ERROR("omp_get_num_teams() reported a value below one.");
+  }
+  
+  for (int x = 1; x < N; ++x) {
+    if (num_teams[x] != num_teams[x - 1]) {
       OMPVV_ERROR("Test reported an inconsistent number of teams between loop iterations.");
-      errors += 1;
+      errors++;
     }
     OMPVV_TEST_AND_SET_VERBOSE(errors, (a[x] != 1 + b[x]));
     if (a[x] != 1 + b[x]){
+      errors++;
       break;
     }
-  }
-
-  if (num_teams[0] == 1) {
-    OMPVV_WARNING("Test operated with one team.  Parallelism of teams distribute can't be guaranteed.");
-  }
-
-  if (!is_offloading) {
-    OMPVV_WARNING("Test operated on host.  Target region was ignored.");
   }
 
   OMPVV_REPORT_AND_RETURN(errors);

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute.c
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute.c
@@ -31,13 +31,10 @@ int main() {
     num_teams[x] = -1;
   }
 
-#pragma omp target data map(tofrom: a[0:N], num_teams[0:N]) map(to: b[0:N])
-  {
-#pragma omp target teams distribute map(alloc: a[0:N], b[0:N], num_teams[0:N])
-    for (int x = 0; x < N; ++x) {
-      num_teams[x] = omp_get_num_teams();
-      a[x] += b[x];
-    }
+#pragma omp target teams distribute map(tofrom: a[0:N], num_teams[0:N]) map(to: b[0:N])
+  for (int x = 0; x < N; ++x) {
+    num_teams[x] = omp_get_num_teams();
+    a[x] += b[x];
   }
 
   if (num_teams[0] == 1) {
@@ -45,7 +42,7 @@ int main() {
   } else if (num_teams[0] < 1) {
     OMPVV_ERROR("omp_get_num_teams() reported a value below one.");
   }
-  
+
   for (int x = 1; x < N; ++x) {
     if (num_teams[x] != num_teams[x - 1]) {
       OMPVV_ERROR("Test reported an inconsistent number of teams between loop iterations.");

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute.c
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute.c
@@ -55,5 +55,7 @@ int main() {
     }
   }
 
+  OMPVV_INFOMSG_IF(!errors, "Test passed with %d teams.", num_teams[0]);
+
   OMPVV_REPORT_AND_RETURN(errors);
 }

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_collapse.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_collapse.F90
@@ -1,4 +1,4 @@
-!===--- test_target_teams_distribute.F90------------------------------------===//
+!===--- test_target_teams_distribute_collapse.F90 --------------------------===//
 !
 ! OpenMP API Version 4.5 Nov 2015
 !
@@ -21,7 +21,7 @@
         errors = 0
         OMPVV_TEST_OFFLOADING
 
-        OMPVV_WARNING("Testing of collasping cannot be tested.")
+        OMPVV_WARNING("Collapse cannot be postively tested.")
         OMPVV_WARNING("Test only verifies that the collapse doesn't ")
         OMPVV_WARNING("collapse too many loops.")
         OMPVV_TEST_VERBOSE(test_collapse1() .ne. 0)


### PR DESCRIPTION
This tests add a passing fortran version of the basic `target teams distribute` test, and also fixes some small errors in the c version and the collapse test. Both tests pass all summit compilers. 