### PR TITLE
Change the header file to address issue #79

### DIFF
--- a/ompvv/ompvv.h
+++ b/ompvv/ompvv.h
@@ -80,7 +80,7 @@ _Pragma("omp target map (from: _ompvv_isOffloadingOn)") \
 #define OMPVV_REPORT(err) { \
   OMPVV_INFOMSG("The value of " #err " is %d.", err); \
   if (_ompvv_isOffloadingOn == -1) \
-    printf("[OMPVV_RESULT: %s] Test %s on the host.\n", __FILENAME__, (err == 0)? "passed":"failed"); \
+    printf("[OMPVV_RESULT: %s] Test %s.\n", __FILENAME__, (err == 0)? "passed":"failed"); \
   else \
     printf("[OMPVV_RESULT: %s] Test %s on the %s.\n", __FILENAME__, (err == 0)? "passed":"failed", (_ompvv_isOffloadingOn)? "device" : "host"); \
 }

--- a/ompvv/ompvv.h
+++ b/ompvv/ompvv.h
@@ -9,6 +9,7 @@
 #include <string.h>
 
 #define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+int _ompvv_isOffloadingOn = -1;
 
 // Macro for output of information, warning and error messages
 #ifdef VERBOSE_MODE
@@ -48,7 +49,7 @@
 #endif // END IF VERBOSE_MODE
 
 #define OMPVV_TEST_OFFLOADING_PROBE \
-  int _ompvv_isOffloadingOn = 0; \
+  _ompvv_isOffloadingOn = 0; \
 _Pragma("omp target map (from: _ompvv_isOffloadingOn)") \
   {  _ompvv_isOffloadingOn = !omp_is_initial_device();  }
 
@@ -77,9 +78,11 @@ _Pragma("omp target map (from: _ompvv_isOffloadingOn)") \
 }
 // Macro for reporting results
 #define OMPVV_REPORT(err) { \
-  OMPVV_TEST_OFFLOADING_PROBE \
   OMPVV_INFOMSG("The value of " #err " is %d.", err); \
-  printf("[OMPVV_RESULT: %s] Test %s on the %s.\n", __FILENAME__, (err == 0)? "passed":"failed", (_ompvv_isOffloadingOn)? "device" : "host"); \
+  if (_ompvv_isOffloadingOn == -1) \
+    printf("[OMPVV_RESULT: %s] Test %s on the host.\n", __FILENAME__, (err == 0)? "passed":"failed"); \
+  else \
+    printf("[OMPVV_RESULT: %s] Test %s on the %s.\n", __FILENAME__, (err == 0)? "passed":"failed", (_ompvv_isOffloadingOn)? "device" : "host"); \
 }
 
 // Macro for correct exit code
@@ -96,7 +99,7 @@ _Pragma("omp target map (from: _ompvv_isOffloadingOn)") \
 // Macro to check if it is a shared data environment
 #define OMPVV_TEST_SHARED_ENVIRONMENT_PROBE \
   int _ompvv_isSharedEnv = 1; \
-  int _ompvv_isOffloadingOn = 0; \
+  _ompvv_isOffloadingOn = 0; \
 _Pragma("omp target map (from: _ompvv_isOffloadingOn) map(to: _ompvv_isSharedEnv)") \
   {  _ompvv_isOffloadingOn = !omp_is_initial_device();  \
      _ompvv_isSharedEnv = 0; \


### PR DESCRIPTION
This is for issue #79. Some tests do not do anything on the device, but the existing header file reports that they "ran on the device" since it directly checks if device offloading is availible. Since this check is redundant when the test also calls OMPVV_TEST_OFFLOADING, in this update to the header file, OMPVV_REPORT now checks a global state variable to see if OMPVV_TEST_OFFLOADING was called. If it was not called, the test reports that it ran on the host at completion.

I am open to changing the message for this case since it would be inaccurate if the test *does* do things on the device but forgets to call OMPVV_TEST_OFFLOADING, perhaps not mentioning device/host at all since it would technically be unknown.