### PR TITLE
test_target_teams_distribute_parallel_for_devices.c: wrong check, mul…

### DIFF
--- a/tests/4.5/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_devices.c
+++ b/tests/4.5/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_devices.c
@@ -38,7 +38,7 @@ int test_target_teams_distribute_parallel_for_devices() {
 
   for (dev = 0; dev < num_dev; ++dev) {
     // check multiple devices 
-#pragma omp target teams distribute parallel for device(dev) map(from: isHost)
+#pragma omp target teams distribute parallel for device(dev) map(tofrom: isHost)
     for (i = 0; i < SIZE_N; i++) {
       isHost[dev] = omp_is_initial_device();// Checking if running on a device
       a[i] += dev;
@@ -48,7 +48,7 @@ int test_target_teams_distribute_parallel_for_devices() {
   for (dev = 0; dev < num_dev; ++dev) {
 #pragma omp target exit data map(from: a[0:SIZE_N]) device(dev)
     OMPVV_INFOMSG("Device %d ran on the %s", dev, isHost[dev] ? "host" : "device");
-    OMPVV_TEST_AND_SET(errors, isHost[dev]);
+    OMPVV_TEST_AND_SET(errors, isHost[dev] && dev != omp_get_initial_device());
     for (i = 0; i < SIZE_N; i++) {
       OMPVV_TEST_AND_SET(errors, a[i] != 1 + dev);
     }


### PR DESCRIPTION
…t-dev handling #140

Issue #140

* tests/4.5/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_devices.c
  (test_target_teams_distribute_parallel_for_devices): Use 'tofrom'
  for isHost array. Permit isHost[i] == true for
  i = omp_get_initial_device().