### PR TITLE
Fix test/test enter exit data map global array.c to add test of delete attribute

### DIFF
--- a/tests/4.5/target_enter_exit_data/test_target_enter_exit_data_map_global_array.c
+++ b/tests/4.5/target_enter_exit_data/test_target_enter_exit_data_map_global_array.c
@@ -1,45 +1,83 @@
+//===--- test_target_enter_exit_data_map_global_array.c ---------------------===//
+//
+// OpenMP API Version 4.5 Nov 2015
+//
+// This test is in two parts. First,
+//
+////===----------------------------------------------------------------------===//
+
 #include <stdio.h>
 #include <stdlib.h>
+#include "ompvv.h"
 #include <omp.h>
 
-// Test for OpenMP 4.5 target enter and target exit data with global arrays.
+#define N 10
 
-int n=10;
-int *x;
-int A[10]={0,0,0,0,0,0,0,0,0,0};
+int A[N] = {0};
+int B[N] = {0};
 
-void init(){
- #pragma omp target enter data map(to:A[:n])
-}
+int test_tofrom() {
+  int errors = 0;
 
-void finalize(){
- #pragma omp target exit data map(from:A[:n])
-}
+  for (int i = 0; i < N; ++i) {
+    A[i] = 0;
+  }
 
-int main (){
-int isHost=-1,i,errors=0;
+#pragma omp target enter data map(to: A)
 
-init();
+#pragma omp target
+  {
+    for (int i = 0; i < N; i++) {
+      A[i] = N;
+    }
+  }
 
-#pragma omp target map(tofrom: isHost)  
-{
- /*Record where the computation was executed*/
- isHost = omp_is_initial_device();
+#pragma omp target exit data map(from: A)
 
- for(i=0;i< n; i++)
-   A[i] = 10;
-}
-
- finalize();
- for(i=0; i<n; i++)
-   if(A[i] != 10){
-     errors += 1;
-   }
-
-  if (!errors)
-    printf("Test passed on %s\n", (isHost ? "host" : "device"));
-  else
-    printf("Test failed on %s\n", (isHost ? "host" : "device"));
+  for (int i = 0; i < N; ++i) {
+    OMPVV_TEST_AND_SET_VERBOSE(errors, A[i] != N);
+  }
 
   return errors;
+}
+
+int test_delete() {
+  int errors = 0;
+
+  for (int i = 0; i < N; ++i) {
+    A[i] = N;
+  }
+
+#pragma omp target data map(tofrom: A) map(from: B)
+  {
+#pragma omp target exit data map(delete: A)
+    for (int i = 0; i < N; ++i) {
+      A[i] = 0;
+    }
+#pragma omp target map(to: A)
+    {
+      for (int i = 0; i < N; ++i) {
+        B[i] = A[i];
+      }
+    }
+  }
+
+  for (int i = 0; i < N; ++i) {
+    OMPVV_TEST_AND_SET_VERBOSE(errors, B[i] != 0);
+  }
+
+  return errors;
+}
+
+int main () {
+  int errors = 0;
+
+  OMPVV_TEST_OFFLOADING;
+
+  OMPVV_TEST_SHARED_ENVIRONMENT;
+
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_tofrom() != 0);
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_delete() != 0);
+
+  OMPVV_REPORT_AND_RETURN(errors);
 }

--- a/tests/4.5/target_enter_exit_data/test_target_enter_exit_data_map_global_array.c
+++ b/tests/4.5/target_enter_exit_data/test_target_enter_exit_data_map_global_array.c
@@ -2,7 +2,12 @@
 //
 // OpenMP API Version 4.5 Nov 2015
 //
-// This test is in two parts. First,
+// This test is in two parts. First, the test checks that mapping to on enter
+// followed by mapping from on exit works, by modifying the data on the
+// device. Then, the delete clause is tested by making sure that deleting
+// an array mapped to the device resets its reference count, meaning that
+// modifications made on the host are remapped back in when another map(to)
+// is encountered.
 //
 ////===----------------------------------------------------------------------===//
 
@@ -54,7 +59,7 @@ int test_delete() {
     for (int i = 0; i < N; ++i) {
       A[i] = 0;
     }
-#pragma omp target map(to: A)
+#pragma omp target map(to: A)   // if the delete does not work, this map will not happen.
     {
       for (int i = 0; i < N; ++i) {
         B[i] = A[i];


### PR DESCRIPTION
Adds testing of delete clause, and addresses issue 10. The delete clause is tested as we proposed in a meeting last month: by mapping an array to the device, running a exit data map(delete) on the array, modifying the array on the host, and then running a target region with a map(to) on the array to see if the changes are seen by the device. The changes will not be seen by the device if the delete did not happen.

This updated test is passing all Summit compilers.