### PR TITLE
Add Fortran version of target teams distribute device test

### DIFF
--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_device.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_device.F90
@@ -57,12 +57,12 @@ CONTAINS
 
     DO dev = 1, num_devices
        !$omp target enter data map(to: a(1:N), b(1:N), c(1:N, dev:dev), &
-       !$omp& num_teams(dev:dev)) device(dev)
+       !$omp& num_teams(dev:dev)) device(dev - 1)
     END DO
 
     DO dev = 1, num_devices
        !$omp target teams distribute map(alloc: a(1:N), b(1:N), &
-       !$omp& c(1:N, dev:dev), num_teams(dev:dev)) device(dev)
+       !$omp& c(1:N, dev:dev), num_teams(dev:dev)) device(dev - 1)
        DO x = 1, N
           IF (omp_get_team_num() .eq. 0) THEN
              num_teams(dev) = omp_get_num_teams()
@@ -73,7 +73,7 @@ CONTAINS
 
     DO dev = 1, num_devices
        !$omp target exit data map(from: c(1:N, dev:dev), &
-       !$omp& num_teams(dev:dev)) map(delete: a(1:N), b(1:N)) device(dev)
+       !$omp& num_teams(dev:dev)) map(delete: a(1:N), b(1:N)) device(dev - 1)
        DO x = 1, N
           IF (c(x, dev) .ne. (1 + dev + x)) THEN
              errors(dev) = errors(dev) + 1

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_device.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_device.F90
@@ -1,0 +1,97 @@
+!===--- test_target_teams_distribute_device.F90------------------------------===//
+!
+! OpenMP API Version 4.5 Nov 2015
+!
+! This test uses the device clause to indicate which device should execute the
+! given target regions.  The test uses the separate device data environments to
+! ensure that operations are executed on the specified device.  If only one device
+! is available, the test issues a warning.
+!
+! By having a separate initialization of the same array on each device at the
+! same time, if all operations were occuring on the same device, we would expect
+! the same results from each device and it wouldn't be able to give proper answers
+! for each initialization.
+!
+!//===----------------------------------------------------------------------===//
+
+#include "ompvv.F90"
+
+#define N 1024
+
+PROGRAM test_target_teams_distribute_device
+  USE iso_fortran_env
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+  INTEGER :: errors
+  errors = 0
+  OMPVV_TEST_OFFLOADING
+  OMPVV_TEST_VERBOSE(test_multiple_devices() .ne. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+CONTAINS
+  INTEGER FUNCTION test_multiple_devices()
+    INTEGER :: x, dev, num_devices, total_errors
+    INTEGER, DIMENSION(N) :: a, b
+    INTEGER, ALLOCATABLE :: c(:, :)
+    INTEGER, ALLOCATABLE :: num_teams(:), errors(:)
+    CHARACTER(len=100) :: message
+
+    num_devices = omp_get_num_devices()
+    total_errors = 0
+
+    ALLOCATE(num_teams(num_devices))
+    ALLOCATE(errors(num_devices))
+    ALLOCATE(c(N, num_devices))
+
+    DO x = 1, N
+       a(x) = 1
+       b(x) = x
+       c(x, :) = 0
+    END DO
+
+    DO x = 1, num_devices
+       num_teams(x) = 0
+       errors(x) = 0
+    END DO
+
+    DO dev = 1, num_devices
+       !$omp target enter data map(to: a(1:N), b(1:N), c(1:N, dev:dev), &
+       !$omp& num_teams(dev:dev)) device(dev)
+    END DO
+
+    DO dev = 1, num_devices
+       !$omp target teams distribute map(alloc: a(1:N), b(1:N), &
+       !$omp& c(1:N, dev:dev), num_teams(dev:dev)) device(dev)
+       DO x = 1, N
+          IF (omp_get_team_num() .eq. 0) THEN
+             num_teams(dev) = omp_get_num_teams()
+          END IF
+          c(x, dev) = a(x) + b(x) + dev
+       END DO
+    END DO
+
+    DO dev = 1, num_devices
+       !$omp target exit data map(from: c(1:N, dev:dev), &
+       !$omp& num_teams(dev:dev)) map(delete: a(1:N), b(1:N)) device(dev)
+       DO x = 1, N
+          IF (c(x, dev) .ne. (1 + dev + x)) THEN
+             errors(dev) = errors(dev) + 1
+          END IF
+       END DO
+       total_errors = total_errors + errors(dev)
+    END DO
+
+    DO dev = 1, num_devices
+       IF (errors(dev) .eq. 0 .and. num_teams(dev) .eq. 1) THEN
+          WRITE(message, '(A,I0)') "Test operated with one team on &
+               &device: ", dev
+          OMPVV_INFOMSG(message)
+       ELSE IF (errors(dev) .ne. 0) THEN
+          WRITE(message, '(A,I0)') "Test failed on device: ", dev
+          OMPVV_INFOMSG(message)
+       END IF
+    END DO
+    test_multiple_devices = total_errors
+  END FUNCTION test_multiple_devices
+END PROGRAM test_target_teams_distribute_device

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_device.c
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_device.c
@@ -4,13 +4,13 @@
 //
 // This test uses the device clause to indicate which device should execute the
 // given target regions.  The test uses the separate device data environments to
-// ensure that operations are executed on the specified device.  If only one device
-// is available, the test issues a warning.
+// ensure that operations are executed on the specified device.  If only one
+// device is available, the test issues a warning.
 //
 // By having a separate initialization of the same array on each device at the
-// same time, if all operations were occuring on the same device, we would expect
-// the same results from each device and it wouldn't be able to give proper answers
-// for each initialization.
+// same time, if all operations were occuring on the same device, we would
+// expect the same results from each device and it wouldn't be able to give
+// proper answers for each initialization.
 //
 ////===----------------------------------------------------------------------===//
 
@@ -32,7 +32,7 @@ int main() {
   int errors[num_devices];
   int sum_errors = 0;
 
-  OMPVV_INFOMSG("running tests on %d devices", num_devices);
+  OMPVV_INFOMSG("Running tests on %d devices", num_devices);
 
   for (int x = 0; x < ARRAY_SIZE; ++x) {
     a[x] = 1;
@@ -51,7 +51,9 @@ int main() {
   for (int dev = 0; dev < num_devices; ++dev) {
 #pragma omp target teams distribute map(alloc: a[0:ARRAY_SIZE], b[0:ARRAY_SIZE], num_teams[dev]) device(dev)
     for (int x = 0; x < ARRAY_SIZE; ++x) {
-      num_teams[dev] = omp_get_num_teams();
+      if (omp_get_team_num() == 0) {
+        num_teams[dev] = omp_get_num_teams();
+      }
       a[x] += b[x] + dev;
     }
   }
@@ -61,7 +63,7 @@ int main() {
     for (int x = 0; x < ARRAY_SIZE; ++x) {
       OMPVV_TEST_AND_SET_VERBOSE(errors[dev], a[x] != 1 + dev + b[x]);
       if (a[x] != 1 + dev + b[x]) {
-	break;
+        break;
       }
     }
   }
@@ -71,12 +73,8 @@ int main() {
   }
 
   for (int dev = 0; dev < num_devices; ++dev) {
-    if (!errors[dev] && num_teams[dev] == 1) {
-      OMPVV_WARNING("Test operated with one team. Parallelism of teams distribute can't be guarnunteed.");
-    }
-    else if (errors[dev]) {
-      OMPVV_ERROR("Test failed with device %d", dev);
-    }
+    OMPVV_WARNING_IF(!errors[dev] && num_teams[dev] == 1, "Test operated with one team. Parallelism of teams distribute can't be guaranteed.");
+    OMPVV_ERROR_IF(errors[dev], "Test failed with device %d", dev);
   }
 
   OMPVV_REPORT_AND_RETURN(sum_errors);


### PR DESCRIPTION
This is a new version of the PR which doesn't include old changes caused by a bad git branch. See PR #64 for the original comments and description. 

At present the Fortran test fails gfortran with this error: `libgomp: GOMP_target_enter_exit_data unhandled kind 0x05`. It passes xlf.