### PR TITLE
Index variable `i` mistakenly shared within parallel region

### DIFF
--- a/tests/4.5/target/test_target_firstprivate.c
+++ b/tests/4.5/target/test_target_firstprivate.c
@@ -25,7 +25,7 @@ int main() {
       compute_array[i][j] = 0;
 
   omp_set_num_threads(NUM_THREADS);
-#pragma omp parallel
+#pragma omp parallel private(i)
 {
   int p_val = omp_get_thread_num();
   actualNumThreads = omp_get_num_threads();


### PR DESCRIPTION
The index `i` of the for-loop inside the parallel region (line 43) is shared by default. A `private(i)` clause may be necessary in the parallel construct to make sure that all threads are using their own index variable. Another possible fix is to write the for-loop at line 43 as `for (int i = 0; i < N; i++)`, which would allow to keep `i` shared in the parallel region and make sure the compiler is correctly making `i` firstprivate within the target-region. Let me know what you think. Thanks!