### PR TITLE
Fixing race in writing compute_array. Issue 31.

### DIFF
--- a/tests/4.5/target/test_target_private.c
+++ b/tests/4.5/target/test_target_private.c
@@ -33,15 +33,14 @@ int main() {
       compute_array[i][j] = 0;
 
 
-  omp_set_num_threads(4);
-  real_num_threads = omp_get_num_threads();  
+    
 
-#pragma omp target map(tofrom:compute_array) private(p_val)
+#pragma omp target map(tofrom:compute_array, real_num_threads) private(p_val)
 {
-#pragma omp parallel
+#pragma omp parallel private(p_val,i) num_threads(4)
   {
     p_val = omp_get_thread_num();
-#pragma omp for
+    real_num_threads = omp_get_num_threads();
     for (i = 0; i < N; i++)
       compute_array[p_val][i] += p_val;
   } // end parallel

--- a/tests/4.5/target/test_target_private.c
+++ b/tests/4.5/target/test_target_private.c
@@ -4,12 +4,9 @@
 //
 // Testing private clause with target directive. The test begins by initializing
 // and filling a 2-D array with all zeros and generating four threads. In a parallel
-// region, each thread is assigned a thread number and an integer. At the beginning 
-// of the parallel region, the 2-D array is mapped to device alongside the private 
-// integer value and firstprivate unqiue thread number. The integer value is set 
-// equal to the thread number inside of the target region and each column of the
-// array is filled based on which thread is currently operating. Finally, back on the
-// host, we check that array is properly filled.
+// region inside the target region, the mapped 2-D array is assigned the integer 
+// value equal to the thread number  assigned to the private variable.
+// Finally, back on the host, we check that array is properly filled.
 //
 ////===--------------------------------------------------------------------------===//
 
@@ -25,6 +22,7 @@ int main() {
   int errors = 0;
   int i, j;
   int real_num_threads;
+  int p_val= -1;
 
   //Check for offloading
   int is_offloading;
@@ -36,25 +34,22 @@ int main() {
 
 
   omp_set_num_threads(4);
-#pragma omp parallel
-{
-  int fp_val = omp_get_thread_num();
-  int p_val=0;
-
   real_num_threads = omp_get_num_threads();  
 
-#pragma omp target map(tofrom:compute_array) firstprivate(fp_val) private(p_val)
+#pragma omp target map(tofrom:compute_array) private(p_val)
+{
+#pragma omp parallel
   {
-    p_val = fp_val;
-
+    p_val = omp_get_thread_num();
+#pragma omp for
     for (i = 0; i < N; i++)
-      compute_array[p_val][i] = 100;
-  } // end target
-}//end parallel
+      compute_array[p_val][i] += p_val;
+  } // end parallel
+}//end target
 
   for (i = 0; i < real_num_threads; i++){ 
     for (j = 0; j < N; j++){
-      OMPVV_TEST_AND_SET_VERBOSE(errors, (compute_array[i][j] != 100));
+      OMPVV_TEST_AND_SET_VERBOSE(errors, (compute_array[i][j] != i));
       OMPVV_ERROR_IF(compute_array[i][j] != 100, "compute_array[%d][%d] = %d\n",i,j,compute_array[i][j]);
     }
   }//end for

--- a/tests/4.5/target/test_target_private.c
+++ b/tests/4.5/target/test_target_private.c
@@ -5,7 +5,7 @@
 // Testing private clause with target directive. The test begins by initializing
 // and filling a 2-D array with all zeros and generating four threads. In a parallel
 // region inside the target region, the mapped 2-D array is assigned the integer 
-// value equal to the thread number  assigned to the private variable.
+// value equal to the thread number assigned to the private variable.
 // Finally, back on the host, we check that array is properly filled.
 //
 ////===--------------------------------------------------------------------------===//
@@ -33,14 +33,13 @@ int main() {
       compute_array[i][j] = 0;
 
 
-    
-
-#pragma omp target map(tofrom:compute_array, real_num_threads) private(p_val)
+#pragma omp target map(tofrom: compute_array) (from: real_num_threads) private(p_val)
 {
 #pragma omp parallel private(p_val,i) num_threads(4)
   {
     p_val = omp_get_thread_num();
     real_num_threads = omp_get_num_threads();
+    OMPVV_WARNING_IF(real_num_threads == 1, "The number of threads creatable was 1. This is not a specifications error but we could not confirm privatization.");
     for (i = 0; i < N; i++)
       compute_array[p_val][i] += p_val;
   } // end parallel
@@ -49,7 +48,6 @@ int main() {
   for (i = 0; i < real_num_threads; i++){ 
     for (j = 0; j < N; j++){
       OMPVV_TEST_AND_SET_VERBOSE(errors, (compute_array[i][j] != i));
-      OMPVV_ERROR_IF(compute_array[i][j] != 100, "compute_array[%d][%d] = %d\n",i,j,compute_array[i][j]);
     }
   }//end for
   


### PR DESCRIPTION
Fixed C test by moving parallel inside target and removing dependence on firstprivate to test for private clause on target.