### PR TITLE
Add Fortran version of shared test and minor cleanup

### DIFF
--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_shared.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_shared.F90
@@ -6,11 +6,12 @@
 ! tests in a few ways that the variable is shared between the teams.  In the
 ! first test, the atomic directive is used to indicate that all operations on
 ! the variable should be done atomically.  If the value is the correct value
-! at the end of the region, then all teams operated on the same variable.
+! at the end of the region, then all teams operated on the same variable, and
+! the variable was not privatized.
 !
 ! The second test, instead of writing to the variable, only reads from the
 ! variable.  This tests that the value of the shared variable has not been
-! initiallized improperly or privatized.
+! initialized improperly.
 !
 !//===----------------------------------------------------------------------===//
 

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_shared.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_shared.F90
@@ -1,0 +1,71 @@
+!===--- test_target_teams_distribute_shared.F90-----------------------------===//
+!
+! OpenMP API Version 4.5 Nov 2015
+!
+! This test uses the shared clause on a target teams distribute directive and
+! tests in a few ways that the variable is shared between the teams.  In the
+! first test, the atomic directive is used to indicate that all operations on
+! the variable should be done atomically.  If the value is the correct value
+! at the end of the region, then all teams operated on the same variable.
+!
+! The second test, instead of writing to the variable, only reads from the
+! variable.  This tests that the value of the shared variable has not been
+! initiallized improperly or privatized.
+!
+!//===----------------------------------------------------------------------===//
+
+#include "ompvv.F90"
+
+#define N 1024
+
+PROGRAM test_target_teams_distribute_shared
+  USE iso_fortran_env
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+
+  OMPVV_TEST_OFFLOADING
+  OMPVV_TEST_SHARED_ENVIRONMENT
+  OMPVV_TEST_VERBOSE(test_shared() .ne. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+CONTAINS
+  INTEGER FUNCTION test_shared()
+    INTEGER,DIMENSION(N):: a
+    INTEGER:: share, errors, x
+    errors = 0
+
+    DO x = 1, N
+       a(x) = x
+    END DO
+
+    !$omp target teams distribute num_teams(10) shared(share) &
+    !$omp& defaultmap(tofrom:scalar)
+    DO x = 1, N
+       !$omp atomic
+       share = share + a(x)
+    END DO
+
+    DO x = 1, N
+       share = share - x
+    END DO
+
+    OMPVV_TEST_AND_SET_VERBOSE(errors, share .ne. 0)
+    OMPVV_ERROR_IF(errors .ne. 0, "Shared variable written incorrectly")
+    
+    share = 5
+    
+    !$omp target data map(tofrom: a(1:N)) map(tofrom: share)
+    !$omp target teams distribute num_teams(10) shared(share)
+    DO x = 1, N
+       a(x) = a(x) + share
+    END DO
+    !$omp end target data
+
+    DO x = 1, N
+       OMPVV_TEST_AND_SET_VERBOSE(errors, a(x) - 5 .ne. x)
+    END DO
+
+    test_shared = errors
+  END FUNCTION test_shared
+END PROGRAM test_target_teams_distribute_device

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_shared.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_shared.F90
@@ -69,6 +69,7 @@ CONTAINS
           OMPVV_ERROR("Shared variable read incorrectly")
           errors = errors + 1
           exit
+       END IF
     END DO
 
     test_shared = errors

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_shared.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_shared.F90
@@ -36,25 +36,26 @@ CONTAINS
     INTEGER,DIMENSION(N):: a
     INTEGER:: share, errors, x
     errors = 0
+    share = 0
 
     DO x = 1, N
        a(x) = x
     END DO
 
     !$omp target teams distribute num_teams(10) shared(share) &
-    !$omp& defaultmap(tofrom:scalar)
+    !$omp& defaultmap(tofrom:scalar) map(to: a(1:N))
     DO x = 1, N
        !$omp atomic
        share = share + a(x)
     END DO
 
     DO x = 1, N
-       share = share - x
+       share = share - a(x)
     END DO
 
     WRITE(errMsg, *) "Share was", share, "but expected 0"
     OMPVV_TEST_AND_SET_VERBOSE(errors, share .ne. 0)
-    OMPVV_ERROR_IF(errors .ne. 0, errMsg)
+    OMPVV_ERROR_IF(share .ne. 0, errMsg)
 
     share = 5
 

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_shared.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_shared.F90
@@ -50,8 +50,10 @@ CONTAINS
        share = share - x
     END DO
 
-    OMPVV_TEST_AND_SET_VERBOSE(errors, share .ne. 0)
-    OMPVV_ERROR_IF(errors .ne. 0, "Shared variable written incorrectly")
+    IF (share .ne. 0) THEN
+       OMPVV_ERROR("Shared variable written incorrectly")
+       errors = errors + 1
+    END IF
     
     share = 5
     
@@ -63,9 +65,12 @@ CONTAINS
     !$omp end target data
 
     DO x = 1, N
-       OMPVV_TEST_AND_SET_VERBOSE(errors, a(x) - 5 .ne. x)
+       IF ((a(x) - 5) .ne. x) THEN
+          OMPVV_ERROR("Shared variable read incorrectly")
+          errors = errors + 1
+          exit
     END DO
 
     test_shared = errors
   END FUNCTION test_shared
-END PROGRAM test_target_teams_distribute_device
+END PROGRAM test_target_teams_distribute_shared

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_shared.c
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_shared.c
@@ -35,7 +35,7 @@ int main() {
   }
 
   // The defaultmap(tofrom:scalar) is used here because the OpenMP 4.5 specification
-  // forbids the use of map and data-sharing clauses on the same list item in the 
+  // forbids the use of map and data-sharing clauses on the same list item in the
   // same construct. See pg. 218, lines 15-16.
 #pragma omp target teams distribute num_teams(10) shared(share, num_teams) map(to: a[0:SIZE]) defaultmap(tofrom:scalar)
   for (int x = 0; x < SIZE; ++x) {
@@ -50,7 +50,7 @@ int main() {
   }
 
   OMPVV_TEST_AND_SET_VERBOSE(errors, (share != 0));
-  OMPVV_ERROR_IF(errors != 0, "The value of share is = %d", share);
+  OMPVV_ERROR_IF(errors != 0, "The value of share is = %d but expected 0.", share);
 
   share = 5;
 

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_shared.c
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_shared.c
@@ -8,13 +8,7 @@
 // the variable should be done atomically.  If the value is the correct value
 // at the end of the region, then all teams operated on the same variable.
 //
-// The second test sets the value of the shared value to a range of values.
-// Since the variable is being updated by each team, it is impossible to know
-// which value will be the last to be assigned to the variable.  However, we
-// test to make sure that the variable is assigned by one of the values that
-// could result from the operation.
-//
-// The third test, instead of writing to the variable, only reads from the
+// The second test, instead of writing to the variable, only reads from the
 // variable.  This tests that the value of the shared variable has not been
 // initiallized improperly or privatized.
 //
@@ -33,7 +27,6 @@ int main() {
   int a[SIZE];
   int share = 0;
   int errors = 0;
-  int prev_errors = errors;
   int num_teams;
 
   for (int x = 0; x < SIZE; ++x) {
@@ -56,8 +49,7 @@ int main() {
   }
 
   OMPVV_TEST_AND_SET_VERBOSE(errors, (share != 0));
-  OMPVV_ERROR_IF(errors != prev_errors, "The value of share is = %d", share);
-  prev_errors = errors;
+  OMPVV_ERROR_IF(errors != 0, "The value of share is = %d", share);
 
   share = 5;
 

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_shared.c
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_shared.c
@@ -6,11 +6,12 @@
 // tests in a few ways that the variable is shared between the teams.  In the
 // first test, the atomic directive is used to indicate that all operations on
 // the variable should be done atomically.  If the value is the correct value
-// at the end of the region, then all teams operated on the same variable.
+// at the end of the region, then all teams operated on the same variable, and
+// the variable was not privatized.
 //
 // The second test, instead of writing to the variable, only reads from the
 // variable.  This tests that the value of the shared variable has not been
-// initiallized improperly or privatized.
+// initialized improperly.
 //
 ////===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
This is the Fortran version of the existing test of `target teams distribute shared`, in addition to some minor cleanup of the C version. Both test are passing all summit compilers, *except* gfortran, which is failing the write test.