### PR TITLE
New test/require unified shared memory

### DIFF
--- a/tests/5.0/requires/test_requires_unified_shared_memory.c
+++ b/tests/5.0/requires/test_requires_unified_shared_memory.c
@@ -74,6 +74,7 @@ int unified_shared_memory_stack() {
   for (int i = 0; i < N; i++) {
     OMPVV_TEST_AND_SET_VERBOSE(errors, anArray[i] != i + 30);
     OMPVV_TEST_AND_SET_VERBOSE(errors, anArrayCopy[i] != i + 30);
+    if (errors) break;
   }
   return errors;
 }
@@ -115,7 +116,11 @@ int unified_shared_memory_heap() {
   for (int i = 0; i < N; i++) {
     OMPVV_TEST_AND_SET_VERBOSE(errors, anArray[i] != i + 30);
     OMPVV_TEST_AND_SET_VERBOSE(errors, anArrayCopy[i] != i + 30);
+    if (errors) break;
   }
+
+  free(anArray);
+  free(anArrayCopy);
   return errors;
 }
 int main() {

--- a/tests/5.0/requires/test_requires_unified_shared_memory.c
+++ b/tests/5.0/requires/test_requires_unified_shared_memory.c
@@ -1,0 +1,131 @@
+//===---test_requires_unified_shared_memory.c -------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+//
+////===----------------------------------------------------------------------===//
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+#pragma omp requires unified_shared_memory
+
+int unified_shared_memory_scalar() {
+  OMPVV_INFOMSG("Unified shared memory testing - scalar value");
+  int errors = 0;
+  
+  int aVariable = 0;
+  // aVariable is only mapped to, with unified shared memory we should see the change reflected in the host.
+  // If no map is explicitely added, then scalars are firstprivate
+#pragma omp target map(to:aVariable)
+  {
+    aVariable += 10;
+  }
+
+  aVariable += 10;
+#pragma omp target map(alloc:aVariable)
+  {
+    aVariable += 10;
+  }
+
+  OMPVV_TEST_AND_SET_VERBOSE(errors, aVariable != 30);
+  return errors;
+}
+
+int unified_shared_memory_stack() {
+  OMPVV_INFOMSG("Unified shared memory testing - Array on stack");
+  int errors = 0;
+  
+  int anArray[N];
+  int anArrayCopy[N];
+
+  for (int i = 0; i < N; i++) {
+    anArray[i] = i;
+    anArrayCopy[i] = 0;
+  }
+  // If for any reason there is data mapping, we avoid the movement
+  // that may occur through the default mapping map(tofrom)
+#pragma omp target data map(alloc:anArray) 
+  {
+    // Modify again on the host
+    for (int i = 0; i < N; i++) {
+        anArray[i] += 10;
+    }
+#pragma omp target
+    {
+      for (int i = 0; i < N; i++) {
+        anArray[i] += 10;
+      }
+    }
+  }
+  // Modify again on the host
+  for (int i = 0; i < N; i++) {
+    anArray[i] += 10;
+  }
+#pragma omp target map(alloc:anArray)
+  {
+    for (int i = 0; i < N; i++) {
+      anArrayCopy[i] = anArray[i];
+    }
+  }
+  for (int i = 0; i < N; i++) {
+    OMPVV_TEST_AND_SET_VERBOSE(errors, anArray[i] != i + 30);
+    OMPVV_TEST_AND_SET_VERBOSE(errors, anArrayCopy[i] != i + 30);
+  }
+  return errors;
+}
+
+int unified_shared_memory_heap() {
+  OMPVV_INFOMSG("Unified shared memory testing - Array on heap");
+  int errors = 0;
+  
+  int *anArray;
+  int *anArrayCopy;
+
+  anArray = (int*)malloc(sizeof(int)*N);
+  anArrayCopy = (int*)malloc(sizeof(int)*N);
+
+  for (int i = 0; i < N; i++) {
+    anArray[i] = i;
+    anArrayCopy[i] = 0;
+  }
+  // Modiify in the device
+#pragma omp target
+  {
+    for (int i = 0; i < N; i++) {
+      anArray[i] += 10;
+    }
+  }
+  // Modify again on the host
+  for (int i = 0; i < N; i++) {
+    anArray[i] += 10;
+  }
+
+  // Get the value the device is seeing
+#pragma omp target 
+  {
+    for (int i = 0; i < N; i++) {
+      anArrayCopy[i] = anArray[i];
+    }
+  }
+
+  for (int i = 0; i < N; i++) {
+    OMPVV_TEST_AND_SET_VERBOSE(errors, anArray[i] != i + 30);
+    OMPVV_TEST_AND_SET_VERBOSE(errors, anArrayCopy[i] != i + 30);
+  }
+  return errors;
+}
+int main() {
+  int isOffloading;
+  OMPVV_TEST_AND_SET_OFFLOADING(isOffloading);
+  OMPVV_WARNING_IF(!isOffloading, "With no offloading, unified shared memory is guaranteed due to host execution");
+  int errors = 0;
+  OMPVV_TEST_AND_SET_VERBOSE(errors, unified_shared_memory_scalar());
+  OMPVV_TEST_AND_SET_VERBOSE(errors, unified_shared_memory_stack());
+  OMPVV_TEST_AND_SET_VERBOSE(errors, unified_shared_memory_heap());
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.0/requires/test_requires_unified_shared_memory.c
+++ b/tests/5.0/requires/test_requires_unified_shared_memory.c
@@ -114,8 +114,8 @@ int unified_shared_memory_heap() {
   }
 
   for (int i = 0; i < N; i++) {
-    OMPVV_TEST_AND_SET_VERBOSE(errors, anArray[i] != i + 30);
-    OMPVV_TEST_AND_SET_VERBOSE(errors, anArrayCopy[i] != i + 30);
+    OMPVV_TEST_AND_SET_VERBOSE(errors, anArray[i] != i + 20);
+    OMPVV_TEST_AND_SET_VERBOSE(errors, anArrayCopy[i] != i + 20);
     if (errors) break;
   }
 

--- a/tests/5.0/requires/test_requires_unified_shared_memory.c
+++ b/tests/5.0/requires/test_requires_unified_shared_memory.c
@@ -1,7 +1,9 @@
 //===---test_requires_unified_shared_memory.c -------------------------------===//
 //
 // OpenMP API Version 5.0 Nov 2018
-//
+// 
+// This test just uses requries unified_shared_memory in a simple target region
+// and it is intended to show that this would not break anything in the compiler
 //
 ////===----------------------------------------------------------------------===//
 #include <omp.h>
@@ -13,124 +15,27 @@
 
 #pragma omp requires unified_shared_memory
 
-int unified_shared_memory_scalar() {
-  OMPVV_INFOMSG("Unified shared memory testing - scalar value");
+int unified_shared_memory() {
+  OMPVV_INFOMSG("Unified shared memory testing");
   int errors = 0;
   
   int aVariable = 0;
-  // aVariable is only mapped to, with unified shared memory we should see the change reflected in the host.
-  // If no map is explicitely added, then scalars are firstprivate
-#pragma omp target map(to:aVariable)
+#pragma omp target map(tofrom:aVariable)
   {
     aVariable += 10;
   }
 
   aVariable += 10;
-#pragma omp target map(alloc:aVariable)
-  {
-    aVariable += 10;
-  }
-
-  OMPVV_TEST_AND_SET_VERBOSE(errors, aVariable != 30);
+  OMPVV_TEST_AND_SET_VERBOSE(errors, aVariable != 20);
   return errors;
 }
 
-int unified_shared_memory_stack() {
-  OMPVV_INFOMSG("Unified shared memory testing - Array on stack");
-  int errors = 0;
-  
-  int anArray[N];
-  int anArrayCopy[N];
-
-  for (int i = 0; i < N; i++) {
-    anArray[i] = i;
-    anArrayCopy[i] = 0;
-  }
-  // If for any reason there is data mapping, we avoid the movement
-  // that may occur through the default mapping map(tofrom)
-#pragma omp target data map(alloc:anArray) 
-  {
-    // Modify again on the host
-    for (int i = 0; i < N; i++) {
-        anArray[i] += 10;
-    }
-#pragma omp target
-    {
-      for (int i = 0; i < N; i++) {
-        anArray[i] += 10;
-      }
-    }
-  }
-  // Modify again on the host
-  for (int i = 0; i < N; i++) {
-    anArray[i] += 10;
-  }
-#pragma omp target map(alloc:anArray)
-  {
-    for (int i = 0; i < N; i++) {
-      anArrayCopy[i] = anArray[i];
-    }
-  }
-  for (int i = 0; i < N; i++) {
-    OMPVV_TEST_AND_SET_VERBOSE(errors, anArray[i] != i + 30);
-    OMPVV_TEST_AND_SET_VERBOSE(errors, anArrayCopy[i] != i + 30);
-    if (errors) break;
-  }
-  return errors;
-}
-
-int unified_shared_memory_heap() {
-  OMPVV_INFOMSG("Unified shared memory testing - Array on heap");
-  int errors = 0;
-  
-  int *anArray;
-  int *anArrayCopy;
-
-  anArray = (int*)malloc(sizeof(int)*N);
-  anArrayCopy = (int*)malloc(sizeof(int)*N);
-
-  for (int i = 0; i < N; i++) {
-    anArray[i] = i;
-    anArrayCopy[i] = 0;
-  }
-  // Modiify in the device
-#pragma omp target
-  {
-    for (int i = 0; i < N; i++) {
-      anArray[i] += 10;
-    }
-  }
-  // Modify again on the host
-  for (int i = 0; i < N; i++) {
-    anArray[i] += 10;
-  }
-
-  // Get the value the device is seeing
-#pragma omp target 
-  {
-    for (int i = 0; i < N; i++) {
-      anArrayCopy[i] = anArray[i];
-    }
-  }
-
-  for (int i = 0; i < N; i++) {
-    OMPVV_TEST_AND_SET_VERBOSE(errors, anArray[i] != i + 20);
-    OMPVV_TEST_AND_SET_VERBOSE(errors, anArrayCopy[i] != i + 20);
-    if (errors) break;
-  }
-
-  free(anArray);
-  free(anArrayCopy);
-  return errors;
-}
 int main() {
   int isOffloading;
   OMPVV_TEST_AND_SET_OFFLOADING(isOffloading);
   OMPVV_WARNING_IF(!isOffloading, "With no offloading, unified shared memory is guaranteed due to host execution");
   int errors = 0;
-  OMPVV_TEST_AND_SET_VERBOSE(errors, unified_shared_memory_scalar());
-  OMPVV_TEST_AND_SET_VERBOSE(errors, unified_shared_memory_stack());
-  OMPVV_TEST_AND_SET_VERBOSE(errors, unified_shared_memory_heap());
+  OMPVV_TEST_AND_SET_VERBOSE(errors, unified_shared_memory());
 
   OMPVV_REPORT_AND_RETURN(errors);
 }

--- a/tests/5.0/requires/test_requires_unified_shared_memory_heap.c
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_heap.c
@@ -1,0 +1,71 @@
+//===---test_requires_unified_shared_memory.c -------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+// 
+// This test Checks for unified shared memory of an array that is allocated on 
+// the heap and that is accessed from host and device with the same pointer
+//
+// It uses the default mapping of pointers to access the array
+//
+////===----------------------------------------------------------------------===//
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+#pragma omp requires unified_shared_memory
+
+int unified_shared_memory_heap() {
+  OMPVV_INFOMSG("Unified shared memory testing - Array on heap");
+  int errors = 0;
+  
+  int *anArray;
+  int anArrayCopy[N];
+
+  anArray = (int*)malloc(sizeof(int)*N);
+
+  for (int i = 0; i < N; i++) {
+    anArray[i] = i;
+    anArrayCopy[i] = 0;
+  }
+  // Modify in the device
+#pragma omp target 
+  {
+    for (int i = 0; i < N; i++) {
+      anArray[i] += 10;
+    }
+  }
+  // Modify again on the host
+  for (int i = 0; i < N; i++) {
+    anArray[i] += 10;
+  }
+
+  // Get the value the device is seeing
+#pragma omp target 
+  {
+    for (int i = 0; i < N; i++) {
+      anArrayCopy[i] = anArray[i];
+    }
+  }
+
+  for (int i = 0; i < N; i++) {
+    OMPVV_TEST_AND_SET_VERBOSE(errors, anArray[i] != i + 20);
+    OMPVV_TEST_AND_SET_VERBOSE(errors, anArrayCopy[i] != i + 20);
+    if (errors) break;
+  }
+
+  free(anArray);
+  return errors;
+}
+int main() {
+  int isOffloading;
+  OMPVV_TEST_AND_SET_OFFLOADING(isOffloading);
+  OMPVV_WARNING_IF(!isOffloading, "With no offloading, unified shared memory is guaranteed due to host execution");
+  int errors = 0;
+  
+  OMPVV_TEST_AND_SET_VERBOSE(errors, unified_shared_memory_heap());
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.0/requires/test_requires_unified_shared_memory_heap.c
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_heap.c
@@ -1,4 +1,4 @@
-//===---test_requires_unified_shared_memory.c -------------------------------===//
+//===---test_requires_unified_shared_memory_heap.c --------------------------===//
 //
 // OpenMP API Version 5.0 Nov 2018
 // 

--- a/tests/5.0/requires/test_requires_unified_shared_memory_heap_is_device_ptr.c
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_heap_is_device_ptr.c
@@ -1,0 +1,71 @@
+//===---test_requires_unified_shared_memory.c -------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+// 
+// This test Checks for unified shared memory of an array that is allocated on 
+// the heap and that is accessed from host and device with the same pointer
+//
+// To guarantee the use of the device pointer, we use the is_device_ptr clause
+//
+////===----------------------------------------------------------------------===//
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+#pragma omp requires unified_shared_memory
+
+int unified_shared_memory_heap() {
+  OMPVV_INFOMSG("Unified shared memory testing - Array on heap");
+  int errors = 0;
+  
+  int *anArray;
+  int anArrayCopy[N];
+
+  anArray = (int*)malloc(sizeof(int)*N);
+
+  for (int i = 0; i < N; i++) {
+    anArray[i] = i;
+    anArrayCopy[i] = 0;
+  }
+  // Modify in the device
+#pragma omp target is_device_ptr(anArray)
+  {
+    for (int i = 0; i < N; i++) {
+      anArray[i] += 10;
+    }
+  }
+  // Modify again on the host
+  for (int i = 0; i < N; i++) {
+    anArray[i] += 10;
+  }
+
+  // Get the value the device is seeing
+#pragma omp target is_device_ptr(anArray)
+  {
+    for (int i = 0; i < N; i++) {
+      anArrayCopy[i] = anArray[i];
+    }
+  }
+
+  for (int i = 0; i < N; i++) {
+    OMPVV_TEST_AND_SET_VERBOSE(errors, anArray[i] != i + 20);
+    OMPVV_TEST_AND_SET_VERBOSE(errors, anArrayCopy[i] != i + 20);
+    if (errors) break;
+  }
+
+  free(anArray);
+  return errors;
+}
+int main() {
+  int isOffloading;
+  OMPVV_TEST_AND_SET_OFFLOADING(isOffloading);
+  OMPVV_WARNING_IF(!isOffloading, "With no offloading, unified shared memory is guaranteed due to host execution");
+  int errors = 0;
+  
+  OMPVV_TEST_AND_SET_VERBOSE(errors, unified_shared_memory_heap());
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.0/requires/test_requires_unified_shared_memory_heap_is_device_ptr.c
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_heap_is_device_ptr.c
@@ -1,4 +1,4 @@
-//===---test_requires_unified_shared_memory.c -------------------------------===//
+//===---test_requires_unified_shared_memory_heap_is_device_ptr.c -----------===//
 //
 // OpenMP API Version 5.0 Nov 2018
 // 

--- a/tests/5.0/requires/test_requires_unified_shared_memory_heap_map.c
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_heap_map.c
@@ -1,0 +1,72 @@
+//===---test_requires_unified_shared_memory.c -------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+// 
+// This test Checks for unified shared memory of an array that is allocated on 
+// the heap and that is accessed from host and device with the same pointer
+//
+// The mapping of a pointer under shared memory should allow for the pointer to
+// have the same value as in the host
+//
+////===----------------------------------------------------------------------===//
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+#pragma omp requires unified_shared_memory
+
+int unified_shared_memory_heap() {
+  OMPVV_INFOMSG("Unified shared memory testing - Array on heap");
+  int errors = 0;
+  
+  int *anArray;
+  int anArrayCopy[N];
+
+  anArray = (int*)malloc(sizeof(int)*N);
+
+  for (int i = 0; i < N; i++) {
+    anArray[i] = i;
+    anArrayCopy[i] = 0;
+  }
+  // Modify in the device
+#pragma omp target map(anArray)
+  {
+    for (int i = 0; i < N; i++) {
+      anArray[i] += 10;
+    }
+  }
+  // Modify again on the host
+  for (int i = 0; i < N; i++) {
+    anArray[i] += 10;
+  }
+
+  // Get the value the device is seeing
+#pragma omp target map(anArray)
+  {
+    for (int i = 0; i < N; i++) {
+      anArrayCopy[i] = anArray[i];
+    }
+  }
+
+  for (int i = 0; i < N; i++) {
+    OMPVV_TEST_AND_SET_VERBOSE(errors, anArray[i] != i + 20);
+    OMPVV_TEST_AND_SET_VERBOSE(errors, anArrayCopy[i] != i + 20);
+    if (errors) break;
+  }
+
+  free(anArray);
+  return errors;
+}
+int main() {
+  int isOffloading;
+  OMPVV_TEST_AND_SET_OFFLOADING(isOffloading);
+  OMPVV_WARNING_IF(!isOffloading, "With no offloading, unified shared memory is guaranteed due to host execution");
+  int errors = 0;
+  
+  OMPVV_TEST_AND_SET_VERBOSE(errors, unified_shared_memory_heap());
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.0/requires/test_requires_unified_shared_memory_heap_map.c
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_heap_map.c
@@ -1,4 +1,4 @@
-//===---test_requires_unified_shared_memory.c -------------------------------===//
+//===---test_requires_unified_shared_memory_heap_map.c ----------------------===//
 //
 // OpenMP API Version 5.0 Nov 2018
 // 

--- a/tests/5.0/requires/test_requires_unified_shared_memory_omp_target_alloc.c
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_omp_target_alloc.c
@@ -1,4 +1,4 @@
-//===---test_requires_unified_shared_memory.c -------------------------------===//
+//===---test_requires_unified_shared_memory_omp_target_alloc.c --------------===//
 //
 // OpenMP API Version 5.0 Nov 2018
 // 

--- a/tests/5.0/requires/test_requires_unified_shared_memory_omp_target_alloc.c
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_omp_target_alloc.c
@@ -29,7 +29,7 @@ int unified_shared_memory_target_alloc() {
 #pragma omp target 
   {
     for (int i = 0; i < N; i++) {
-      anArray[i] = 0;
+      anArray[i] = i;
     }
   }
   for (int i = 0; i < N; i++) {

--- a/tests/5.0/requires/test_requires_unified_shared_memory_omp_target_alloc.c
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_omp_target_alloc.c
@@ -63,7 +63,7 @@ int unified_shared_memory_target_alloc() {
     if (errors) break;
   }
 
-  free(anArray);
+  omp_target_free(anArray,omp_get_default_device());
   return errors;
 }
 int main() {

--- a/tests/5.0/requires/test_requires_unified_shared_memory_omp_target_alloc.c
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_omp_target_alloc.c
@@ -1,0 +1,78 @@
+//===---test_requires_unified_shared_memory.c -------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+// 
+// This test Checks for unified shared memory of an array that is allocated on 
+// the device and accessed in both host and device
+//
+// We use default mapping of pointers, which should be mappend as a zero lenght
+// array
+//
+////===----------------------------------------------------------------------===//
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+#pragma omp requires unified_shared_memory
+
+int unified_shared_memory_target_alloc() {
+  OMPVV_INFOMSG("Unified shared memory testing - Memory allocated in the device");
+  int errors = 0;
+  
+  int *anArray = (int *) omp_target_alloc(sizeof(int)*N, omp_get_default_device());
+  int anArrayCopy[N];
+
+  // Initialization
+#pragma omp target 
+  {
+    for (int i = 0; i < N; i++) {
+      anArray[i] = 0;
+    }
+  }
+  for (int i = 0; i < N; i++) {
+    anArrayCopy[i] = 0;
+  }
+
+  // Modify in the device
+#pragma omp target
+  {
+    for (int i = 0; i < N; i++) {
+      anArray[i] += 10;
+    }
+  }
+
+  // Modify again on the host
+  for (int i = 0; i < N; i++) {
+    anArray[i] += 10;
+  }
+
+  // Get the value the device is seeing
+#pragma omp target
+  {
+    for (int i = 0; i < N; i++) {
+      anArrayCopy[i] = anArray[i];
+    }
+  }
+
+  for (int i = 0; i < N; i++) {
+    OMPVV_TEST_AND_SET_VERBOSE(errors, anArray[i] != i + 20);
+    OMPVV_TEST_AND_SET_VERBOSE(errors, anArrayCopy[i] != i + 20);
+    if (errors) break;
+  }
+
+  free(anArray);
+  return errors;
+}
+int main() {
+  int isOffloading;
+  OMPVV_TEST_AND_SET_OFFLOADING(isOffloading);
+  OMPVV_WARNING_IF(!isOffloading, "With no offloading, unified shared memory is guaranteed due to host execution");
+  int errors = 0;
+  
+  OMPVV_TEST_AND_SET_VERBOSE(errors, unified_shared_memory_target_alloc());
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.0/requires/test_requires_unified_shared_memory_omp_target_alloc_is_device_ptr.c
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_omp_target_alloc_is_device_ptr.c
@@ -63,7 +63,7 @@ int unified_shared_memory_target_alloc() {
     if (errors) break;
   }
 
-  free(anArray);
+  omp_target_free(anArray, omp_get_default_device());
   return errors;
 }
 int main() {

--- a/tests/5.0/requires/test_requires_unified_shared_memory_omp_target_alloc_is_device_ptr.c
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_omp_target_alloc_is_device_ptr.c
@@ -1,4 +1,4 @@
-//===---test_requires_unified_shared_memory.c -------------------------------===//
+//===---test_requires_unified_shared_memory_omp_target_alloc_is_device_ptr.c -===//
 //
 // OpenMP API Version 5.0 Nov 2018
 // 
@@ -29,7 +29,7 @@ int unified_shared_memory_target_alloc() {
 #pragma omp target is_device_ptr(anArray)
   {
     for (int i = 0; i < N; i++) {
-      anArray[i] = 0;
+      anArray[i] = i;
     }
   }
   for (int i = 0; i < N; i++) {

--- a/tests/5.0/requires/test_requires_unified_shared_memory_omp_target_alloc_is_device_ptr.c
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_omp_target_alloc_is_device_ptr.c
@@ -1,0 +1,78 @@
+//===---test_requires_unified_shared_memory.c -------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+// 
+// This test Checks for unified shared memory of an array that is allocated on 
+// the device and accessed in both host and device
+//
+// We use is_device_ptr to guarantee the use of the host pointer value in the 
+// device 
+//
+////===----------------------------------------------------------------------===//
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+#pragma omp requires unified_shared_memory
+
+int unified_shared_memory_target_alloc() {
+  OMPVV_INFOMSG("Unified shared memory testing - Memory allocated in the device");
+  int errors = 0;
+  
+  int *anArray = (int *) omp_target_alloc(sizeof(int)*N, omp_get_default_device());
+  int anArrayCopy[N];
+
+  // Initialization
+#pragma omp target is_device_ptr(anArray)
+  {
+    for (int i = 0; i < N; i++) {
+      anArray[i] = 0;
+    }
+  }
+  for (int i = 0; i < N; i++) {
+    anArrayCopy[i] = 0;
+  }
+
+  // Modify in the device
+#pragma omp target is_device_ptr(anArray)
+  {
+    for (int i = 0; i < N; i++) {
+      anArray[i] += 10;
+    }
+  }
+
+  // Modify again on the host
+  for (int i = 0; i < N; i++) {
+    anArray[i] += 10;
+  }
+
+  // Get the value the device is seeing
+#pragma omp target is_device_ptr(anArray)
+  {
+    for (int i = 0; i < N; i++) {
+      anArrayCopy[i] = anArray[i];
+    }
+  }
+
+  for (int i = 0; i < N; i++) {
+    OMPVV_TEST_AND_SET_VERBOSE(errors, anArray[i] != i + 20);
+    OMPVV_TEST_AND_SET_VERBOSE(errors, anArrayCopy[i] != i + 20);
+    if (errors) break;
+  }
+
+  free(anArray);
+  return errors;
+}
+int main() {
+  int isOffloading;
+  OMPVV_TEST_AND_SET_OFFLOADING(isOffloading);
+  OMPVV_WARNING_IF(!isOffloading, "With no offloading, unified shared memory is guaranteed due to host execution");
+  int errors = 0;
+  
+  OMPVV_TEST_AND_SET_VERBOSE(errors, unified_shared_memory_target_alloc());
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.0/requires/test_requires_unified_shared_memory_stack.c
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_stack.c
@@ -1,4 +1,4 @@
-//===---test_requires_unified_shared_memory.c -------------------------------===//
+//===---test_requires_unified_shared_memory_stack.c ------------------------===//
 //
 // OpenMP API Version 5.0 Nov 2018
 //

--- a/tests/5.0/requires/test_requires_unified_shared_memory_stack.c
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_stack.c
@@ -1,0 +1,70 @@
+//===---test_requires_unified_shared_memory.c -------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// Testing memory access from host and device to a variable allocated in the stack
+// The variable is accessed through a pointer to guarantee that there is no default
+// mapping tofrom: of the stack array
+//
+// Default mapping of the pointer should translate into the host pointer value, which
+// should be accessible from the device
+//
+////===----------------------------------------------------------------------===//
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+#pragma omp requires unified_shared_memory
+
+int unified_shared_memory_stack() {
+  OMPVV_INFOMSG("Unified shared memory testing - Array on stack");
+  int errors = 0;
+  
+  int anArray[N];
+  int anArrayCopy[N];
+  int * aPtr = anArray;
+
+  for (int i = 0; i < N; i++) {
+    anArray[i] = i;
+    anArrayCopy[i] = 0;
+  }
+
+  // Test for writes to this varriable from device
+#pragma omp target 
+  {
+    for (int i = 0; i < N; i++) {
+      aPtr[i] += 10;
+    }
+  }
+  // Modify again on the host
+  for (int i = 0; i < N; i++) {
+    aPtr[i] += 10;
+  }
+
+  // Test for reads to this variable from device
+#pragma omp target 
+  {
+    for (int i = 0; i < N; i++) {
+      anArrayCopy[i] = aPtr[i];
+    }
+  }
+  for (int i = 0; i < N; i++) {
+    OMPVV_TEST_AND_SET_VERBOSE(errors, anArray[i] != i + 20);
+    OMPVV_TEST_AND_SET_VERBOSE(errors, anArrayCopy[i] != i + 20);
+    if (errors) break;
+  }
+  return errors;
+}
+
+int main() {
+  int isOffloading;
+  OMPVV_TEST_AND_SET_OFFLOADING(isOffloading);
+  OMPVV_WARNING_IF(!isOffloading, "With no offloading, unified shared memory is guaranteed due to host execution");
+  int errors = 0;
+  OMPVV_TEST_AND_SET_VERBOSE(errors, unified_shared_memory_stack());
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.0/requires/test_requires_unified_shared_memory_stack_is_device_ptr.c
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_stack_is_device_ptr.c
@@ -1,0 +1,69 @@
+//===---test_requires_unified_shared_memory.c -------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// Testing memory access from host and device to a variable allocated in the stack
+// The variable is accessed through a pointer to guarantee that there is no default
+// mapping tofrom: of the stack array
+//
+// We use the is_device_ptr to guarantee using the host pointer is used in the device
+//
+////===----------------------------------------------------------------------===//
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+#pragma omp requires unified_shared_memory
+
+int unified_shared_memory_stack() {
+  OMPVV_INFOMSG("Unified shared memory testing - Array on stack");
+  int errors = 0;
+  
+  int anArray[N];
+  int anArrayCopy[N];
+  int * aPtr = anArray;
+
+  for (int i = 0; i < N; i++) {
+    anArray[i] = i;
+    anArrayCopy[i] = 0;
+  }
+
+  // Test for writes to this variable from device
+#pragma omp target is_device_ptr(aPtr)
+  {
+    for (int i = 0; i < N; i++) {
+      aPtr[i] += 10;
+    }
+  }
+  // Modify again on the host
+  for (int i = 0; i < N; i++) {
+    aPtr[i] += 10;
+  }
+
+  // Test for reads to this variable from device
+#pragma omp target is_device_ptr(aPtr)
+  {
+    for (int i = 0; i < N; i++) {
+      anArrayCopy[i] = aPtr[i];
+    }
+  }
+  for (int i = 0; i < N; i++) {
+    OMPVV_TEST_AND_SET_VERBOSE(errors, anArray[i] != i + 20);
+    OMPVV_TEST_AND_SET_VERBOSE(errors, anArrayCopy[i] != i + 20);
+    if (errors) break;
+  }
+  return errors;
+}
+
+int main() {
+  int isOffloading;
+  OMPVV_TEST_AND_SET_OFFLOADING(isOffloading);
+  OMPVV_WARNING_IF(!isOffloading, "With no offloading, unified shared memory is guaranteed due to host execution");
+  int errors = 0;
+  OMPVV_TEST_AND_SET_VERBOSE(errors, unified_shared_memory_stack());
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.0/requires/test_requires_unified_shared_memory_stack_is_device_ptr.c
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_stack_is_device_ptr.c
@@ -1,4 +1,4 @@
-//===---test_requires_unified_shared_memory.c -------------------------------===//
+//===---test_requires_unified_shared_memory_stack_is_device_ptr.c ------------===//
 //
 // OpenMP API Version 5.0 Nov 2018
 //

--- a/tests/5.0/requires/test_requires_unified_shared_memory_stack_map.c
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_stack_map.c
@@ -1,4 +1,4 @@
-//===---test_requires_unified_shared_memory.c -------------------------------===//
+//===---test_requires_unified_shared_memory_stack_map.c ---------------------===//
 //
 // OpenMP API Version 5.0 Nov 2018
 //

--- a/tests/5.0/requires/test_requires_unified_shared_memory_stack_map.c
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_stack_map.c
@@ -1,0 +1,70 @@
+//===---test_requires_unified_shared_memory.c -------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// Testing memory access from host and device to a variable allocated in the stack
+// The variable is accessed through a pointer to guarantee that there is no default
+// mapping tofrom: of the stack array
+//
+// Using the map of a pointer to test the mapping of the pointer from the host to 
+// the device.
+//
+////===----------------------------------------------------------------------===//
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+#pragma omp requires unified_shared_memory
+
+int unified_shared_memory_stack() {
+  OMPVV_INFOMSG("Unified shared memory testing - Array on stack");
+  int errors = 0;
+  
+  int anArray[N];
+  int anArrayCopy[N];
+  int * aPtr = anArray;
+
+  for (int i = 0; i < N; i++) {
+    anArray[i] = i;
+    anArrayCopy[i] = 0;
+  }
+
+  // Test for writes to this variable from device
+#pragma omp target map(aPtr)
+  {
+    for (int i = 0; i < N; i++) {
+      aPtr[i] += 10;
+    }
+  }
+  // Modify again on the host
+  for (int i = 0; i < N; i++) {
+    aPtr[i] += 10;
+  }
+
+  // Test for reads to this variable from device
+#pragma omp target map(aPtr)
+  {
+    for (int i = 0; i < N; i++) {
+      anArrayCopy[i] = aPtr[i];
+    }
+  }
+  for (int i = 0; i < N; i++) {
+    OMPVV_TEST_AND_SET_VERBOSE(errors, anArray[i] != i + 20);
+    OMPVV_TEST_AND_SET_VERBOSE(errors, anArrayCopy[i] != i + 20);
+    if (errors) break;
+  }
+  return errors;
+}
+
+int main() {
+  int isOffloading;
+  OMPVV_TEST_AND_SET_OFFLOADING(isOffloading);
+  OMPVV_WARNING_IF(!isOffloading, "With no offloading, unified shared memory is guaranteed due to host execution");
+  int errors = 0;
+  OMPVV_TEST_AND_SET_VERBOSE(errors, unified_shared_memory_stack());
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.0/requires/test_requires_unified_shared_memory_static.c
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_static.c
@@ -1,0 +1,72 @@
+//===---test_requires_unified_shared_memory.c -------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// We request the use of unified_shared_memory in this proogram.
+// Checking for static arrays. The array is global and then accessed through 
+// a pointer from the host and the device.
+//
+// We use default mapping of the pointer, which should result in mapping of a zero
+// lenght array
+//
+////===----------------------------------------------------------------------===//
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+#pragma omp requires unified_shared_memory
+
+// STATIC ARRAY 
+int anArray[N];
+
+int unified_shared_memory_static() {
+  OMPVV_INFOMSG("Unified shared memory testing - Static Array");
+  int errors = 0;
+  
+  int anArrayCopy[N];
+  int * aPtr = anArray;
+
+  for (int i = 0; i < N; i++) {
+    anArray[i] = i;
+    anArrayCopy[i] = 0;
+  }
+
+  // Test for writes to this variable from device
+#pragma omp target 
+  {
+    for (int i = 0; i < N; i++) {
+      aPtr[i] += 10;
+    }
+  }
+  // Modify again on the host
+  for (int i = 0; i < N; i++) {
+    aPtr[i] += 10;
+  }
+
+  // Test for reads to this variable from device
+#pragma omp target 
+  {
+    for (int i = 0; i < N; i++) {
+      anArrayCopy[i] = aPtr[i];
+    }
+  }
+  for (int i = 0; i < N; i++) {
+    OMPVV_TEST_AND_SET_VERBOSE(errors, anArray[i] != i + 20);
+    OMPVV_TEST_AND_SET_VERBOSE(errors, anArrayCopy[i] != i + 20);
+    if (errors) break;
+  }
+  return errors;
+}
+
+int main() {
+  int isOffloading;
+  OMPVV_TEST_AND_SET_OFFLOADING(isOffloading);
+  OMPVV_WARNING_IF(!isOffloading, "With no offloading, unified shared memory is guaranteed due to host execution");
+  int errors = 0;
+  OMPVV_TEST_AND_SET_VERBOSE(errors, unified_shared_memory_static());
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.0/requires/test_requires_unified_shared_memory_static.c
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_static.c
@@ -1,4 +1,4 @@
-//===---test_requires_unified_shared_memory.c -------------------------------===//
+//===---test_requires_unified_shared_memory_static.c ------------------------===//
 //
 // OpenMP API Version 5.0 Nov 2018
 //

--- a/tests/5.0/requires/test_requires_unified_shared_memory_static_is_device_ptr.c
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_static_is_device_ptr.c
@@ -1,0 +1,71 @@
+//===---test_requires_unified_shared_memory.c -------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// We request the use of unified_shared_memory in this proogram.
+// Checking for static arrays. The array is global and then accessed through 
+// a pointer from the host and the device.
+//
+// We use is_device_ptr to guarantee that the host pointer is used in the device
+//
+////===----------------------------------------------------------------------===//
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+#pragma omp requires unified_shared_memory
+
+// STATIC ARRAY 
+int anArray[N];
+
+int unified_shared_memory_static() {
+  OMPVV_INFOMSG("Unified shared memory testing - Static Array");
+  int errors = 0;
+  
+  int anArrayCopy[N];
+  int * aPtr = anArray;
+
+  for (int i = 0; i < N; i++) {
+    anArray[i] = i;
+    anArrayCopy[i] = 0;
+  }
+
+  // Test for writes to this variable from device
+#pragma omp target is_device_ptr(aPtr)
+  {
+    for (int i = 0; i < N; i++) {
+      aPtr[i] += 10;
+    }
+  }
+  // Modify again on the host
+  for (int i = 0; i < N; i++) {
+    aPtr[i] += 10;
+  }
+
+  // Test for reads to this variable from device
+#pragma omp target is_device_ptr(aPtr)
+  {
+    for (int i = 0; i < N; i++) {
+      anArrayCopy[i] = aPtr[i];
+    }
+  }
+  for (int i = 0; i < N; i++) {
+    OMPVV_TEST_AND_SET_VERBOSE(errors, anArray[i] != i + 20);
+    OMPVV_TEST_AND_SET_VERBOSE(errors, anArrayCopy[i] != i + 20);
+    if (errors) break;
+  }
+  return errors;
+}
+
+int main() {
+  int isOffloading;
+  OMPVV_TEST_AND_SET_OFFLOADING(isOffloading);
+  OMPVV_WARNING_IF(!isOffloading, "With no offloading, unified shared memory is guaranteed due to host execution");
+  int errors = 0;
+  OMPVV_TEST_AND_SET_VERBOSE(errors, unified_shared_memory_static());
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.0/requires/test_requires_unified_shared_memory_static_is_device_ptr.c
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_static_is_device_ptr.c
@@ -1,4 +1,4 @@
-//===---test_requires_unified_shared_memory.c -------------------------------===//
+//===---test_requires_unified_shared_memory_static_is_device_ptr.c ----------===//
 //
 // OpenMP API Version 5.0 Nov 2018
 //

--- a/tests/5.0/requires/test_requires_unified_shared_memory_static_map.c
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_static_map.c
@@ -1,4 +1,4 @@
-//===---test_requires_unified_shared_memory.c -------------------------------===//
+//===---test_requires_unified_shared_memory_static_map.c --------------------===//
 //
 // OpenMP API Version 5.0 Nov 2018
 //

--- a/tests/5.0/requires/test_requires_unified_shared_memory_static_map.c
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_static_map.c
@@ -1,0 +1,71 @@
+//===---test_requires_unified_shared_memory.c -------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// We request the use of unified_shared_memory in this proogram.
+// Checking for static arrays. The array is global and then accessed through 
+// a pointer from the host and the device.
+//
+// We use the map clause on the pointer, with zero lenght array, to use the host
+// pointer on the device
+////===----------------------------------------------------------------------===//
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+#pragma omp requires unified_shared_memory
+
+// STATIC ARRAY 
+int anArray[N];
+
+int unified_shared_memory_static() {
+  OMPVV_INFOMSG("Unified shared memory testing - Static Array");
+  int errors = 0;
+  
+  int anArrayCopy[N];
+  int * aPtr = anArray;
+
+  for (int i = 0; i < N; i++) {
+    anArray[i] = i;
+    anArrayCopy[i] = 0;
+  }
+
+  // Test for writes to this varriable from device
+#pragma omp target map(aPtr)
+  {
+    for (int i = 0; i < N; i++) {
+      aPtr[i] += 10;
+    }
+  }
+  // Modify again on the host
+  for (int i = 0; i < N; i++) {
+    aPtr[i] += 10;
+  }
+
+  // Test for reads to this variable from device
+#pragma omp target map(aPtr)
+  {
+    for (int i = 0; i < N; i++) {
+      anArrayCopy[i] = aPtr[i];
+    }
+  }
+  for (int i = 0; i < N; i++) {
+    OMPVV_TEST_AND_SET_VERBOSE(errors, anArray[i] != i + 20);
+    OMPVV_TEST_AND_SET_VERBOSE(errors, anArrayCopy[i] != i + 20);
+    if (errors) break;
+  }
+  return errors;
+}
+
+int main() {
+  int isOffloading;
+  OMPVV_TEST_AND_SET_OFFLOADING(isOffloading);
+  OMPVV_WARNING_IF(!isOffloading, "With no offloading, unified shared memory is guaranteed due to host execution");
+  int errors = 0;
+  OMPVV_TEST_AND_SET_VERBOSE(errors, unified_shared_memory_static());
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}


### PR DESCRIPTION
This is a test for ` omp requires unified_shared_memory` It checks three different elements: 

1. Check if for a scalar value, we see the value reflected back and forth between host and device
2. Check if for an array allocated in the stack, we see the values reflected back and forth between host and device
3. Check if for an array allocated in the heap, we see the values reflected back and forth between host and device. 
