### PR TITLE
Add fixed version of default_firstprivate test

### DIFF
--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_default_firstprivate.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_default_firstprivate.F90
@@ -100,7 +100,7 @@ CONTAINS
 
     !$omp target data map(from: d(1:N), num_teams(1:N)) &
     !$omp& map(to: a(1:N), b(1:N), c(1:N))
-    !$omp target teams distribute default(firstprivate) &
+    !$omp target teams distribute default(firstprivate) shared(d) &
     !$omp& map(alloc: a(1:N), b(1:N), c(1:N), d(1:N)) num_teams(OMPVV_NUM_TEAMS_DEVICE)
     DO x = 1, N
        num_teams(x) = omp_get_num_teams()

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_default_firstprivate.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_default_firstprivate.F90
@@ -46,9 +46,10 @@ CONTAINS
        privatized_array(x) = 0
     END DO
 
-    !$omp target data map(from: d(1:N)) map(to: a(1:N), b(1:N), c(1:N))
+    !$omp target data map(from: d(1:N), num_teams(1:N)) &
+    !$omp& map(to: a(1:N), b(1:N), c(1:N))
     !$omp target teams distribute default(firstprivate) &
-    !$omp& map(alloc: a(1:N), b(1:N), c(1:N), d(1:N)) num_teams(10)
+    !$omp& shared(a, b, c, d, num_teams) num_teams(OMPVV_NUM_TEAMS_DEVICE)
     DO x = 1, N
        num_teams(x) = omp_get_num_teams()
        DO y = 1, a(x) + b(x)
@@ -97,9 +98,10 @@ CONTAINS
        privatized_array(x) = x
     END DO
 
-    !$omp target data map(from: d(1:N)) map(to: a(1:N), b(1:N), c(1:N))
+    !$omp target data map(from: d(1:N), num_teams(1:N)) &
+    !$omp& map(to: a(1:N), b(1:N), c(1:N))
     !$omp target teams distribute default(firstprivate) &
-    !$omp& map(alloc: a(1:N), b(1:N), c(1:N), d(1:N)) num_teams(10)
+    !$omp& map(alloc: a(1:N), b(1:N), c(1:N), d(1:N)) num_teams(OMPVV_NUM_TEAMS_DEVICE)
     DO x = 1, N
        num_teams(x) = omp_get_num_teams()
        d(x) = a(x) + b(x) + c(x) + privatized_array(MOD(x, 10) + 1) + privatized


### PR DESCRIPTION
Addressing issue #129. My proposed fix is to add data sharing attributes for the arrays that have been improperly made firstprivate. However, the "first" part of the test is still failing on gfortran, but I am hesitant to file a bug report until we are sure because they have already ruled a bug report from me as invalid for this test (due to the issue this PR is fixing). See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94290.