### PR TITLE
Add Fortran default firstprivate test

### DIFF
--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_default_firstprivate.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_default_firstprivate.F90
@@ -32,7 +32,6 @@ CONTAINS
   INTEGER FUNCTION test_default_firstprivate()
     INTEGER,DIMENSION(N):: a, b, c, d
     INTEGER:: privatized, errors, x, y
-    CHARACTER(len=300):: errMsg
     errors = 0
 
     DO x = 1, N

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_default_firstprivate.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_default_firstprivate.F90
@@ -1,61 +1,118 @@
-!===--- test_target_teams_distribute_default_private.F90--------------------===//
+!===--- test_target_teams_distribute_firstprivate.F90-----------------------===//
 !
 ! OpenMP API Version 4.5 Nov 2015
 !
-! This test uses the default firstprivate clause on a target teams distribute
-! directive to indicate that a scalar variable should be by default made
-! firstprivate to each team executing the teams distribute region.  The test
-! then operates on the firstprivatized variable in such a way that would most
-! likely cause competiting operations if the variable is not privatized, and
-! such that the outcome depends on the initial host value of the variable. If
-! the computation completes without errors, we assume that the
-! firstprivatization occured.
+! This test uses the default firstprivate clause and tests it in two separate
+! parts. The test first tests the privatization of the firstprivatized scalars
+! and then separately tests the proper initialization of them separately
 !
-!===------------------------------------------------------------------------===//
+!//===----------------------------------------------------------------------===//
 
 #include "ompvv.F90"
 
 #define N 1024
 
-PROGRAM test_target_teams_distribute_device
+PROGRAM test_target_teams_distribute_default_firstprivate
   USE iso_fortran_env
   USE ompvv_lib
   USE omp_lib
   implicit none
-
+  INTEGER :: errors
   OMPVV_TEST_OFFLOADING
-  OMPVV_TEST_VERBOSE(test_default_firstprivate() .ne. 0)
+  errors = 0
+
+  OMPVV_TEST_VERBOSE(test_firstprivate_private() .ne. 0)
+  OMPVV_TEST_VERBOSE(test_firstprivate_first() .ne. 0)
 
   OMPVV_REPORT_AND_RETURN()
 CONTAINS
-  INTEGER FUNCTION test_default_firstprivate()
-    INTEGER,DIMENSION(N):: a, b, c, d
-    INTEGER:: privatized, errors, x, y
+  INTEGER FUNCTION test_firstprivate_private()
+    INTEGER:: errors, x, y, z, privatized
+    INTEGER,DIMENSION(N):: a, b, c, d, num_teams
+    INTEGER,DIMENSION(10):: privatized_array
+
     errors = 0
+    privatized = 0
 
     DO x = 1, N
        a(x) = 1
        b(x) = x
-       c(x) = 2*x
+       c(x) = 2 * x
        d(x) = 0
+       num_teams(x) = -1
     END DO
 
-    privatized = 5
+    DO x = 1, 10
+       privatized_array(x) = 0
+    END DO
 
-    !$omp target teams distribute default(firstprivate) shared(a, &
-    !$omp& b, c, d)
+    !$omp target data map(from: d(1:N)) map(to: a(1:N), b(1:N), c(1:N))
+    !$omp target teams distribute default(firstprivate) &
+    !$omp& map(alloc: a(1:N), b(1:N), c(1:N), d(1:N)) num_teams(10)
     DO x = 1, N
+       num_teams(x) = omp_get_num_teams()
        DO y = 1, a(x) + b(x)
           privatized = privatized + 1
+          DO z = 1, 10
+             privatized_array(z) = privatized_array(z) + 1
+          END DO
        END DO
-       d(x) = c(x)*privatized
-       privatized = 5
+       d(x) = c(x) * privatized
+       DO z = 1, 10
+          d(x) = d(x) + privatized_array(z)
+       END DO
+       privatized = 0
+       DO z = 1, 10
+          privatized_array(z) = 0
+       END DO
     END DO
+    !$omp end target data
 
     DO x = 1, N
-       OMPVV_TEST_AND_SET(errors, (d(x) .ne. (2*x)*(6 + x)))
+       IF (d(x) .ne. 10*(1 + x) + (1 + x)*2*x) THEN
+          errors = errors + 1
+       END IF
+       OMPVV_WARNING_IF(num_teams(x) .eq. 1, "Did not create enough teams to check for potential data races.")
     END DO
 
-    test_default_firstprivate = errors
-  END FUNCTION test_default_firstprivate
-END PROGRAM test_target_teams_distribute_device
+    test_firstprivate_private = errors
+  END FUNCTION test_firstprivate_private
+  INTEGER FUNCTION test_firstprivate_first()
+    INTEGER:: errors, x, p, privatized
+    INTEGER,DIMENSION(N):: a, b, c, d, num_teams
+    INTEGER,DIMENSION(10):: privatized_array
+
+    errors = 0
+    privatized = 1
+
+    DO x = 1, N
+       a(x) = 1
+       b(x) = x
+       c(x) = 2 * x
+       d(x) = 0
+       num_teams(x) = -1
+    END DO
+
+    DO x = 1, 10
+       privatized_array(x) = x
+    END DO
+
+    !$omp target data map(from: d(1:N)) map(to: a(1:N), b(1:N), c(1:N))
+    !$omp target teams distribute default(firstprivate) &
+    !$omp& map(alloc: a(1:N), b(1:N), c(1:N), d(1:N)) num_teams(10)
+    DO x = 1, N
+       num_teams(x) = omp_get_num_teams()
+       d(x) = a(x) + b(x) + c(x) + privatized_array(MOD(x, 10) + 1) + privatized
+    END DO
+    !$omp end target data
+
+    DO x = 1, N
+       IF (d(x) .ne. 2 + 3*x + MOD(x, 10) + 1) THEN
+          errors = errors + 1
+       END IF
+       OMPVV_WARNING_IF(num_teams(x) .eq. 1, "Did not create enough teams to check for potential data races.")
+    END DO
+
+    test_firstprivate_first = errors
+  END FUNCTION test_firstprivate_first
+END PROGRAM test_target_teams_distribute_default_firstprivate

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_default_firstprivate.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_default_firstprivate.F90
@@ -11,7 +11,7 @@
 ! the computation completes without errors, we assume that the
 ! firstprivatization occured.
 !
-!===----------------------------------------------------------------------===//
+!===------------------------------------------------------------------------===//
 
 #include "ompvv.F90"
 
@@ -22,8 +22,7 @@ PROGRAM test_target_teams_distribute_device
   USE ompvv_lib
   USE omp_lib
   implicit none
-  INTEGER :: errors
-  errors = 0
+
   OMPVV_TEST_OFFLOADING
   OMPVV_TEST_VERBOSE(test_default_firstprivate() .ne. 0)
 

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_default_firstprivate.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_default_firstprivate.F90
@@ -1,0 +1,62 @@
+!===--- test_target_teams_distribute_default_private.F90--------------------===//
+!
+! OpenMP API Version 4.5 Nov 2015
+!
+! This test uses the default firstprivate clause on a target teams distribute
+! directive to indicate that a scalar variable should be by default made
+! firstprivate to each team executing the teams distribute region.  The test
+! then operates on the firstprivatized variable in such a way that would most
+! likely cause competiting operations if the variable is not privatized, and
+! such that the outcome depends on the initial host value of the variable. If
+! the computation completes without errors, we assume that the
+! firstprivatization occured.
+!
+!//===----------------------------------------------------------------------===//
+
+#include "ompvv.F90"
+
+#define N 1024
+
+PROGRAM test_target_teams_distribute_device
+  USE iso_fortran_env
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+  INTEGER :: errors
+  errors = 0
+  OMPVV_TEST_OFFLOADING
+  OMPVV_TEST_VERBOSE(test_default_firstprivate() .ne. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+CONTAINS
+  INTEGER FUNCTION test_default_firstprivate()
+    INTEGER,DIMENSION(N):: a, b, c, d
+    INTEGER:: privatized, errors, x, y
+    CHARACTER(len=300):: errMsg
+    errors = 0
+
+    DO x = 1, N
+       a(x) = 1
+       b(x) = x
+       c(x) = 2*x
+       d(x) = 0
+    END DO
+
+    privatized = 5
+
+    !$omp target teams distribute default(firstprivate) shared(a, &
+    !$omp& b, c, d)
+    DO x = 1, N
+       DO y = 1, a(x) + b(x)
+          privatized = privatized + 1
+       END DO
+       d(x) = c(x)*privatized
+    END DO
+
+    DO x = 1, N
+       OMPVV_TEST_AND_SET(errors, (d(x) .ne. (2*x)*(6 + x)))
+    END DO
+
+    test_default_firstprivate = errors
+  END FUNCTION test_default_firstprivate
+END PROGRAM test_target_teams_distribute_device

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_default_firstprivate.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_default_firstprivate.F90
@@ -11,7 +11,7 @@
 ! the computation completes without errors, we assume that the
 ! firstprivatization occured.
 !
-!//===----------------------------------------------------------------------===//
+!===----------------------------------------------------------------------===//
 
 #include "ompvv.F90"
 

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_default_firstprivate.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_default_firstprivate.F90
@@ -49,6 +49,7 @@ CONTAINS
           privatized = privatized + 1
        END DO
        d(x) = c(x)*privatized
+       privatized = 5
     END DO
 
     DO x = 1, N


### PR DESCRIPTION
This is a test for the default(firstprivate) clause, which is only available in Fortran. It uses a similar approach to the private test, except it gives an initial value to the privatized variable on the host.

Right now both gfortran and xlf are failing this test. I suspect this is a bug since moving the initialization to inside the target teams distribute region causes it to pass.