### PR TITLE
Fix test/test enter exit data map malloced array.c to add delete testing and fix issue #10

### DIFF
--- a/tests/4.5/target_enter_exit_data/test_target_enter_exit_data_map_malloced_array.c
+++ b/tests/4.5/target_enter_exit_data/test_target_enter_exit_data_map_malloced_array.c
@@ -13,21 +13,27 @@
 #define N 10
 
 int *x;
+int *y;
 
-int main() {
+int test_tofrom() {
   int i, errors = 0;
   int *A;
 
-  A = (int *) malloc(n*sizeof(int));
+  A = (int *) malloc(N*sizeof(int));
   if (NULL == A) {
+    OMPVV_ERROR("Malloc returned NULL.");
     exit(-1);
+  }
+
+  for (i = 0; i < N; ++i) {
+    A[i] = 0;
   }
 
   x = A;
 
-#pragma omp target enter data map(to: x) // Note: Mapping *A[:n] is incorrect as OpenMP doesn't support arbitrary expressions
+#pragma omp target enter data map(to: A)
 
-#pragma omp target map(tofrom: isHost)
+#pragma omp target
   {
     for (i = 0; i < N; i++) {
       A[i] = N;
@@ -39,6 +45,58 @@ int main() {
   for (i = 0; i < N; i++) {
     OMPVV_TEST_AND_SET_VERBOSE(errors, A[i] != N);
   }
+
+  return errors;
+}
+
+int test_delete() {
+  int i, errors = 0;
+  int *A, *B;
+
+  A = (int *) malloc(N*sizeof(int));
+  B = (int *) malloc(N*sizeof(int));
+  if (NULL == A || NULL == B) {
+    OMPVV_ERROR("Malloc returned NULL.");
+    exit(-1);
+  }
+
+  for (i = 0; i < N; ++i) {
+    A[i] = N;
+  }
+
+  x = A;
+  y = B;
+
+#pragma omp target data map(tofrom: x) map(from: y)
+  {
+#pragma omp target exit data map(delete: x)
+    for (i = 0; i < N; ++i) {
+      x[i] = 0;
+    }
+#pragma omp target map(to: x)
+    {
+      for (i = 0; i < N; i++) {
+        y[i] = x[i];
+      }
+    }
+  }
+
+  for (i = 0; i < N; i++) {
+    OMPVV_TEST_AND_SET_VERBOSE(errors, B[i] != 0);
+  }
+
+  return errors;
+}
+
+int main() {
+  int errors = 0;
+
+  OMPVV_TEST_OFFLOADING;
+
+  OMPVV_TEST_SHARED_ENVIRONMENT;
+
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_tofrom());
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_delete());
 
   OMPVV_REPORT_AND_RETURN(errors);
 }

--- a/tests/4.5/target_enter_exit_data/test_target_enter_exit_data_map_malloced_array.c
+++ b/tests/4.5/target_enter_exit_data/test_target_enter_exit_data_map_malloced_array.c
@@ -1,48 +1,44 @@
+//===--- test_target_enter_exit_data_map_global_array.c ---------------------===//
+//
+// OpenMP API Version 4.5 Nov 2015
+//
+//
+////===----------------------------------------------------------------------===//
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <omp.h>
+#include "ompvv.h"
 
-// Test for OpenMP 4.5 target enter and target exit data with allocated arrays.
+#define N 10
 
-int n=10;
 int *x;
 
-void init(int **A){
- *A = (int *)malloc(n*sizeof(int));
- if(NULL == *A) exit(-1);
- x=*A;
- #pragma omp target enter data map(to:x[:n])//Note:Mapping *A[:n] is incorrect as OpenMP doesn't support arbitrary expressions
-}
+int main() {
+  int i, errors = 0;
+  int *A;
 
-void finalize(){
- #pragma omp target exit data map(from:x[:n])
-}
+  A = (int *) malloc(n*sizeof(int));
+  if (NULL == A) {
+    exit(-1);
+  }
 
-int main (){
-int isHost=-1,i,errors=0;
-int *A;
+  x = A;
 
-init( &A);
+#pragma omp target enter data map(to: x) // Note: Mapping *A[:n] is incorrect as OpenMP doesn't support arbitrary expressions
 
-#pragma omp target map(tofrom: isHost) map(to: n) 
-{
- /*Record where the computation was executed*/
- isHost = omp_is_initial_device();
+#pragma omp target map(tofrom: isHost)
+  {
+    for (i = 0; i < N; i++) {
+      A[i] = N;
+    }
+  }
 
- for(i=0;i< n; i++)
-   A[i] = 10;
-}
+#pragma omp target exit data map(from: x)
 
- finalize();
- for(i=0; i<n; i++)
-   if(A[i] != 10){
-     errors += 1;
-   }
+  for (i = 0; i < N; i++) {
+    OMPVV_TEST_AND_SET_VERBOSE(errors, A[i] != N);
+  }
 
-  if (!errors)
-    printf("Test passed on %s\n", (isHost ? "host" : "device"));
-  else
-    printf("Test failed on %s\n", (isHost ? "host" : "device"));
-
-  return errors;
+  OMPVV_REPORT_AND_RETURN(errors);
 }

--- a/tests/4.5/target_enter_exit_data/test_target_enter_exit_data_map_malloced_array.c
+++ b/tests/4.5/target_enter_exit_data/test_target_enter_exit_data_map_malloced_array.c
@@ -31,12 +31,12 @@ int test_tofrom() {
 
   x = A;
 
-#pragma omp target enter data map(to: A)
+#pragma omp target enter data map(to: x)
 
 #pragma omp target
   {
     for (i = 0; i < N; i++) {
-      A[i] = N;
+      x[i] = N;
     }
   }
 

--- a/tests/4.5/target_enter_exit_data/test_target_enter_exit_data_map_malloced_array.c
+++ b/tests/4.5/target_enter_exit_data/test_target_enter_exit_data_map_malloced_array.c
@@ -31,7 +31,7 @@ int test_tofrom() {
 
   x = A;
 
-#pragma omp target enter data map(to: x)
+#pragma omp target enter data map(to: x[:N])
 
 #pragma omp target
   {
@@ -40,7 +40,7 @@ int test_tofrom() {
     }
   }
 
-#pragma omp target exit data map(from: x)
+#pragma omp target exit data map(from: x[:N])
 
   for (i = 0; i < N; i++) {
     OMPVV_TEST_AND_SET_VERBOSE(errors, A[i] != N);
@@ -67,13 +67,13 @@ int test_delete() {
   x = A;
   y = B;
 
-#pragma omp target data map(tofrom: x) map(from: y)
+#pragma omp target data map(tofrom: x[:N]) map(from: y[:N])
   {
-#pragma omp target exit data map(delete: x)
+#pragma omp target exit data map(delete: x[:N])
     for (i = 0; i < N; ++i) {
       x[i] = 0;
     }
-#pragma omp target map(to: x)
+#pragma omp target map(to: x[:N])
     {
       for (i = 0; i < N; i++) {
         y[i] = x[i];

--- a/tests/4.5/target_enter_exit_data/test_target_enter_exit_data_map_malloced_array.c
+++ b/tests/4.5/target_enter_exit_data/test_target_enter_exit_data_map_malloced_array.c
@@ -1,4 +1,4 @@
-//===--- test_target_enter_exit_data_map_global_array.c ---------------------===//
+//===--- test_target_enter_exit_data_map_malloced_array.c ---------------------===//
 //
 // OpenMP API Version 4.5 Nov 2015
 //


### PR DESCRIPTION
This is to address issue #10 and add testing of the delete clause. The approach is exactly the same as used for pul request #85. 

The test passes all summit compilers.