### PR TITLE
Fix issue #128, uninit arrays in reduction_bitand.F90 and bitor

### DIFF
--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_bitand.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_bitand.F90
@@ -29,7 +29,7 @@ CONTAINS
   INTEGER FUNCTION test_bitand()
     INTEGER,DIMENSION(N):: a
     REAL(8),DIMENSION(N, 32):: randoms
-    INTEGER:: result, host_result, x, y, z, errors, itr_count
+    INTEGER:: result, host_result, x, y, errors, itr_count
     LOGICAL:: tested_true, tested_false
     REAL(8):: false_margin
     result = 0
@@ -46,9 +46,9 @@ CONTAINS
        CALL RANDOM_NUMBER(randoms)
        DO x = 1, N
           a(x) = 0
-          DO z = 1, 32
+          DO y = 1, 32
              IF (randoms(x, y) .lt. false_margin) THEN
-                a(x) = a(x) + (2**z)
+                a(x) = a(x) + (2**y)
                 tested_true = .TRUE.
              ELSE
                 tested_false = .TRUE.
@@ -58,9 +58,9 @@ CONTAINS
 
        result = 0
        host_result = 0
-       DO z = 1, 32
-          result = result + (2**z)
-          host_result = host_result + (2**z)
+       DO y = 1, 32
+          result = result + (2**y)
+          host_result = host_result + (2**y)
        END DO
 
        DO x = 1, N

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_bitor.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_bitor.F90
@@ -29,7 +29,7 @@ CONTAINS
   INTEGER FUNCTION test_bitor()
     INTEGER,DIMENSION(N) :: a
     REAL(8),DIMENSION(N, 32):: randoms
-    INTEGER:: result, host_result, x, y, z, errors, itr_count
+    INTEGER:: result, host_result, x, y, errors, itr_count
     LOGICAL:: tested_true, tested_false
     REAL(8):: true_margin
     errors = 0
@@ -48,9 +48,9 @@ CONTAINS
        result = 0
        DO x = 1, N
           a(x) = 0
-          DO z = 1, 32
+          DO y = 1, 32
              IF (randoms(x, y) .gt. true_margin) THEN
-                a(x) = a(x) + (2**z)
+                a(x) = a(x) + (2**y)
                 tested_true = .TRUE.
              ELSE
                 tested_false = .TRUE.

--- a/tests/5.0/target_teams_distribute/test_target_teams_distribute_reduction_bitand.F90
+++ b/tests/5.0/target_teams_distribute/test_target_teams_distribute_reduction_bitand.F90
@@ -29,7 +29,7 @@ CONTAINS
   INTEGER FUNCTION test_bitand()
     INTEGER,DIMENSION(N):: a
     REAL(8),DIMENSION(N, 32):: randoms
-    INTEGER:: result, host_result, x, y, z, errors, itr_count
+    INTEGER:: result, host_result, x, y, errors, itr_count
     LOGICAL:: tested_true, tested_false
     REAL(8):: false_margin
     result = 0
@@ -46,9 +46,9 @@ CONTAINS
        CALL RANDOM_NUMBER(randoms)
        DO x = 1, N
           a(x) = 0
-          DO z = 1, 32
+          DO y = 1, 32
              IF (randoms(x, y) .lt. false_margin) THEN
-                a(x) = a(x) + (2**z)
+                a(x) = a(x) + (2**y)
                 tested_true = .TRUE.
              ELSE
                 tested_false = .TRUE.
@@ -58,9 +58,9 @@ CONTAINS
 
        result = 0
        host_result = 0
-       DO z = 1, 32
-          result = result + (2**z)
-          host_result = host_result + (2**z)
+       DO y = 1, 32
+          result = result + (2**y)
+          host_result = host_result + (2**y)
        END DO
 
        DO x = 1, N

--- a/tests/5.0/target_teams_distribute/test_target_teams_distribute_reduction_bitor.F90
+++ b/tests/5.0/target_teams_distribute/test_target_teams_distribute_reduction_bitor.F90
@@ -29,7 +29,7 @@ CONTAINS
   INTEGER FUNCTION test_bitor()
     INTEGER,DIMENSION(N) :: a
     REAL(8),DIMENSION(N, 32):: randoms
-    INTEGER:: result, host_result, x, y, z, errors, itr_count
+    INTEGER:: result, host_result, x, y, errors, itr_count
     LOGICAL:: tested_true, tested_false
     REAL(8):: true_margin
     errors = 0
@@ -48,9 +48,9 @@ CONTAINS
        result = 0
        DO x = 1, N
           a(x) = 0
-          DO z = 1, 32
+          DO y = 1, 32
              IF (randoms(x, y) .gt. true_margin) THEN
-                a(x) = a(x) + (2**z)
+                a(x) = a(x) + (2**y)
                 tested_true = .TRUE.
              ELSE
                 tested_false = .TRUE.


### PR DESCRIPTION
For issue #128. Just some small changes. I mixed up two array names, so I removed the unneeded one. Changes are tested and passing on Summit gfortran and xlf.