### PR TITLE
Add tulip.def, AMD compiler flags for Cray CCE, and DEVICE_TYPE Makefile option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -449,6 +449,7 @@ help:
 	@echo "  LOG_ALL=1                 Enables dump of the make process output, errors, and binary execution outputs into logs.txt"
 	@echo "  SYSTEM=sys_name           Includes the definitions for the requires modules and batch schedulers in the different systems"
 	@echo "                            This definitions must be in sys/SYSTEM.def. (Do not include the .def extension)"
+	@echo "  DEVICE_TYPE=dev_name      Specifies device type being used, either nvidia or amd, to change compiler flags as needed."
 	@echo "  MODULE_LOAD=1             Before compiling or running, module load is called"
 	@echo "  ADD_BATCH_SCHED=1         Add the jsrun command before the execution of the running script to send it to a compute node"
 	@echo "  NO_OFFLOADING=1           Turn off offloading"

--- a/sys/make/make.def
+++ b/sys/make/make.def
@@ -67,11 +67,20 @@ CC?=none
 CPP?=none
 FC?=none
 
-# CRAY compiler
-ifeq ($(CC), cc)
-  CFLAGS += -fopenmp -fopenmp-targets=nvptx64 -Xopenmp-target -march=sm_70
-  CLINK = cc
-  CLINKFLAGS += -fopenmp -fopenmp-targets=nvptx64 -Xopenmp-target -march=sm_70
+ifeq ($(DEVICE_TYPE), amd)
+  # CRAY compiler (AMD)
+  ifeq ($(CC), cc)
+    CFLAGS += -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx906
+    CLINK = cc
+    CLINKFLAGS += -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx906
+  endif
+else
+  # CRAY compiler (NVIDIA)
+  ifeq ($(CC), cc)
+    CFLAGS += -fopenmp -fopenmp-targets=nvptx64 -Xopenmp-target -march=sm_70
+    CLINK = cc
+    CLINKFLAGS += -fopenmp -fopenmp-targets=nvptx64 -Xopenmp-target -march=sm_70
+  endif
 endif
 
 # GCC compiler

--- a/sys/make/make.def
+++ b/sys/make/make.def
@@ -264,17 +264,17 @@ endif
 # CRAY compilers
 ifeq ($(DEVICE_TYPE), amd)
   # CRAY compiler (AMD)
-  ifeq ($(CXX), CC)
-    CXXFLAGS += -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx906
-    CXXLINK = cc
-    CXXLINKFLAGS += -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx906
+  ifeq ($(FC), ftn)
+    FFLAGS += -fopenmp -J./ompvv
+    FLINK = cc
+    FLINKFLAGS += -fopenmp
   endif
 else
   # CRAY compiler (NVIDIA)
-  ifeq ($(CXX), CC)
-    CXXFLAGS += -fopenmp -fopenmp-targets=nvptx64 -Xopenmp-target -march=sm_70
-    CXXLINK = cc
-    CXXLINKFLAGS += -fopenmp -fopenmp-targets=nvptx64 -Xopenmp-target -march=sm_70
+  ifeq ($(FC), ftn)
+    FFLAGS += -fopenmp -J./ompvv
+    FLINK = cc
+    FLINKFLAGS += -fopenmp
   endif
 endif
 

--- a/sys/make/make.def
+++ b/sys/make/make.def
@@ -67,6 +67,7 @@ CC?=none
 CPP?=none
 FC?=none
 
+# CRAY compilers
 ifeq ($(DEVICE_TYPE), amd)
   # CRAY compiler (AMD)
   ifeq ($(CC), cc)
@@ -153,11 +154,21 @@ endif
 CXXCOMPILERS?="clang++, g++, xlc++"
 CXX_VERSION?= echo "version unknown"
 
-# CRAY compiler
-ifeq ($(CXX), CC)
-  CXXFLAGS += -fopenmp -fopenmp-targets=nvptx64 -Xopenmp-target -march=sm_70
-  CXXLINK = cc
-  CXXLINKFLAGS += -fopenmp -fopenmp-targets=nvptx64 -Xopenmp-target -march=sm_70
+# CRAY compilers
+ifeq ($(DEVICE_TYPE), amd)
+  # CRAY compiler (AMD)
+  ifeq ($(CXX), CC)
+    CXXFLAGS += -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx906
+    CXXLINK = cc
+    CXXLINKFLAGS += -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx906
+  endif
+else
+  # CRAY compiler (NVIDIA)
+  ifeq ($(CXX), CC)
+    CXXFLAGS += -fopenmp -fopenmp-targets=nvptx64 -Xopenmp-target -march=sm_70
+    CXXLINK = cc
+    CXXLINKFLAGS += -fopenmp -fopenmp-targets=nvptx64 -Xopenmp-target -march=sm_70
+  endif
 endif
 
 # GCC compiler
@@ -249,6 +260,7 @@ ifeq ($(FC), $(filter $(FC), xlf xlf_r))
   FLINK = xlc
   FLINKFLAGS += -O3 -qsmp=omp $(FOFFLOADING)
 endif
+
 #---------------------------------------------------------------------------
 # These macros are passed to the linker
 #---------------------------------------------------------------------------

--- a/sys/make/make.def
+++ b/sys/make/make.def
@@ -71,16 +71,16 @@ FC?=none
 ifeq ($(DEVICE_TYPE), amd)
   # CRAY compiler (AMD)
   ifeq ($(CC), cc)
-    CFLAGS += -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx906
+    CFLAGS += -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa
     CLINK = cc
-    CLINKFLAGS += -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx906
+    CLINKFLAGS += -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa
   endif
-else
+else ifeq ($(DEVICE_TYPE), nvidia)
   # CRAY compiler (NVIDIA)
   ifeq ($(CC), cc)
-    CFLAGS += -fopenmp -fopenmp-targets=nvptx64 -Xopenmp-target -march=sm_70
+    CFLAGS += -fopenmp -fopenmp-targets=nvptx64 -Xopenmp-target
     CLINK = cc
-    CLINKFLAGS += -fopenmp -fopenmp-targets=nvptx64 -Xopenmp-target -march=sm_70
+    CLINKFLAGS += -fopenmp -fopenmp-targets=nvptx64 -Xopenmp-target
   endif
 endif
 

--- a/sys/make/make.def
+++ b/sys/make/make.def
@@ -261,6 +261,23 @@ ifeq ($(FC), $(filter $(FC), xlf xlf_r))
   FLINKFLAGS += -O3 -qsmp=omp $(FOFFLOADING)
 endif
 
+# CRAY compilers
+ifeq ($(DEVICE_TYPE), amd)
+  # CRAY compiler (AMD)
+  ifeq ($(CXX), CC)
+    CXXFLAGS += -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx906
+    CXXLINK = cc
+    CXXLINKFLAGS += -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx906
+  endif
+else
+  # CRAY compiler (NVIDIA)
+  ifeq ($(CXX), CC)
+    CXXFLAGS += -fopenmp -fopenmp-targets=nvptx64 -Xopenmp-target -march=sm_70
+    CXXLINK = cc
+    CXXLINKFLAGS += -fopenmp -fopenmp-targets=nvptx64 -Xopenmp-target -march=sm_70
+  endif
+endif
+
 #---------------------------------------------------------------------------
 # These macros are passed to the linker
 #---------------------------------------------------------------------------

--- a/sys/systems/summit.def
+++ b/sys/systems/summit.def
@@ -16,19 +16,19 @@ CCOMPILERS="clang, gcc, xlc"
 
 # GCC compiler
 ifeq ($(CC), gcc)
-  C_COMPILER_MODULE = gcc/8.1.1
+  C_COMPILER_MODULE = gcc/9.1.0
   C_VERSION = gcc -dumpversion
 endif
 
 # IBM XL compiler
 ifeq ($(CC), xlc)
-  C_COMPILER_MODULE = xl/16.1.1-3
+  C_COMPILER_MODULE = xl/16.1.1-7
   C_VERSION = xlc -qversion | grep "Version: .*$$" | sed "s/Version: //g"
 endif
 
 # Clang compiler
 ifeq ($(CC), clang)
-  C_COMPILER_MODULE = llvm/1.0-20180531
+  C_COMPILER_MODULE = llvm/1.0-20190225
   C_VERSION = clang -v 2>&1 | grep -oh 'clang version [0-9.]*'| grep -oh 'version .*' | sed 's/.*/& CORAL/'
 endif
 
@@ -39,19 +39,19 @@ CXXCOMPILERS="clang++, g++, xlc++"
 
 # GCC compiler
 ifeq ($(CXX), g++)
-  CXX_COMPILER_MODULE = gcc/8.1.1
+  CXX_COMPILER_MODULE = gcc/9.1.0
   CXX_VERSION = g++ -dumpversion
 endif
 
 # IBM XL compiler
 ifeq ($(CXX), xlc++)
-  CXX_COMPILER_MODULE =  xl/16.1.1-3
+  CXX_COMPILER_MODULE =  xl/16.1.1-7
   CXX_VERSION = xlc -qversion | grep "Version: .*$$" | sed "s/Version: //g"
 endif
 
 # Clang compiler
 ifeq ($(CXX), clang++)
-  CXX_COMPILER_MODULE = llvm/1.0-20180531
+  CXX_COMPILER_MODULE = llvm/1.0-20190225
   CXX_VERSION = clang++ -v 2>&1 | grep -oh 'clang version [0-9.]*' | grep -oh 'version .*' | sed 's/.*/& CORAL/'
 endif
 
@@ -62,15 +62,14 @@ FCOMPILERS="gfortran, xlf"
 
 # GCC compiler
 ifeq ($(FC), gfortran)
-  F_COMPILER_MODULE = gcc/8.1.1
+  F_COMPILER_MODULE = gcc/9.1.0
   F_VERSION = gfortran -dumpversion
 endif
 
 # IBM XL compiler
-# Summitdev happens to have a wrapper that without it we cannot execute 
+# Summitdev happens to have a wrapper that without it we cannot execute
 # xlf with OMP 4.5 support. This wrapper is xlf_r
 ifeq ($(FC), $(filter $(FC), xlf xlf_r))
-  F_COMPILER_MODULE = xl/16.1.1-3 
-  F_VERSION = xlf -qversion | grep 'Version: .*$$' | sed 's/Version: //g' 
+  F_COMPILER_MODULE = xl/16.1.1-7
+  F_VERSION = xlf -qversion | grep 'Version: .*$$' | sed 's/Version: //g'
 endif
-

--- a/sys/systems/tulip.def
+++ b/sys/systems/tulip.def
@@ -1,0 +1,62 @@
+# Definitions for the COE Tulip system
+
+$(info "Including tulip.def file")
+
+#---------------------------------------------------------------------------
+# BATCH Scheduler
+#---------------------------------------------------------------------------
+JSRUN_COMMAND = srun -p amdMI60 
+BATCH_SCHEDULER = $(JSRUN_COMMAND)
+
+CUDA_MODULE ?= 
+#---------------------------------------------------------------------------
+# C compilers
+#---------------------------------------------------------------------------
+CCOMPILERS="gcc, cc"
+
+# GCC compiler
+ifeq ($(CC), gcc)
+  C_COMPILER_MODULE = cuda/10.1.243 gcc/8.1.1-openacc-gcc-8-branch-20190215
+  C_VERSION = gcc -dumpversion
+endif
+
+# CRAY compiler
+ifeq ($(CC), cc)
+  C_COMPILER_MODULE = PrgEnv-cray; module switch cce cce/10.0.0.374-classic; module load craype-x86-naples; module load craype-accel-amd-gfx906
+  C_VERSION = cc --version 2>&1 | grep -oh 'clang version [0-9.]*'| grep -oh 'version .*' | sed "s/version/cray/g"
+endif
+
+#---------------------------------------------------------------------------
+# C++ compilers
+#---------------------------------------------------------------------------
+CXXCOMPILERS="g++, c++"
+
+# GCC compiler
+ifeq ($(CXX), g++)
+  CXX_COMPILER_MODULE = cuda/10.1.243 gcc/8.1.1-openacc-gcc-8-branch-20190215
+  CXX_VERSION = g++ -dumpversion
+endif
+
+
+# CRAY compiler
+ifeq ($(CXX), c++)
+  CXX_COMPILER_MODULE = cdt/19.11 PrgEnv-cray; module switch cce cce/9.1.0;module load craype-x86-skylake; module unload cray-libsci; module load cudatoolkit craype-accel-nvidia70
+  CXX_VERSION = CC --version 2>&1 | grep -oh 'clang version [0-9.]*'| grep -oh 'version .*' | sed "s/version/cray/g"
+endif
+
+#---------------------------------------------------------------------------
+# FORTRAN Compilers
+#---------------------------------------------------------------------------
+FCOMPILERS="gfortran, ftn"
+
+# GCC compiler
+ifeq ($(FC), gfortran)
+  F_COMPILER_MODULE = cuda/10.1.243 gcc/8.1.1-openacc-gcc-8-branch-20190215
+  F_VERSION = gfortran -dumpversion
+endif
+
+# CRAY compiler
+ifeq ($(CXX), ftn)
+  F_COMPILER_MODULE = cdt/19.11 PrgEnv-cray; module switch cce cce/9.1.0;module load craype-x86-skylake; module unload cray-libsci; module load cudatoolkit craype-accel-nvidia70
+  F_VERSION = ftn --version 2>&1 | grep -oh 'clang version [0-9.]*'| grep -oh 'version .*' | sed "s/version/cray/g"
+endif

--- a/sys/systems/tulip.def
+++ b/sys/systems/tulip.def
@@ -38,9 +38,9 @@ ifeq ($(CXX), g++)
 endif
 
 
-# CRAY compiler
+# CRAY compiler (AMD)
 ifeq ($(CXX), c++)
-  CXX_COMPILER_MODULE = cdt/19.11 PrgEnv-cray; module switch cce cce/9.1.0;module load craype-x86-skylake; module unload cray-libsci; module load cudatoolkit craype-accel-nvidia70
+  CXX_COMPILER_MODULE = PrgEnv-cray; module load cce; module load craype-x86-naples; module load craype-accel-amd-gfx906; module load rocm/3.1.0
   CXX_VERSION = CC --version 2>&1 | grep -oh 'clang version [0-9.]*'| grep -oh 'version .*' | sed "s/version/cray/g"
 endif
 
@@ -57,6 +57,6 @@ endif
 
 # CRAY compiler
 ifeq ($(CXX), ftn)
-  F_COMPILER_MODULE = cdt/19.11 PrgEnv-cray; module switch cce cce/9.1.0;module load craype-x86-skylake; module unload cray-libsci; module load cudatoolkit craype-accel-nvidia70
+  F_COMPILER_MODULE = PrgEnv-cray; module load cce; module load craype-x86-naples; module load craype-accel-amd-gfx906; module load rocm/3.1.0
   F_VERSION = ftn --version 2>&1 | grep -oh 'clang version [0-9.]*'| grep -oh 'version .*' | sed "s/version/cray/g"
 endif

--- a/sys/systems/tulip.def
+++ b/sys/systems/tulip.def
@@ -20,9 +20,9 @@ ifeq ($(CC), gcc)
   C_VERSION = gcc -dumpversion
 endif
 
-# CRAY compiler
+# CRAY compiler (AMD)
 ifeq ($(CC), cc)
-  C_COMPILER_MODULE = PrgEnv-cray; module switch cce cce/10.0.0.374-classic; module load craype-x86-naples; module load craype-accel-amd-gfx906
+  C_COMPILER_MODULE = PrgEnv-cray; module load cce; module load craype-x86-naples; module load craype-accel-amd-gfx906; module load rocm/3.1.0
   C_VERSION = cc --version 2>&1 | grep -oh 'clang version [0-9.]*'| grep -oh 'version .*' | sed "s/version/cray/g"
 endif
 

--- a/sys/systems/tulip.def
+++ b/sys/systems/tulip.def
@@ -22,7 +22,7 @@ endif
 
 # CRAY compiler (AMD)
 ifeq ($(CC), cc)
-  C_COMPILER_MODULE = PrgEnv-cray; module load cce; module load craype-x86-naples; module load craype-accel-amd-gfx906; module load rocm/3.1.0
+  C_COMPILER_MODULE = craype-x86-naples; module load PrgEnv-cray; module load cce; module load craype-accel-amd-gfx906; module load rocm/3.3.0
   C_VERSION = cc --version 2>&1 | grep -oh 'clang version [0-9.]*'| grep -oh 'version .*' | sed "s/version/cray/g"
 endif
 
@@ -39,8 +39,8 @@ endif
 
 
 # CRAY compiler (AMD)
-ifeq ($(CXX), c++)
-  CXX_COMPILER_MODULE = PrgEnv-cray; module load cce; module load craype-x86-naples; module load craype-accel-amd-gfx906; module load rocm/3.1.0
+ifeq ($(CXX), CC)
+  CXX_COMPILER_MODULE = PrgEnv-cray; module load cce; module load craype-x86-naples; module load craype-accel-amd-gfx906; module load rocm/3.3.0
   CXX_VERSION = CC --version 2>&1 | grep -oh 'clang version [0-9.]*'| grep -oh 'version .*' | sed "s/version/cray/g"
 endif
 
@@ -56,7 +56,7 @@ ifeq ($(FC), gfortran)
 endif
 
 # CRAY compiler
-ifeq ($(CXX), ftn)
-  F_COMPILER_MODULE = PrgEnv-cray; module load cce; module load craype-x86-naples; module load craype-accel-amd-gfx906; module load rocm/3.1.0
+ifeq ($(FC), ftn)
+  F_COMPILER_MODULE = PrgEnv-cray; module load cce; module load craype-x86-naples; module load craype-accel-amd-gfx906; module load rocm/3.3.0
   F_VERSION = ftn --version 2>&1 | grep -oh 'clang version [0-9.]*'| grep -oh 'version .*' | sed "s/version/cray/g"
 endif


### PR DESCRIPTION
In this PR:

1. Add `tulip.def` so the infrastructure will automatically load the needed modules to compile on Tulip when `SYSTEM=tulip MODULE_LOAD=1` is provided.

2. Modify `make.def` to add Cray compiler flags for AMD devices, and an option called `DEVICE_TYPE` which changes the flags appropriately for Nvidia and AMD targets. I have not yet configured these flags for the Cray Fortran compiler, `ftn`.

3. Modify `Makefile` to document the new `DEVICE_TYPE` flag.