### PR TITLE
Add Fortran version of defaultmap test plus C version cleanup

### DIFF
--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_defaultmap.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_defaultmap.F90
@@ -38,7 +38,6 @@ PROGRAM test_target_teams_distribute_defaultmap
 CONTAINS
   INTEGER FUNCTION test_defaultmap_on()
     INTEGER :: errors, x
-    CHARACTER :: scalar_char
     BYTE :: scalar_byte
     INTEGER(kind = 2) :: scalar_short
     INTEGER(kind = 4) :: scalar_int
@@ -49,9 +48,7 @@ CONTAINS
     LOGICAL(kind = 4) :: scalar_logical_kind4
     LOGICAL(kind = 8) :: scalar_logical_kind8
     COMPLEX :: scalar_complex
-    COMPLEX(kind = 16) :: scalar_double_complex
 
-    CHARACTER,DIMENSION(N) :: char_array
     BYTE,DIMENSION(N) :: byte_array
     INTEGER(kind = 2),DIMENSION(N) :: short_array
     INTEGER(kind = 4),DIMENSION(N) :: int_array
@@ -62,9 +59,7 @@ CONTAINS
     LOGICAL(kind = 4),DIMENSION(N) :: logical_kind4_array
     LOGICAL(kind = 8),DIMENSION(N) :: logical_kind8_array
     COMPLEX,DIMENSION(N) :: complex_array
-    COMPLEX(kind = 16),DIMENSION(N) :: double_complex_array
 
-    scalar_char = 'a'
     scalar_byte = 8
     scalar_short = 23
     scalar_int = 56
@@ -75,18 +70,16 @@ CONTAINS
     scalar_logical_kind4 = .TRUE.
     scalar_logical_kind8 = .TRUE.
     scalar_complex = (1, 1)
-    scalar_double_complex = (1e+10, 1e+10)
 
     errors = 0
 
     !$omp target teams distribute defaultmap(tofrom: scalar) map(tofrom: &
-    !$omp& char_array(1:N), byte_array(1:N), short_array(1:N), &
+    !$omp& byte_array(1:N), short_array(1:N), &
     !$omp& int_array(1:N), long_int_array(1:N), float_array(1:N), &
     !$omp& double_array(1:N), logical_array(1:N), &
     !$omp& logical_kind4_array(1:N),  logical_kind8_array(1:N), &
-    !$omp& complex_array(1:N), double_complex_array(1:N))
+    !$omp& complex_array(1:N))
     DO x = 1, N
-       char_array(x) = scalar_char
        byte_array(x) = scalar_byte
        short_array(x) = scalar_short
        int_array(x) = scalar_int
@@ -97,12 +90,10 @@ CONTAINS
        logical_kind4_array(x) = scalar_logical_kind4
        logical_kind8_array(x) = scalar_logical_kind8
        complex_array(x) = scalar_complex
-       double_complex_array(x) = scalar_double_complex
     END DO
     !$omp end target teams distribute
 
     DO x = 1, N
-       OMPVV_TEST_AND_SET_VERBOSE(errors, char_array(x) .ne. scalar_char)
        OMPVV_TEST_AND_SET_VERBOSE(errors, byte_array(x) .ne. scalar_byte)
        OMPVV_TEST_AND_SET_VERBOSE(errors, short_array(x) .ne. scalar_short)
        OMPVV_TEST_AND_SET_VERBOSE(errors, int_array(x) .ne. scalar_int)
@@ -114,28 +105,25 @@ CONTAINS
        OMPVV_TEST_AND_SET_VERBOSE(errors, LOGICAL(logical_kind8_array(x) .neqv. scalar_logical_kind8, 4))
        OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(REAL(complex_array(x)) - REAL(scalar_complex)) .gt. .00001)
        OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(IMAG(complex_array(x)) - IMAG(scalar_complex)) .gt. .00001)
-       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(REAL(double_complex_array(x)) - REAL(scalar_double_complex)) .gt. .0000000001)
-       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(IMAG(double_complex_array(x)) - IMAG(scalar_double_complex)) .gt. .0000000001)
     END DO
 
     !$omp target teams distribute defaultmap(tofrom: scalar)
     DO x = 1, N
-       scalar_char = 'b'
-       scalar_byte = 5
-       scalar_short = 83
-       scalar_int = 49
-       scalar_long_int = 12345
-       scalar_float  = 11.2
-       scalar_double  = 9.5
-       scalar_logical = .false.
-       scalar_logical_kind4 = .false.
-       scalar_logical_kind8 = .false.
-       scalar_complex = (5, 5)
-       scalar_double_complex = (5e+9, 5e+9)
+       IF (omp_get_team_num() .eq. 0) THEN
+          scalar_byte = 5
+          scalar_short = 83
+          scalar_int = 49
+          scalar_long_int = 12345
+          scalar_float  = 11.2
+          scalar_double  = 9.5
+          scalar_logical = .false.
+          scalar_logical_kind4 = .false.
+          scalar_logical_kind8 = .false.
+          scalar_complex = (5, 5)
+       END IF
     END DO
     !$omp end target teams distribute
 
-    OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_char .ne. 'b')
     OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_byte .ne. 5)
     OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_short .ne. 83)
     OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_int .ne. 49)
@@ -147,15 +135,12 @@ CONTAINS
     OMPVV_TEST_AND_SET_VERBOSE(errors, LOGICAL(scalar_logical_kind8 .neqv. .false., 4))
     OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(REAL(scalar_complex) - 5) .gt. .00001)
     OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(IMAG(scalar_complex) - 5) .gt. .00001)
-    OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(REAL(scalar_double_complex) - 5e+9) .gt. .0000000001)
-    OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(IMAG(scalar_double_complex) - 5e+9) .gt. .0000000001)
 
     test_defaultmap_on = errors
   END FUNCTION test_defaultmap_on
 
   INTEGER FUNCTION test_defaultmap_off()
     INTEGER :: errors, x, y
-    CHARACTER :: scalar_char, scalar_char_copy
     BYTE :: scalar_byte, scalar_byte_copy
     INTEGER(kind = 2) :: scalar_short, scalar_short_copy
     INTEGER(kind = 4) :: scalar_int, scalar_int_copy
@@ -166,10 +151,7 @@ CONTAINS
     LOGICAL(kind = 4) :: scalar_logical_kind4, scalar_logical_kind4_copy
     LOGICAL(kind = 8) :: scalar_logical_kind8, scalar_logical_kind8_copy
     COMPLEX :: scalar_complex, scalar_complex_copy
-    COMPLEX(kind = 16) :: scalar_double_complex
-    COMPLEX(kind = 16) :: scalar_double_complex_copy
 
-    CHARACTER,DIMENSION(N) :: char_array_a, char_array_b
     BYTE,DIMENSION(N) :: byte_array_a, byte_array_b
     INTEGER(kind = 2),DIMENSION(N) :: short_array_a, short_array_b
     INTEGER(kind = 4),DIMENSION(N) :: int_array_a, int_array_b
@@ -183,10 +165,7 @@ CONTAINS
     LOGICAL(kind = 8),DIMENSION(N, 16) :: logical_kind8_array_a
     LOGICAL(kind = 8),DIMENSION(N) :: logical_kind8_array_b
     COMPLEX,DIMENSION(N) :: complex_array_a, complex_array_b
-    COMPLEX(kind = 16),DIMENSION(N) :: double_complex_array_a
-    COMPLEX(kind = 16),DIMENSION(N) :: double_complex_array_b
 
-    scalar_char = 'a'
     scalar_byte = 8
     scalar_short = 23
     scalar_int = 56
@@ -197,10 +176,8 @@ CONTAINS
     scalar_logical_kind4 = .TRUE.
     scalar_logical_kind8 = .TRUE.
     scalar_complex = (1, 1)
-    scalar_double_complex = (14, 13)
 
     DO x = 1, N
-       char_array_a(x) = 'b'
        byte_array_a(x) = 9
        short_array_a(x) = 50
        int_array_a(x) = 70
@@ -213,14 +190,13 @@ CONTAINS
           logical_kind8_array_a(x, y) = .TRUE.
        END DO
        complex_array_a(x) = (20, 40)
-       double_complex_array_a(x) = (49, 82)
     END DO
 
 
     errors = 0
 
-    !$omp target teams distribute map(tofrom: char_array_a(1:N), &
-    !$omp & char_array_b(1:N), byte_array_a(1:N), byte_array_b(1:N), &
+    !$omp target teams distribute map(tofrom: &
+    !$omp & byte_array_a(1:N), byte_array_b(1:N), &
     !$omp & short_array_a(1:N), short_array_b(1:N), int_array_a(1:N),  &
     !$omp & int_array_b(1:N), float_array_a(1:N), &
     !$omp & float_array_b(1:N), double_array_a(1:N), &
@@ -228,12 +204,8 @@ CONTAINS
     !$omp & logical_array_b(1:N), logical_kind4_array_a(1:N, 1:16), &
     !$omp & logical_kind4_array_b(1:N), logical_kind8_array_a(1:N, 1:16),&
     !$omp & logical_kind8_array_b(1:N), complex_array_a(1:N), &
-    !$omp & complex_array_b(1:N), double_complex_array_a(1:N), &
-    !$omp & double_complex_array_b(1:N))
+    !$omp & complex_array_b(1:N))
     DO x = 1, N
-       scalar_char = char_array_a(x)
-       char_array_b(x) = scalar_char
-
        scalar_byte = 0
        DO y = 1, byte_array_a(x)
           scalar_byte = scalar_byte + 1
@@ -295,19 +267,11 @@ CONTAINS
           scalar_complex = scalar_complex + (1, 1)
        END DO
        complex_array_b(x) = scalar_complex
-
-       scalar_double_complex = (0, 0)
-       DO WHILE (ABS(scalar_double_complex) .lt. ABS(double_complex_array&
-            &_a(x)))
-          scalar_double_complex = scalar_double_complex + (1, 1)
-       END DO
-       double_complex_array_b(x) = scalar_double_complex
     END DO
 
 
 
     DO x = 1, N
-       OMPVV_TEST_AND_SET_VERBOSE(errors, char_array_a(x) .ne. char_array_b(x))
        OMPVV_TEST_AND_SET_VERBOSE(errors, byte_array_a(x) .ne. byte_array_b(x))
        OMPVV_TEST_AND_SET_VERBOSE(errors, short_array_a(x) .ne. short_array_b(x))
        OMPVV_TEST_AND_SET_VERBOSE(errors, int_array_a(x) .ne. int_array_b(x))
@@ -319,11 +283,8 @@ CONTAINS
        OMPVV_TEST_AND_SET_VERBOSE(errors, LOGICAL(logical_kind8_array_b(x) .neqv. .FALSE., 4))
        OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(complex_array_b(x)) - ABS(complex_array_a(x)) .lt. 0)
        OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(complex_array_b(x) - (1, 1)) - (ABS(complex_array_a(x))) .gt. 0)
-       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(double_complex_array_b(x)) - ABS(complex_array_a(x)) .lt. 0)
-       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(double_complex_array_b(x) - (1, 1)) - (ABS(double_complex_array_a(x))) .gt. 0)
     END DO
 
-    scalar_char = 'c'
     scalar_byte = 8
     scalar_short = 23
     scalar_int = 56
@@ -334,9 +295,7 @@ CONTAINS
     scalar_logical_kind4 = .TRUE.
     scalar_logical_kind8 = .TRUE.
     scalar_complex = (1, 1)
-    scalar_double_complex = (14, 13)
 
-    scalar_char_copy = scalar_char
     scalar_byte_copy = scalar_byte
     scalar_short_copy = scalar_short
     scalar_int_copy = scalar_int
@@ -347,16 +306,13 @@ CONTAINS
     scalar_logical_kind4_copy = scalar_logical_kind4
     scalar_logical_kind8_copy = scalar_logical_kind8
     scalar_complex_copy = scalar_complex
-    scalar_double_complex_copy = scalar_double_complex
 
-    !$omp target teams distribute map(tofrom: char_array_a(1:N), byte_&
-    !$omp &array_a(1:N), short_array_a(1:N), int_array_a(1:N), long_int_&
+    !$omp target teams distribute map(tofrom: byte_array_a(1:N), &
+    !$omp &short_array_a(1:N), int_array_a(1:N), long_int_&
     !$omp &array_a(1:N), float_array_a(1:N), double_array_a(1:N), &
     !$omp & logical_array_b(1:N), logical_kind4_array_b(1:N), logical_&
-    !$omp &kind8_array_b(1:N), complex_array_a(1:N), &
-    !$omp & double_complex_array_a(1:N))
+    !$omp &kind8_array_b(1:N), complex_array_a(1:N))
     DO x = 1, N
-       char_array_a(x) = scalar_char
        byte_array_a(x) = scalar_byte
        short_array_a(x) = scalar_short
        int_array_a(x) = scalar_int
@@ -367,12 +323,10 @@ CONTAINS
        logical_kind4_array_b(x) = scalar_logical_kind4
        logical_kind8_array_b(x) = scalar_logical_kind8
        complex_array_a(x) = scalar_complex
-       double_complex_array_a(x) = scalar_double_complex
     END DO
 
     !$omp target teams distribute
     DO x = 1, N
-       scalar_char = 'z'
        scalar_byte = 0
        scalar_short = 0
        scalar_int = 0
@@ -383,11 +337,9 @@ CONTAINS
        scalar_logical_kind4 = .FALSE.
        scalar_logical_kind8 = .FALSE.
        scalar_complex = (0, 0)
-       scalar_double_complex = (0, 0)
     END DO
 
     DO x = 1, N
-       OMPVV_TEST_AND_SET_VERBOSE(errors, char_array_a(x) .ne. scalar_char_copy)
        OMPVV_TEST_AND_SET_VERBOSE(errors, byte_array_a(x) .ne. scalar_byte_copy)
        OMPVV_TEST_AND_SET_VERBOSE(errors, short_array_a(x) .ne. scalar_short_copy)
        OMPVV_TEST_AND_SET_VERBOSE(errors, int_array_a(x) .ne. scalar_int_copy)
@@ -398,11 +350,9 @@ CONTAINS
        OMPVV_TEST_AND_SET_VERBOSE(errors, logical_kind4_array_b(x) .neqv. scalar_logical_kind4_copy)
        OMPVV_TEST_AND_SET_VERBOSE(errors, LOGICAL(logical_kind8_array_b(x) .neqv. scalar_logical_kind8_copy, 4))
        OMPVV_TEST_AND_SET_VERBOSE(errors, complex_array_a(x) .ne. scalar_complex_copy)
-       OMPVV_TEST_AND_SET_VERBOSE(errors, double_complex_array_a(x) .ne. scalar_double_complex_copy)
     END DO
 
     IF (isSharedEnv .neqv. .TRUE.) THEN
-       OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_char .ne. scalar_char_copy)
        OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_byte .ne. scalar_byte_copy)
        OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_short .ne. scalar_short_copy)
        OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_int .ne. scalar_int_copy)
@@ -414,8 +364,6 @@ CONTAINS
        OMPVV_TEST_AND_SET_VERBOSE(errors, LOGICAL(scalar_logical_kind8 .neqv. scalar_logical_kind8_copy, 4))
        OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(REAL(scalar_complex) - REAL(scalar_complex_copy)) .gt. .000001)
        OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(IMAG(scalar_complex) - IMAG(scalar_complex_copy)) .gt. .000001)
-       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(REAL(scalar_double_complex) - REAL(scalar_double_complex)) .gt. .0000000001)
-       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(IMAG(scalar_double_complex) - IMAG(scalar_double_complex)) .gt. .0000000001)
     END IF
     test_defaultmap_off = errors
   END FUNCTION test_defaultmap_off

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_defaultmap.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_defaultmap.F90
@@ -416,7 +416,6 @@ CONTAINS
        OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(IMAG(scalar_complex) - IMAG(scalar_complex_copy)) .gt. .000001)
        OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(REAL(scalar_double_complex) - REAL(scalar_double_complex)) .gt. .0000000001)
        OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(IMAG(scalar_double_complex) - IMAG(scalar_double_complex)) .gt. .0000000001)
-       END IF
     END IF
     test_defaultmap_off = errors
   END FUNCTION test_defaultmap_off

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_defaultmap.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_defaultmap.F90
@@ -25,7 +25,7 @@ PROGRAM test_target_teams_distribute_defaultmap
   USE omp_lib
   implicit none
   LOGICAL :: isSharedEnv
-  OMPVV_TEST_OFFLOADING()
+  OMPVV_TEST_OFFLOADING
   OMPVV_TEST_AND_SET_SHARED_ENVIRONMENT(isSharedEnv)
   IF (isSharedEnv) THEN
      OMPVV_WARNING("Shared memory environment. Scalars are not copied")
@@ -107,23 +107,15 @@ CONTAINS
        OMPVV_TEST_AND_SET_VERBOSE(errors, short_array(x) .ne. scalar_short)
        OMPVV_TEST_AND_SET_VERBOSE(errors, int_array(x) .ne. scalar_int)
        OMPVV_TEST_AND_SET_VERBOSE(errors, long_int_array(x) .ne. scalar_long_int)
-       OMPVV_TEST_AND_SET_VERBOSE(errors, abs(float_array(x) - scalar_float) &
-            & .gt. .00001)
-       OMPVV_TEST_AND_SET_VERBOSE(errors, abs(double_array(x) - scalar_double) &
-            & .gt. .0000000001)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, abs(float_array(x) - scalar_float) .gt. .00001)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, abs(double_array(x) - scalar_double) .gt. .0000000001)
        OMPVV_TEST_AND_SET_VERBOSE(errors, logical_array(x) .neqv. scalar_logical)
-       OMPVV_TEST_AND_SET_VERBOSE(errors, logical_kind4_array(x) &
-            & .neqv. scalar_logical_kind4)
-       OMPVV_TEST_AND_SET_VERBOSE(errors, logical_kind8_array(x) &
-            & .neqv. scalar_logical_kind8)
-       OMPVV_TEST_AND_SET_VERBOSE(errors, abs(REAL(complex_array(x)) &
-            & - REAL(scalar_complex)) .gt. .00001)
-       OMPVV_TEST_AND_SET_VERBOSE(errors, abs(IMAG(complex_array(x)) &
-            & - IMAG(scalar_complex)) .gt. .00001)
-       OMPVV_TEST_AND_SET_VERBOSE(errors, abs(REAL(double_complex_array(x)) &
-            & - REAL(scalar_double_complex)) .gt. .0000000001)
-       OMPVV_TEST_AND_SET_VERBOSE(errors, abs(IMAG(double_complex_array(x)) &
-            & - IMAG(scalar_double_complex)) .gt. .0000000001)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, logical_kind4_array(x) .neqv. scalar_logical_kind4)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, LOGICAL(logical_kind8_array(x) .neqv. scalar_logical_kind8, 4))
+       OMPVV_TEST_AND_SET_VERBOSE(errors, abs(REAL(complex_array(x)) - REAL(scalar_complex)) .gt. .00001)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, abs(IMAG(complex_array(x)) - IMAG(scalar_complex)) .gt. .00001)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, abs(REAL(double_complex_array(x)) - REAL(scalar_double_complex)) .gt. .0000000001)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, abs(IMAG(double_complex_array(x)) - IMAG(scalar_double_complex)) .gt. .0000000001)
     END DO
 
     !$omp target teams distribute defaultmap(tofrom: scalar)

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_defaultmap.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_defaultmap.F90
@@ -229,7 +229,7 @@ CONTAINS
     !$omp & logical_kind4_array_b(1:N), logical_kind8_array_a(1:N, 1:16),&
     !$omp & logical_kind8_array_b(1:N), complex_array_a(1:N), &
     !$omp & complex_array_b(1:N), double_complex_array_a(1:N), &
-    !$omp & double_complex_array_b(1:N)) defaultmap(tofrom: scalar)
+    !$omp & double_complex_array_b(1:N))
     DO x = 1, N
        scalar_char = char_array_a(x)
        char_array_b(x) = scalar_char

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_defaultmap.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_defaultmap.F90
@@ -1,0 +1,544 @@
+!===--- test_target_teams_distribute_defaultmap.F90-------------------------===//
+!
+! OpenMP API Version 4.5 Nov 2015
+!
+! This test uses the defaultmap clause on a target teams distribute directive.
+! This tests the following scalars: char, short, int, float, double, and enum.
+! Both using the clause defaultmap(tofrom:scalar) is used. When it is used,
+! the test tests the to nature by setting arrays to the value.  Then it is also
+! tested that, as opposed to the default action on scalars which is to first-
+! privatize them, they are shared and returned to the host.
+!
+! It also tests the default operation of treating scalars without the defaultmap
+! clause.  The test first tests the privatization of the firstprivatized
+! scalars and then separately tests the proper initialization of them separately
+!
+!===------------------------------------------------------------------------===//
+
+#include "ompvv.F90"
+
+#define N 1024
+
+PROGRAM test_target_teams_distribute_defaultmap
+  USE iso_fortran_env
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+  LOGICAL :: isSharedEnv
+  OMPVV_TEST_OFFLOADING()
+  OMPVV_TEST_AND_SET_SHARED_ENVIRONMENT(isSharedEnv)
+  IF (isSharedEnv) THEN
+     OMPVV_WARNING("Shared memory environment. Scalars are not copied")
+     OMPVV_WARNING("but modified. Defaultmap off test is inconclusive")
+  END IF
+  OMPVV_TEST_VERBOSE(test_defaultmap_on() .ne. 0)
+  OMPVV_TEST_VERBOSE(test_defaultmap_off() .ne. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+CONTAINS
+  INTEGER FUNCTION test_defaultmap_on()
+    INTEGER :: errors, x
+    CHARACTER :: scalar_char
+    BYTE :: scalar_byte
+    INTEGER(kind = 2) :: scalar_short
+    INTEGER(kind = 4) :: scalar_int
+    INTEGER(kind = 8) :: scalar_long_int
+    REAL(kind = 4) :: scalar_float
+    REAL(kind = 8) :: scalar_double
+    LOGICAL :: scalar_logical
+    LOGICAL(kind = 4) :: scalar_logical_kind4
+    LOGICAL(kind = 8) :: scalar_logical_kind8
+    COMPLEX :: scalar_complex
+    COMPLEX(kind = 16) :: scalar_double_complex
+
+    CHARACTER,DIMENSION(N) :: char_array
+    BYTE,DIMENSION(N) :: byte_array
+    INTEGER(kind = 2),DIMENSION(N) :: short_array
+    INTEGER(kind = 4),DIMENSION(N) :: int_array
+    INTEGER(kind = 8),DIMENSION(N) :: long_int_array
+    REAL(kind = 4),DIMENSION(N) :: float_array
+    REAL(kind = 8),DIMENSION(N) :: double_array
+    LOGICAL,DIMENSION(N) :: logical_array
+    LOGICAL(kind = 4),DIMENSION(N) :: logical_kind4_array
+    LOGICAL(kind = 8),DIMENSION(N) :: logical_kind8_array
+    COMPLEX,DIMENSION(N) :: complex_array
+    COMPLEX(kind = 16),DIMENSION(N) :: double_complex_array
+
+    scalar_char = 'a'
+    scalar_byte = 8
+    scalar_short = 23
+    scalar_int = 56
+    scalar_long_int = 90000
+    scalar_float = 4.5
+    scalar_double = 4.9
+    scalar_logical = .TRUE.
+    scalar_logical_kind4 = .TRUE.
+    scalar_logical_kind8 = .TRUE.
+    scalar_complex = (1, 1)
+    scalar_double_complex = (1e+10, 1e+10)
+
+    errors = 0
+
+    !$omp target teams distribute defaultmap(tofrom: scalar) map(tofrom: &
+    !$omp& char_array(1:N), byte_array(1:N), short_array(1:N), &
+    !$omp& int_array(1:N), long_int_array(1:N), float_array(1:N), &
+    !$omp& double_array(1:N), logical_array(1:N), &
+    !$omp& logical_kind4_array(1:N),  logical_kind8_array(1:N), &
+    !$omp& complex_array(1:N), double_complex_array(1:N))
+    DO x = 1, N
+       char_array(x) = scalar_char
+       byte_array(x) = scalar_byte
+       short_array(x) = scalar_short
+       int_array(x) = scalar_int
+       long_int_array(x) = scalar_long_int
+       float_array(x) = scalar_float
+       double_array(x) = scalar_double
+       logical_array(x) = scalar_logical
+       logical_kind4_array(x) = scalar_logical_kind4
+       logical_kind8_array(x) = scalar_logical_kind8
+       complex_array(x) = scalar_complex
+       double_complex_array(x) = scalar_double_complex
+    END DO
+    !$omp end target teams distribute
+
+    DO x = 1, N
+       OMPVV_TEST_AND_SET_VERBOSE(errors, char_array(x) .ne. scalar_char)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, byte_array(x) .ne. scalar_byte)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, short_array(x) .ne. scalar_short)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, int_array(x) .ne. scalar_int)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, long_int_array(x) .ne. scalar_long_int)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, abs(float_array(x) - scalar_float) &
+            & .gt. .00001)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, abs(double_array(x) - scalar_double) &
+            & .gt. .0000000001)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, logical_array(x) .neqv. scalar_logical)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, logical_kind4_array(x) &
+            & .neqv. scalar_logical_kind4)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, logical_kind8_array(x) &
+            & .neqv. scalar_logical_kind8)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, abs(REAL(complex_array(x)) &
+            & - REAL(scalar_complex)) .gt. .00001)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, abs(IMAG(complex_array(x)) &
+            & - IMAG(scalar_complex)) .gt. .00001)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, abs(REAL(double_complex_array(x)) &
+            & - REAL(scalar_double_complex)) .gt. .0000000001)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, abs(IMAG(double_complex_array(x)) &
+            & - IMAG(scalar_double_complex)) .gt. .0000000001)
+    END DO
+
+    !$omp target teams distribute defaultmap(tofrom: scalar)
+    DO x = 1, N
+       scalar_char = 'b'
+       scalar_byte = 5
+       scalar_short = 83
+       scalar_int = 49
+       scalar_long_int = 12345
+       scalar_float  = 11.2
+       scalar_double  = 9.5
+       scalar_logical = .false.
+       scalar_logical_kind4 = .false.
+       scalar_logical_kind8 = .false.
+       scalar_complex = (5, 5)
+       scalar_double_complex = (5e+9, 5e+9)
+    END DO
+    !$omp end target teams distribute
+
+    IF (scalar_char .ne. 'b') THEN
+       errors = errors + 1
+    END IF
+    IF (scalar_byte .ne. 5) THEN
+       errors = errors + 1
+    END IF
+    IF (scalar_short .ne. 83) THEN
+       errors = errors + 1
+    END IF
+    IF (scalar_int .ne. 49) THEN
+       errors = errors + 1
+    END IF
+    IF (scalar_long_int .ne. 12345) THEN
+       errors = errors + 1
+    END IF
+    IF (abs(scalar_float - 11.2) .gt. .00001) THEN
+       errors = errors + 1
+    END IF
+    IF (abs(scalar_double - 9.5) .gt. .0000000001) THEN
+       errors = errors + 1
+    END IF
+    IF (scalar_logical .neqv. .false.) THEN
+       errors = errors + 1
+    END IF
+    IF (scalar_logical_kind4 .neqv. .false.) THEN
+       errors = errors + 1
+    END IF
+    IF (scalar_logical_kind8 .neqv. .false.) THEN
+       errors = errors + 1
+    END IF
+    IF (abs(REAL(scalar_complex) - 5) .gt. .00001) THEN
+       errors = errors + 1
+    END IF
+    IF (abs(IMAG(scalar_complex) - 5) .gt. .00001) THEN
+       errors = errors + 1
+    END IF
+    IF (abs(REAL(scalar_double_complex) - 5e+9) .gt. .0000000001) THEN
+       errors = errors + 1
+    END IF
+    IF (abs(IMAG(scalar_double_complex) - 5e+9) .gt. .0000000001) THEN
+       errors = errors + 1
+    END IF
+    test_defaultmap_on = errors
+  END FUNCTION test_defaultmap_on
+
+  INTEGER FUNCTION test_defaultmap_off()
+    INTEGER :: errors, x, y
+    CHARACTER :: scalar_char, scalar_char_copy
+    BYTE :: scalar_byte, scalar_byte_copy
+    INTEGER(kind = 2) :: scalar_short, scalar_short_copy
+    INTEGER(kind = 4) :: scalar_int, scalar_int_copy
+    INTEGER(kind = 8) :: scalar_long_int, scalar_long_int_copy
+    REAL(kind = 4) :: scalar_float, scalar_float_copy
+    REAL(kind = 8) :: scalar_double, scalar_double_copy
+    LOGICAL :: scalar_logical, scalar_logical_copy
+    LOGICAL(kind = 4) :: scalar_logical_kind4, scalar_logical_kind4_copy
+    LOGICAL(kind = 8) :: scalar_logical_kind8, scalar_logical_kind8_copy
+    COMPLEX :: scalar_complex, scalar_complex_copy
+    COMPLEX(kind = 16) :: scalar_double_complex
+    COMPLEX(kind = 16) :: scalar_double_complex_copy
+
+    CHARACTER,DIMENSION(N) :: char_array_a, char_array_b
+    BYTE,DIMENSION(N) :: byte_array_a, byte_array_b
+    INTEGER(kind = 2),DIMENSION(N) :: short_array_a, short_array_b
+    INTEGER(kind = 4),DIMENSION(N) :: int_array_a, int_array_b
+    INTEGER(kind = 8),DIMENSION(N) :: long_int_array_a, long_int_array_b
+    REAL(kind = 4),DIMENSION(N) :: float_array_a, float_array_b
+    REAL(kind = 8),DIMENSION(N) :: double_array_a, double_array_b
+    LOGICAL,DIMENSION(N, 16) :: logical_array_a
+    LOGICAL,DIMENSION(N) :: logical_array_b
+    LOGICAL(kind = 4),DIMENSION(N, 16) :: logical_kind4_array_a
+    LOGICAL(kind = 4),DIMENSION(N) :: logical_kind4_array_b
+    LOGICAL(kind = 8),DIMENSION(N, 16) :: logical_kind8_array_a
+    LOGICAL(kind = 8),DIMENSION(N) :: logical_kind8_array_b
+    COMPLEX,DIMENSION(N) :: complex_array_a, complex_array_b
+    COMPLEX(kind = 16),DIMENSION(N) :: double_complex_array_a
+    COMPLEX(kind = 16),DIMENSION(N) :: double_complex_array_b
+
+    scalar_char = 'a'
+    scalar_byte = 8
+    scalar_short = 23
+    scalar_int = 56
+    scalar_long_int = 90000
+    scalar_float = 4.5
+    scalar_double = 4.9
+    scalar_logical = .TRUE.
+    scalar_logical_kind4 = .TRUE.
+    scalar_logical_kind8 = .TRUE.
+    scalar_complex = (1, 1)
+    scalar_double_complex = (14, 13)
+
+    DO x = 1, N
+       char_array_a(x) = 'b'
+       byte_array_a(x) = 9
+       short_array_a(x) = 50
+       int_array_a(x) = 70
+       long_int_array_a(x) = 150
+       float_array_a(x) = 15.5
+       double_array_a(x) = 52.45
+       DO y = 1, 16
+          logical_array_a(x, y) = .TRUE.
+          logical_kind4_array_a(x, y) = .TRUE.
+          logical_kind8_array_a(x, y) = .TRUE.
+       END DO
+       complex_array_a(x) = (20, 40)
+       double_complex_array_a(x) = (49, 82)
+    END DO
+
+
+    errors = 0
+
+    !$omp target teams distribute map(tofrom: char_array_a(1:N), &
+    !$omp & char_array_b(1:N), byte_array_a(1:N), byte_array_b(1:N), &
+    !$omp & short_array_a(1:N), short_array_b(1:N), int_array_a(1:N),  &
+    !$omp & int_array_b(1:N), float_array_a(1:N), &
+    !$omp & float_array_b(1:N), double_array_a(1:N), &
+    !$omp & double_array_b(1:N), logical_array_a(1:N, 1:16), &
+    !$omp & logical_array_b(1:N), logical_kind4_array_a(1:N, 1:16), &
+    !$omp & logical_kind4_array_b(1:N), logical_kind8_array_a(1:N, 1:16),&
+    !$omp & logical_kind8_array_b(1:N), complex_array_a(1:N), &
+    !$omp & complex_array_b(1:N), double_complex_array_a(1:N), &
+    !$omp & double_complex_array_b(1:N)) defaultmap(tofrom: scalar)
+    DO x = 1, N
+       scalar_char = char_array_a(x)
+       char_array_b(x) = scalar_char
+
+       scalar_byte = 0
+       DO y = 1, byte_array_a(x)
+          scalar_byte = scalar_byte + 1
+       END DO
+       byte_array_b(x) = scalar_byte
+
+       scalar_short = 0
+       DO y = 1, short_array_a(x)
+          scalar_short = scalar_short + 1
+       END DO
+       short_array_b(x) = scalar_short
+
+       scalar_int = 0
+       DO y = 1, int_array_a(x)
+          scalar_int = scalar_int + 1
+       END DO
+       int_array_b(x) = scalar_int
+
+       scalar_long_int = 0
+       DO y = 1, long_int_array_a(x)
+          scalar_long_int = scalar_long_int + 1
+       END DO
+       long_int_array_b(x) = scalar_long_int
+
+       scalar_float = 0
+       DO y = 1, INT(float_array_a(x))
+          scalar_float = scalar_float + .7
+       END DO
+       float_array_b(x) = scalar_float
+
+       scalar_double = 0
+       DO y = 1, INT(double_array_a(x))
+          scalar_double = scalar_double + .7
+       END DO
+
+       scalar_logical = .FALSE.
+       DO y = 1, 16
+          scalar_logical = scalar_logical .NEQV. logical_array_a(x, y)
+       END DO
+       logical_array_b(x) = scalar_logical
+
+       scalar_logical_kind4 = .FALSE.
+       DO y = 1, 16
+          scalar_logical_kind4 = scalar_logical_kind4 .NEQV. logical_&
+               &kind4_array_a(x, y)
+       END DO
+       logical_kind4_array_b(x) = scalar_logical_kind4
+
+       scalar_logical_kind8 = .FALSE.
+       DO y = 1, 16
+          scalar_logical_kind8 = scalar_logical_kind8 .NEQV. logical_&
+               &kind8_array_a(x, y)
+       END DO
+       logical_kind8_array_b(x) = scalar_logical_kind8
+
+       scalar_complex = (0, 0)
+       DO WHILE (ABS(scalar_complex) .lt. ABS(complex_array_a(x)))
+          scalar_complex = scalar_complex + (1, 1)
+       END DO
+       complex_array_b(x) = scalar_complex
+
+       scalar_double_complex = (0, 0)
+       DO WHILE (ABS(scalar_double_complex) .lt. ABS(double_complex_array&
+            &_a(x)))
+          scalar_double_complex = scalar_double_complex + (1, 1)
+       END DO
+       double_complex_array_b(x) = scalar_double_complex
+    END DO
+
+
+
+    DO x = 1, N
+       IF (char_array_a(x) .ne. char_array_b(x)) THEN
+          errors = errors + 1
+       END IF
+       IF (byte_array_a(x) .ne. byte_array_b(x)) THEN
+          errors = errors + 1
+       END IF
+       IF (short_array_a(x) .ne. short_array_b(x)) THEN
+          errors = errors + 1
+       END IF
+       IF (int_array_a(x) .ne. int_array_b(x)) THEN
+          errors = errors + 1
+       END IF
+       IF (long_int_array_a(x) .ne. long_int_array_b(x)) THEN
+          errors = errors + 1
+       END IF
+       IF (abs((INT(float_array_a(x)) * .7) - float_array_b(x)) .gt. &
+            & .00001) THEN
+          errors = errors + 1
+       END IF
+       IF (abs((INT(double_array_a(x)) * .7) - double_array_b(x)) .gt. &
+            & .0000000001) THEN
+          errors = errors + 1
+       END IF
+       IF (logical_array_b(x) .neqv. .FALSE.) THEN
+          errors = errors + 1
+       END IF
+       IF (logical_kind4_array_b(x) .neqv. .FALSE.) THEN
+          errors = errors + 1
+       END IF
+       IF (logical_kind8_array_b(x) .neqv. .FALSE.) THEN
+          errors = errors + 1
+       END IF
+       IF (ABS(complex_array_b(x)) - ABS(complex_array_a(x)) .lt. 0) THEN
+          errors = errors + 1
+       ELSEIF (ABS(complex_array_b(x) - (1, 1)) - (ABS(complex_array_a(x) &
+            & )) .gt. 0) THEN
+          errors = errors + 1
+       END IF
+       IF (ABS(double_complex_array_b(x)) - ABS(complex_array_a(x)) .lt. &
+            & 0) THEN
+          errors = errors + 1
+       ELSEIF (ABS(double_complex_array_b(x) - (1, 1)) - (ABS(double_&
+            &complex_array_a(x))) .gt. 0) THEN
+          errors = errors + 1
+       END IF
+    END DO
+
+    scalar_char = 'c'
+    scalar_byte = 8
+    scalar_short = 23
+    scalar_int = 56
+    scalar_long_int = 90000
+    scalar_float = 4.5
+    scalar_double = 4.9
+    scalar_logical = .TRUE.
+    scalar_logical_kind4 = .TRUE.
+    scalar_logical_kind8 = .TRUE.
+    scalar_complex = (1, 1)
+    scalar_double_complex = (14, 13)
+
+    scalar_char_copy = scalar_char
+    scalar_byte_copy = scalar_byte
+    scalar_short_copy = scalar_short
+    scalar_int_copy = scalar_int
+    scalar_long_int_copy = scalar_long_int
+    scalar_float_copy = scalar_float
+    scalar_double_copy = scalar_double
+    scalar_logical_copy = scalar_logical
+    scalar_logical_kind4_copy = scalar_logical_kind4
+    scalar_logical_kind8_copy = scalar_logical_kind8
+    scalar_complex_copy = scalar_complex
+    scalar_double_complex_copy = scalar_double_complex
+
+    !$omp target teams distribute map(tofrom: char_array_a(1:N), byte_&
+    !$omp &array_a(1:N), short_array_a(1:N), int_array_a(1:N), long_int_&
+    !$omp &array_a(1:N), float_array_a(1:N), double_array_a(1:N), &
+    !$omp & logical_array_b(1:N), logical_kind4_array_b(1:N), logical_&
+    !$omp &kind8_array_b(1:N), complex_array_a(1:N), &
+    !$omp & double_complex_array_a(1:N))
+    DO x = 1, N
+       char_array_a(x) = scalar_char
+       byte_array_a(x) = scalar_byte
+       short_array_a(x) = scalar_short
+       int_array_a(x) = scalar_int
+       long_int_array_a(x) = scalar_long_int
+       float_array_a(x) = scalar_float
+       double_array_a(x) = scalar_double
+       logical_array_b(x) = scalar_logical
+       logical_kind4_array_b(x) = scalar_logical_kind4
+       logical_kind8_array_b(x) = scalar_logical_kind8
+       complex_array_a(x) = scalar_complex
+       double_complex_array_a(x) = scalar_double_complex
+    END DO
+
+    !$omp target teams distribute
+    DO x = 1, N
+       scalar_char = 'z'
+       scalar_byte = 0
+       scalar_short = 0
+       scalar_int = 0
+       scalar_long_int = 0
+       scalar_float = 0
+       scalar_double = 0
+       scalar_logical = .FALSE.
+       scalar_logical_kind4 = .FALSE.
+       scalar_logical_kind8 = .FALSE.
+       scalar_complex = (0, 0)
+       scalar_double_complex = (0, 0)
+    END DO
+
+    DO x = 1, N
+       IF (char_array_a(x) .ne. scalar_char_copy) THEN
+          errors = errors + 1
+       END IF
+       IF (byte_array_a(x) .ne. scalar_byte_copy) THEN
+          errors = errors + 1
+       END IF
+       IF (short_array_a(x) .ne. scalar_short_copy) THEN
+          errors = errors + 1
+       END IF
+       IF (int_array_a(x) .ne. scalar_int_copy) THEN
+          errors = errors + 1
+       END IF
+       IF (long_int_array_a(x) .ne. scalar_long_int_copy) THEN
+          errors = errors + 1
+       END IF
+       IF (ABS(float_array_a(x) - scalar_float_copy) .gt. .000001) THEN
+          errors = errors + 1
+       END IF
+       IF (ABS(double_array_a(x) - scalar_double_copy) .gt. .0000000001) &
+            &THEN
+          errors = errors + 1
+       END IF
+       IF (logical_array_b(x) .neqv. scalar_logical_copy) THEN
+          errors = errors + 1
+       END IF
+       IF (logical_kind4_array_b(x) .neqv. scalar_logical_kind4_copy) THEN
+          errors = errors + 1
+       END IF
+       IF (logical_kind8_array_b(x) .neqv. scalar_logical_kind8_copy) THEN
+          errors = errors + 1
+       END IF
+       IF (complex_array_a(x) .ne. scalar_complex_copy) THEN
+          errors = errors + 1
+       END IF
+       IF (double_complex_array_a(x) .ne. scalar_double_complex_copy) THEN
+          errors = errors + 1
+       END IF
+    END DO
+
+    IF (isSharedEnv .neqv. .TRUE.) THEN
+       IF (scalar_char .ne. scalar_char_copy) THEN
+          errors = errors + 1
+       END IF
+       IF (scalar_byte .ne. scalar_byte_copy) THEN
+          errors = errors + 1
+       END IF
+       IF (scalar_short .ne. scalar_short_copy) THEN
+          errors = errors + 1
+       END IF
+       IF (scalar_int .ne. scalar_int_copy) THEN
+          errors = errors + 1
+       END IF
+       IF (scalar_long_int .ne. scalar_long_int_copy) THEN
+          errors = errors + 1
+       END IF
+       IF (ABS(scalar_float - scalar_float_copy) .gt. .000001) THEN
+          errors = errors + 1
+       END IF
+       IF (ABS(scalar_double - scalar_double_copy) .gt. .0000000001) THEN
+          errors = errors + 1
+       END IF
+       IF (scalar_logical .neqv. scalar_logical_copy) THEN
+          errors = errors + 1
+       END IF
+       IF (scalar_logical_kind4 .neqv. scalar_logical_kind4_copy) THEN
+          errors = errors + 1
+       END IF
+       IF (scalar_logical_kind8 .neqv. scalar_logical_kind8_copy) THEN
+          errors = errors + 1
+       END IF
+       IF (ABS(REAL(scalar_complex) - REAL(scalar_complex_copy)) .gt. &
+            & .000001) THEN
+          errors = errors + 1
+       END IF
+       IF (ABS(IMAG(scalar_complex) - IMAG(scalar_complex_copy)) .gt. &
+            & .000001) THEN
+          errors = errors + 1
+       END IF
+       IF (ABS(REAL(scalar_double_complex) - REAL(scalar_double_complex)) &
+            & .gt. .0000000001) THEN
+          errors = errors + 1
+       END IF
+       IF (ABS(IMAG(scalar_double_complex) - IMAG(scalar_double_complex)) &
+            & .gt. .0000000001) THEN
+          errors = errors + 1
+       END IF
+    END IF
+    test_defaultmap_off = errors
+  END FUNCTION test_defaultmap_off
+END PROGRAM test_target_teams_distribute_defaultmap

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_defaultmap.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_defaultmap.F90
@@ -277,7 +277,7 @@ CONTAINS
        OMPVV_TEST_AND_SET_VERBOSE(errors, int_array_a(x) .ne. int_array_b(x))
        OMPVV_TEST_AND_SET_VERBOSE(errors, long_int_array_a(x) .ne. long_int_array_b(x))
        OMPVV_TEST_AND_SET_VERBOSE(errors, ABS((INT(float_array_a(x)) * .7) - float_array_b(x)) .gt. .00001)
-       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS((INT(double_array_a(x)) * .7) - double_array_b(x)) .gt. .0000000001)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS((INT(double_array_a(x)) * .7) - double_array_b(x)) .gt. .00001)
        OMPVV_TEST_AND_SET_VERBOSE(errors, logical_array_b(x) .neqv. .FALSE.)
        OMPVV_TEST_AND_SET_VERBOSE(errors, logical_kind4_array_b(x) .neqv. .FALSE.)
        OMPVV_TEST_AND_SET_VERBOSE(errors, LOGICAL(logical_kind8_array_b(x) .neqv. .FALSE., 4))

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_defaultmap.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_defaultmap.F90
@@ -107,15 +107,15 @@ CONTAINS
        OMPVV_TEST_AND_SET_VERBOSE(errors, short_array(x) .ne. scalar_short)
        OMPVV_TEST_AND_SET_VERBOSE(errors, int_array(x) .ne. scalar_int)
        OMPVV_TEST_AND_SET_VERBOSE(errors, long_int_array(x) .ne. scalar_long_int)
-       OMPVV_TEST_AND_SET_VERBOSE(errors, abs(float_array(x) - scalar_float) .gt. .00001)
-       OMPVV_TEST_AND_SET_VERBOSE(errors, abs(double_array(x) - scalar_double) .gt. .0000000001)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(float_array(x) - scalar_float) .gt. .00001)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(double_array(x) - scalar_double) .gt. .0000000001)
        OMPVV_TEST_AND_SET_VERBOSE(errors, logical_array(x) .neqv. scalar_logical)
        OMPVV_TEST_AND_SET_VERBOSE(errors, logical_kind4_array(x) .neqv. scalar_logical_kind4)
        OMPVV_TEST_AND_SET_VERBOSE(errors, LOGICAL(logical_kind8_array(x) .neqv. scalar_logical_kind8, 4))
-       OMPVV_TEST_AND_SET_VERBOSE(errors, abs(REAL(complex_array(x)) - REAL(scalar_complex)) .gt. .00001)
-       OMPVV_TEST_AND_SET_VERBOSE(errors, abs(IMAG(complex_array(x)) - IMAG(scalar_complex)) .gt. .00001)
-       OMPVV_TEST_AND_SET_VERBOSE(errors, abs(REAL(double_complex_array(x)) - REAL(scalar_double_complex)) .gt. .0000000001)
-       OMPVV_TEST_AND_SET_VERBOSE(errors, abs(IMAG(double_complex_array(x)) - IMAG(scalar_double_complex)) .gt. .0000000001)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(REAL(complex_array(x)) - REAL(scalar_complex)) .gt. .00001)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(IMAG(complex_array(x)) - IMAG(scalar_complex)) .gt. .00001)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(REAL(double_complex_array(x)) - REAL(scalar_double_complex)) .gt. .0000000001)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(IMAG(double_complex_array(x)) - IMAG(scalar_double_complex)) .gt. .0000000001)
     END DO
 
     !$omp target teams distribute defaultmap(tofrom: scalar)
@@ -135,48 +135,21 @@ CONTAINS
     END DO
     !$omp end target teams distribute
 
-    IF (scalar_char .ne. 'b') THEN
-       errors = errors + 1
-    END IF
-    IF (scalar_byte .ne. 5) THEN
-       errors = errors + 1
-    END IF
-    IF (scalar_short .ne. 83) THEN
-       errors = errors + 1
-    END IF
-    IF (scalar_int .ne. 49) THEN
-       errors = errors + 1
-    END IF
-    IF (scalar_long_int .ne. 12345) THEN
-       errors = errors + 1
-    END IF
-    IF (abs(scalar_float - 11.2) .gt. .00001) THEN
-       errors = errors + 1
-    END IF
-    IF (abs(scalar_double - 9.5) .gt. .0000000001) THEN
-       errors = errors + 1
-    END IF
-    IF (scalar_logical .neqv. .false.) THEN
-       errors = errors + 1
-    END IF
-    IF (scalar_logical_kind4 .neqv. .false.) THEN
-       errors = errors + 1
-    END IF
-    IF (scalar_logical_kind8 .neqv. .false.) THEN
-       errors = errors + 1
-    END IF
-    IF (abs(REAL(scalar_complex) - 5) .gt. .00001) THEN
-       errors = errors + 1
-    END IF
-    IF (abs(IMAG(scalar_complex) - 5) .gt. .00001) THEN
-       errors = errors + 1
-    END IF
-    IF (abs(REAL(scalar_double_complex) - 5e+9) .gt. .0000000001) THEN
-       errors = errors + 1
-    END IF
-    IF (abs(IMAG(scalar_double_complex) - 5e+9) .gt. .0000000001) THEN
-       errors = errors + 1
-    END IF
+    OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_char .ne. 'b')
+    OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_byte .ne. 5)
+    OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_short .ne. 83)
+    OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_int .ne. 49)
+    OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_long_int .ne. 12345)
+    OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(scalar_float - 11.2) .gt. .00001)
+    OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(scalar_double - 9.5) .gt. .0000000001)
+    OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_logical .neqv. .false.)
+    OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_logical_kind4 .neqv. .false.)
+    OMPVV_TEST_AND_SET_VERBOSE(errors, LOGICAL(scalar_logical_kind8 .neqv. .false., 4))
+    OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(REAL(scalar_complex) - 5) .gt. .00001)
+    OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(IMAG(scalar_complex) - 5) .gt. .00001)
+    OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(REAL(scalar_double_complex) - 5e+9) .gt. .0000000001)
+    OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(IMAG(scalar_double_complex) - 5e+9) .gt. .0000000001)
+
     test_defaultmap_on = errors
   END FUNCTION test_defaultmap_on
 
@@ -295,6 +268,7 @@ CONTAINS
        DO y = 1, INT(double_array_a(x))
           scalar_double = scalar_double + .7
        END DO
+       double_array_b(x) = scalar_double
 
        scalar_logical = .FALSE.
        DO y = 1, 16
@@ -333,51 +307,20 @@ CONTAINS
 
 
     DO x = 1, N
-       IF (char_array_a(x) .ne. char_array_b(x)) THEN
-          errors = errors + 1
-       END IF
-       IF (byte_array_a(x) .ne. byte_array_b(x)) THEN
-          errors = errors + 1
-       END IF
-       IF (short_array_a(x) .ne. short_array_b(x)) THEN
-          errors = errors + 1
-       END IF
-       IF (int_array_a(x) .ne. int_array_b(x)) THEN
-          errors = errors + 1
-       END IF
-       IF (long_int_array_a(x) .ne. long_int_array_b(x)) THEN
-          errors = errors + 1
-       END IF
-       IF (abs((INT(float_array_a(x)) * .7) - float_array_b(x)) .gt. &
-            & .00001) THEN
-          errors = errors + 1
-       END IF
-       IF (abs((INT(double_array_a(x)) * .7) - double_array_b(x)) .gt. &
-            & .0000000001) THEN
-          errors = errors + 1
-       END IF
-       IF (logical_array_b(x) .neqv. .FALSE.) THEN
-          errors = errors + 1
-       END IF
-       IF (logical_kind4_array_b(x) .neqv. .FALSE.) THEN
-          errors = errors + 1
-       END IF
-       IF (logical_kind8_array_b(x) .neqv. .FALSE.) THEN
-          errors = errors + 1
-       END IF
-       IF (ABS(complex_array_b(x)) - ABS(complex_array_a(x)) .lt. 0) THEN
-          errors = errors + 1
-       ELSEIF (ABS(complex_array_b(x) - (1, 1)) - (ABS(complex_array_a(x) &
-            & )) .gt. 0) THEN
-          errors = errors + 1
-       END IF
-       IF (ABS(double_complex_array_b(x)) - ABS(complex_array_a(x)) .lt. &
-            & 0) THEN
-          errors = errors + 1
-       ELSEIF (ABS(double_complex_array_b(x) - (1, 1)) - (ABS(double_&
-            &complex_array_a(x))) .gt. 0) THEN
-          errors = errors + 1
-       END IF
+       OMPVV_TEST_AND_SET_VERBOSE(errors, char_array_a(x) .ne. char_array_b(x))
+       OMPVV_TEST_AND_SET_VERBOSE(errors, byte_array_a(x) .ne. byte_array_b(x))
+       OMPVV_TEST_AND_SET_VERBOSE(errors, short_array_a(x) .ne. short_array_b(x))
+       OMPVV_TEST_AND_SET_VERBOSE(errors, int_array_a(x) .ne. int_array_b(x))
+       OMPVV_TEST_AND_SET_VERBOSE(errors, long_int_array_a(x) .ne. long_int_array_b(x))
+       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS((INT(float_array_a(x)) * .7) - float_array_b(x)) .gt. .00001)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS((INT(double_array_a(x)) * .7) - double_array_b(x)) .gt. .0000000001)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, logical_array_b(x) .neqv. .FALSE.)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, logical_kind4_array_b(x) .neqv. .FALSE.)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, LOGICAL(logical_kind8_array_b(x) .neqv. .FALSE., 4))
+       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(complex_array_b(x)) - ABS(complex_array_a(x)) .lt. 0)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(complex_array_b(x) - (1, 1)) - (ABS(complex_array_a(x))) .gt. 0)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(double_complex_array_b(x)) - ABS(complex_array_a(x)) .lt. 0)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(double_complex_array_b(x) - (1, 1)) - (ABS(double_complex_array_a(x))) .gt. 0)
     END DO
 
     scalar_char = 'c'
@@ -444,91 +387,35 @@ CONTAINS
     END DO
 
     DO x = 1, N
-       IF (char_array_a(x) .ne. scalar_char_copy) THEN
-          errors = errors + 1
-       END IF
-       IF (byte_array_a(x) .ne. scalar_byte_copy) THEN
-          errors = errors + 1
-       END IF
-       IF (short_array_a(x) .ne. scalar_short_copy) THEN
-          errors = errors + 1
-       END IF
-       IF (int_array_a(x) .ne. scalar_int_copy) THEN
-          errors = errors + 1
-       END IF
-       IF (long_int_array_a(x) .ne. scalar_long_int_copy) THEN
-          errors = errors + 1
-       END IF
-       IF (ABS(float_array_a(x) - scalar_float_copy) .gt. .000001) THEN
-          errors = errors + 1
-       END IF
-       IF (ABS(double_array_a(x) - scalar_double_copy) .gt. .0000000001) &
-            &THEN
-          errors = errors + 1
-       END IF
-       IF (logical_array_b(x) .neqv. scalar_logical_copy) THEN
-          errors = errors + 1
-       END IF
-       IF (logical_kind4_array_b(x) .neqv. scalar_logical_kind4_copy) THEN
-          errors = errors + 1
-       END IF
-       IF (logical_kind8_array_b(x) .neqv. scalar_logical_kind8_copy) THEN
-          errors = errors + 1
-       END IF
-       IF (complex_array_a(x) .ne. scalar_complex_copy) THEN
-          errors = errors + 1
-       END IF
-       IF (double_complex_array_a(x) .ne. scalar_double_complex_copy) THEN
-          errors = errors + 1
-       END IF
+       OMPVV_TEST_AND_SET_VERBOSE(errors, char_array_a(x) .ne. scalar_char_copy)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, byte_array_a(x) .ne. scalar_byte_copy)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, short_array_a(x) .ne. scalar_short_copy)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, int_array_a(x) .ne. scalar_int_copy)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, long_int_array_a(x) .ne. scalar_long_int_copy)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(float_array_a(x) - scalar_float_copy) .gt. .000001)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(double_array_a(x) - scalar_double_copy) .gt. .0000000001)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, logical_array_b(x) .neqv. scalar_logical_copy)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, logical_kind4_array_b(x) .neqv. scalar_logical_kind4_copy)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, LOGICAL(logical_kind8_array_b(x) .neqv. scalar_logical_kind8_copy, 4))
+       OMPVV_TEST_AND_SET_VERBOSE(errors, complex_array_a(x) .ne. scalar_complex_copy)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, double_complex_array_a(x) .ne. scalar_double_complex_copy)
     END DO
 
     IF (isSharedEnv .neqv. .TRUE.) THEN
-       IF (scalar_char .ne. scalar_char_copy) THEN
-          errors = errors + 1
-       END IF
-       IF (scalar_byte .ne. scalar_byte_copy) THEN
-          errors = errors + 1
-       END IF
-       IF (scalar_short .ne. scalar_short_copy) THEN
-          errors = errors + 1
-       END IF
-       IF (scalar_int .ne. scalar_int_copy) THEN
-          errors = errors + 1
-       END IF
-       IF (scalar_long_int .ne. scalar_long_int_copy) THEN
-          errors = errors + 1
-       END IF
-       IF (ABS(scalar_float - scalar_float_copy) .gt. .000001) THEN
-          errors = errors + 1
-       END IF
-       IF (ABS(scalar_double - scalar_double_copy) .gt. .0000000001) THEN
-          errors = errors + 1
-       END IF
-       IF (scalar_logical .neqv. scalar_logical_copy) THEN
-          errors = errors + 1
-       END IF
-       IF (scalar_logical_kind4 .neqv. scalar_logical_kind4_copy) THEN
-          errors = errors + 1
-       END IF
-       IF (scalar_logical_kind8 .neqv. scalar_logical_kind8_copy) THEN
-          errors = errors + 1
-       END IF
-       IF (ABS(REAL(scalar_complex) - REAL(scalar_complex_copy)) .gt. &
-            & .000001) THEN
-          errors = errors + 1
-       END IF
-       IF (ABS(IMAG(scalar_complex) - IMAG(scalar_complex_copy)) .gt. &
-            & .000001) THEN
-          errors = errors + 1
-       END IF
-       IF (ABS(REAL(scalar_double_complex) - REAL(scalar_double_complex)) &
-            & .gt. .0000000001) THEN
-          errors = errors + 1
-       END IF
-       IF (ABS(IMAG(scalar_double_complex) - IMAG(scalar_double_complex)) &
-            & .gt. .0000000001) THEN
-          errors = errors + 1
+       OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_char .ne. scalar_char_copy)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_byte .ne. scalar_byte_copy)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_short .ne. scalar_short_copy)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_int .ne. scalar_int_copy)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_long_int .ne. scalar_long_int_copy)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(scalar_float - scalar_float_copy) .gt. .000001)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(scalar_double - scalar_double_copy) .gt. .0000000001)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_logical .neqv. scalar_logical_copy)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_logical_kind4 .neqv. scalar_logical_kind4_copy)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, LOGICAL(scalar_logical_kind8 .neqv. scalar_logical_kind8_copy, 4))
+       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(REAL(scalar_complex) - REAL(scalar_complex_copy)) .gt. .000001)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(IMAG(scalar_complex) - IMAG(scalar_complex_copy)) .gt. .000001)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(REAL(scalar_double_complex) - REAL(scalar_double_complex)) .gt. .0000000001)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(IMAG(scalar_double_complex) - IMAG(scalar_double_complex)) .gt. .0000000001)
        END IF
     END IF
     test_defaultmap_off = errors

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_defaultmap.c
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_defaultmap.c
@@ -45,11 +45,11 @@ int test_defaultmap_on() {
   enum enum_type enum_array[ARRAY_SIZE];
 
 #pragma omp target teams distribute defaultmap(tofrom: scalar) map(from: char_array[0:ARRAY_SIZE], \
-								   short_array[0:ARRAY_SIZE], \
-								   int_array[0:ARRAY_SIZE], \
-								   float_array[0:ARRAY_SIZE], \
-								   double_array[0:ARRAY_SIZE], \
-								   enum_array[0:ARRAY_SIZE])
+                                                                   short_array[0:ARRAY_SIZE], \
+                                                                   int_array[0:ARRAY_SIZE], \
+                                                                   float_array[0:ARRAY_SIZE], \
+                                                                   double_array[0:ARRAY_SIZE], \
+                                                                   enum_array[0:ARRAY_SIZE])
   for (int x = 0; x < ARRAY_SIZE; ++x){
     char_array[x] = scalar_char;
     short_array[x] = scalar_short;
@@ -111,11 +111,11 @@ int test_defaultmap_on() {
   }
 
 #pragma omp target teams distribute defaultmap(tofrom: scalar) map(tofrom: char_array[0:ARRAY_SIZE], \
-								   short_array[0:ARRAY_SIZE], \
-								   int_array[0:ARRAY_SIZE], \
-								   float_array[0:ARRAY_SIZE], \
-								   double_array[0:ARRAY_SIZE], \
-								   enum_array[0:ARRAY_SIZE])
+                                                                   short_array[0:ARRAY_SIZE], \
+                                                                   int_array[0:ARRAY_SIZE], \
+                                                                   float_array[0:ARRAY_SIZE], \
+                                                                   double_array[0:ARRAY_SIZE], \
+                                                                   enum_array[0:ARRAY_SIZE])
   for (int x = 0; x < ARRAY_SIZE; ++x) {
     scalar_char = char_array[x];
     scalar_short = short_array[x];
@@ -228,11 +228,11 @@ int test_defaultmap_off() {
 
   //Testing the privatization nature of firstprivate default action
 #pragma omp target teams distribute map(tofrom: char_array_a[0:ARRAY_SIZE], char_array_b[0:ARRAY_SIZE], \
-					short_array_a[0:ARRAY_SIZE], short_array_b[0:ARRAY_SIZE], \
-					int_array_a[0:ARRAY_SIZE], int_array_b[0:ARRAY_SIZE], \
-					float_array_a[0:ARRAY_SIZE], float_array_b[0:ARRAY_SIZE], \
-					double_array_a[0:ARRAY_SIZE], double_array_b[0:ARRAY_SIZE], \
-					enum_array_a[0:ARRAY_SIZE], enum_array_b[0:ARRAY_SIZE])
+                                        short_array_a[0:ARRAY_SIZE], short_array_b[0:ARRAY_SIZE], \
+                                        int_array_a[0:ARRAY_SIZE], int_array_b[0:ARRAY_SIZE], \
+                                        float_array_a[0:ARRAY_SIZE], float_array_b[0:ARRAY_SIZE], \
+                                        double_array_a[0:ARRAY_SIZE], double_array_b[0:ARRAY_SIZE], \
+                                        enum_array_a[0:ARRAY_SIZE], enum_array_b[0:ARRAY_SIZE])
   for (int x = 0; x < ARRAY_SIZE; ++x) {
     scalar_char = 0;
     for (int y = 0; y < char_array_a[x]; ++y) {
@@ -324,8 +324,8 @@ int test_defaultmap_off() {
 
   // Testing the copy of scalar values to the device
 #pragma omp target teams distribute map(tofrom: char_array_a[0:ARRAY_SIZE], short_array_a[0:ARRAY_SIZE], \
-					int_array_a[0:ARRAY_SIZE], float_array_a[0:ARRAY_SIZE], \
-					double_array_a[0:ARRAY_SIZE], enum_array_a[0:ARRAY_SIZE])
+                                        int_array_a[0:ARRAY_SIZE], float_array_a[0:ARRAY_SIZE], \
+                                        double_array_a[0:ARRAY_SIZE], enum_array_a[0:ARRAY_SIZE])
   for (int x = 0; x < ARRAY_SIZE; ++x) {
     char_array_a[x] = scalar_char;
     short_array_a[x] = scalar_short;

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_defaultmap.c
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_defaultmap.c
@@ -117,12 +117,14 @@ int test_defaultmap_on() {
                                                                    double_array[0:ARRAY_SIZE], \
                                                                    enum_array[0:ARRAY_SIZE])
   for (int x = 0; x < ARRAY_SIZE; ++x) {
-    scalar_char = char_array[x];
-    scalar_short = short_array[x];
-    scalar_int = int_array[x];
-    scalar_float = float_array[x];
-    scalar_double = double_array[x];
-    scalar_enum = enum_array[x];
+    if (omp_get_team_num() == 0) {
+      scalar_char = char_array[x];
+      scalar_short = short_array[x];
+      scalar_int = int_array[x];
+      scalar_float = float_array[x];
+      scalar_double = double_array[x];
+      scalar_enum = enum_array[x];
+    }
   }
 
   OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_char != char_array[0]);
@@ -173,8 +175,6 @@ int test_defaultmap_on() {
       break;
     }
   }
-
-
 
   return errors;
 }

--- a/tests/4.5/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_defaultmap.c
+++ b/tests/4.5/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_defaultmap.c
@@ -1,10 +1,10 @@
 //===---- test_target_teams_distribute_parallel_for_defaultmap.c - combined consutrct -===//
-// 
+//
 // OpenMP API Version 4.5 Nov 2015
-// 
-// testing de defaultmap of different scalar values. We check when it is off and when it is
-// on. The first one should not copy values back from the device of scalars. the second one 
-// should copy the values back even if they are not mapped explicitely
+//
+// Testing defaultmap of different scalar values. We check when it is off and when it is
+// on. The first one should not copy values back from the device of scalars. The second
+// should copy the values back even if they are not mapped explicitly.
 //
 //===----------------------------------------------------------------------------------===//
 
@@ -35,7 +35,7 @@ int test_defaultmap_on() {
   double scalar_double = 10.45;
   double scalar_double_cpy[ITERATIONS];
   enum { VAL1 = 1, VAL2, VAL3, VAL4} scalar_enum = VAL1, scalar_enum_cpy[ITERATIONS];
-  
+
 
   // Testing the to behavior of the tofrom we use an array to avoid data
   // races and check that all threads get the value
@@ -61,13 +61,17 @@ int test_defaultmap_on() {
   // Map the same array to multiple devices. initialize with device number
 #pragma omp target teams distribute parallel for defaultmap(tofrom: scalar)
   for (i = 0; i < ITERATIONS; ++i) {
-    scalar_char = 'b';
-    scalar_short = 20;
-    scalar_int = 33;
-    scalar_float = 6.5f;
-    scalar_double = 20.45;
-    scalar_enum = VAL4;
-  } // end of omp target 
+    if (omp_get_team_num() == 0) {
+      if (omp_get_thread_num() == 0) {
+        scalar_char = 'b';
+        scalar_short = 20;
+        scalar_int = 33;
+        scalar_float = 6.5f;
+        scalar_double = 20.45;
+        scalar_enum = VAL4;
+      }
+    }
+  } // end of omp target
 
   OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_char != 'b');
   OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_short != 20);
@@ -75,16 +79,16 @@ int test_defaultmap_on() {
   OMPVV_TEST_AND_SET_VERBOSE(errors, fabs(scalar_float - 6.5f) > 0.0001);
   OMPVV_TEST_AND_SET_VERBOSE(errors, fabs(scalar_double - 20.45) > 0.00001);
   OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_enum != VAL4);
-  
+
   return errors;
 }
 
 int test_defaultmap_off() {
   OMPVV_INFOMSG("test_defaultmap_off");
-  
+
   int errors = 0;
   int i;
-  
+
   // we try with all the scalars
   char scalar_char = 'a';
   char scalar_char_cpy[ITERATIONS];
@@ -119,7 +123,7 @@ int test_defaultmap_off() {
     OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_enum_cpy[i] != VAL1);
   }
   // Map the same array to multiple devices. initialize with device number
-#pragma omp target teams distribute parallel for 
+#pragma omp target teams distribute parallel for
   for (i = 0; i < ITERATIONS; ++i) {
       scalar_char = 'b';
       scalar_short = 20;
@@ -127,15 +131,15 @@ int test_defaultmap_off() {
       scalar_float = 6.5f;
       scalar_double = 20.45;
       scalar_enum = VAL4;
-  } // end of omp target 
-  
+  } // end of omp target
+
   OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_char != 'a');
   OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_short != 10);
   OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_int != 11);
   OMPVV_TEST_AND_SET_VERBOSE(errors, fabs(scalar_float - 5.5f) > 0.0001);
   OMPVV_TEST_AND_SET_VERBOSE(errors, fabs(scalar_double - 10.45) > 0.0001);
   OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_enum != VAL1);
-  
+
   return errors;
 }
 int main() {
@@ -147,4 +151,3 @@ int main() {
 
   OMPVV_REPORT_AND_RETURN(errors);
 }
-


### PR DESCRIPTION
This is a Fortran version of `test_target_teams_distribute_defaultmap`. It checks for mapping of all availible scalar types, so it is quite long.

At present it fails to compile on gfortran with the message `lto1: fatal error: unsupported mode TF`, and passes xlf. 