### PR TITLE
test_target_teams_distribute_collapse.F90 – wrong map flag #138

### DIFF
--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_collapse.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_collapse.F90
@@ -91,7 +91,7 @@
             END DO
 
             !$omp target teams distribute map(to: a(1:N, 1:N, 1:N)) &
-            !$omp& map(from: b(1:N, 1:N, 1:N+1)) collapse(2)
+            !$omp& map(tofrom: b(1:N, 1:N, 1:N+1)) collapse(2)
             DO x = 1, N
               DO y = 1, N
                 DO z = 1, N


### PR DESCRIPTION
The variable 'b' is initialized on the host as b(:, :, 1) = 0
and used as 'b(x, y, z+1) = b(x, y, z) ...' on the device.
To avoid uninitialized use, 'b' needs to be mapped 'to' the
device, i.e. map(tofrom:b) instead of just map(from:b).

* tests/4.5/target_teams_distribute/test_target_teams_distribute_collapse.F90
  (test_collapse2): Use 'tofrom' for 'b'.