### PR TITLE
Remove shared env macro from target and target data tests

### DIFF
--- a/template/ompvv_template.F90
+++ b/template/ompvv_template.F90
@@ -1,4 +1,4 @@
-!===------FILE_NAME.F90 ------------------ Test title ---------------------===//
+!===------FILE_NAME.F90 ---------------------------------------------------===//
 ! 
 ! OpenMP API Version 4.5 Nov 2015
 ! 
@@ -15,7 +15,6 @@
         CHARACTER(len=500):: myTmpChar
         INTEGER:: errors
 
-        OMPVV_TEST_OFFLOADING
         OMPVV_TEST_OFFLOADING
 
         OMPVV_INFOMSG("This is an OMPVV_INFOMSG")
@@ -36,8 +35,6 @@
         OMPVV_ERROR_IF(myTrueVar,"This is an OMPVV_ERROR_IF(.true.)")
         OMPVV_ERROR_IF(myFalseVar,"This should not show up")
         OMPVV_ERROR_IF(1==1,"This is an OMPVV_ERROR_IF 1==1")
-
-        OMPVV_TEST_SHARED_ENVIRONMENT
 
         WRITE(myTmpChar,*) "errors is internally handle, but you can &
         & obtain and set  the value with these functions"

--- a/template/ompvv_template.c
+++ b/template/ompvv_template.c
@@ -1,4 +1,4 @@
-//===------ FILE_NAME.c ------------------ Test title ---------------------===//
+//===------ FILE_NAME.c ---------------------------------------------------===//
 // 
 // OpenMP API Version 4.5 Nov 2015
 // 
@@ -37,8 +37,6 @@ int main() {
   OMPVV_ERROR("THIS IS IS AN EXAMPLE OF AN ERROR WITH PARAMETERS (%d, %s, %f)", 3, "ompvv", 3.3);
   OMPVV_ERROR_IF(1==1, "THIS IS IS AN EXAMPLE OF AN ERROR_IF 1==1");
   OMPVV_ERROR_IF(1==0, "THIS IS IS AN EXAMPLE OF AN ERROR_IF 1==0 (THIS SHOULD NOT BE DISPLAYED)");
-
-  OMPVV_TEST_SHARED_ENVIRONMENT;
 
   int errors = 0;
   OMPVV_TEST_AND_SET(errors, 1!=0); // Condition to generate an error

--- a/tests/4.5/target/test_target_map_module_array.F90
+++ b/tests/4.5/target/test_target_map_module_array.F90
@@ -1,5 +1,5 @@
 !===--test_target_map_module_array.F90 -------mapping of arrays inmodules--===!
-! 
+!
 ! OpenMP API Version 4.5 Nov 2015
 !
 ! Testing the mapping of arrays that are created inside module
@@ -9,24 +9,22 @@
 #include "ompvv.F90"
 
 #define N 100
-      
+
       MODULE testing_module
         INTEGER :: array_1d(N)
         INTEGER :: array_2d(N,N)
         INTEGER :: array_3d(N,N,N)
 
       END MODULE testing_module
-      
+
       PROGRAM test_target_map_module_array
         USE iso_fortran_env
         USE ompvv_lib
         USE omp_lib
         USE testing_module
         implicit none
-        LOGICAL :: isSharedEnv
-        
+
         OMPVV_TEST_OFFLOADING
-        OMPVV_TEST_AND_SET_SHARED_ENVIRONMENT(isSharedEnv)
 
         OMPVV_TEST_VERBOSE(test_module_map_to_array() .ne. 0)
         OMPVV_TEST_VERBOSE(test_module_map_from_array() .ne. 0)
@@ -35,7 +33,7 @@
         OMPVV_REPORT_AND_RETURN()
 
 
-        CONTAINS 
+        CONTAINS
           ! Function to tests the map (to:...)
           INTEGER FUNCTION  test_module_map_to_array()
             INTEGER :: helper_array_1d(N)
@@ -44,7 +42,7 @@
             INTEGER :: err_before, err_after
 
             OMPVV_GET_ERRORS(err_before)
-            
+
             OMPVV_INFOMSG("testing map(to...) of array in module")
 
             array_1d(:) = 10
@@ -69,13 +67,9 @@
             OMPVV_TEST_VERBOSE(ANY(helper_array_3d /= 10))
 
             ! check that it did not copy back
-            IF (.not. isSharedEnv) THEN
-              OMPVV_TEST_VERBOSE(ANY(array_1d /= 10))
-              OMPVV_TEST_VERBOSE(ANY(array_2d /= 10))
-              OMPVV_TEST_VERBOSE(ANY(array_3d /= 10))
-            ELSE
-              OMPVV_WARNING("Part of test ommited: shared data env")
-            END IF
+            OMPVV_TEST_VERBOSE(ANY(array_1d /= 10))
+            OMPVV_TEST_VERBOSE(ANY(array_2d /= 10))
+            OMPVV_TEST_VERBOSE(ANY(array_3d /= 10))
 
             OMPVV_GET_ERRORS(err_after)
 
@@ -91,7 +85,7 @@
             CHARACTER(len=400) :: msgHelper
 
             OMPVV_GET_ERRORS(err_before)
-            
+
             OMPVV_INFOMSG("testing map(from...) of array in module")
 
             array_1d(:) = 999
@@ -113,13 +107,11 @@
             !$omp end target
 
             ! Checking that data is not copied to the device
-            IF (.not. isSharedEnv) THEN
-              WRITE(msgHelper, *) "Array seemed to have been copied to &
-                & the device when using the from modifier."
-              OMPVV_WARNING_IF(ALL(helper_array_1d == 999), msgHelper)
-              OMPVV_WARNING_IF(ALL(helper_array_2d == 999), msgHelper)
-              OMPVV_WARNING_IF(ALL(helper_array_3d == 999), msgHelper)
-            END IF
+            WRITE(msgHelper, *) "Array seemed to have been copied to &
+              & the device when using the from modifier."
+            OMPVV_WARNING_IF(ALL(helper_array_1d == 999), msgHelper)
+            OMPVV_WARNING_IF(ALL(helper_array_2d == 999), msgHelper)
+            OMPVV_WARNING_IF(ALL(helper_array_3d == 999), msgHelper)
 
             OMPVV_TEST_VERBOSE(ANY(array_1d /= 20))
             OMPVV_TEST_VERBOSE(ANY(array_2d /= 20))
@@ -138,7 +130,7 @@
             INTEGER :: err_before, err_after
 
             OMPVV_GET_ERRORS(err_before)
-            
+
             OMPVV_INFOMSG("testing map(tofrom...) of array in module")
 
             array_1d(:) = 10
@@ -163,7 +155,7 @@
             OMPVV_TEST_VERBOSE(ANY(helper_array_2d /= 10))
             OMPVV_TEST_VERBOSE(ANY(helper_array_3d /= 10))
 
-            ! Testing the from functionality 
+            ! Testing the from functionality
             OMPVV_TEST_VERBOSE(ANY(array_1d /= 20))
             OMPVV_TEST_VERBOSE(ANY(array_2d /= 20))
             OMPVV_TEST_VERBOSE(ANY(array_3d /= 20))
@@ -174,4 +166,3 @@
 
           END FUNCTION test_module_map_tofrom_array
       END PROGRAM test_target_map_module_array
-

--- a/tests/4.5/target/test_target_map_program_arrays.F90
+++ b/tests/4.5/target/test_target_map_program_arrays.F90
@@ -1,5 +1,5 @@
 !===--test_target_map_program_array.F90 ----mapping of arrays in programs--===!
-! 
+!
 ! OpenMP API Version 4.5 Nov 2015
 !
 ! Testing the mapping of arrays that are created inside program
@@ -9,19 +9,17 @@
 #include "ompvv.F90"
 
 #define N 100
-      
+
       PROGRAM test_target_map_program_array
         USE iso_fortran_env
         USE ompvv_lib
         USE omp_lib
         implicit none
-        LOGICAL :: isSharedEnv
         INTEGER :: array_1d(N)
         INTEGER :: array_2d(N,N)
         INTEGER :: array_3d(N,N,N)
-        
+
         OMPVV_TEST_OFFLOADING
-        OMPVV_TEST_AND_SET_SHARED_ENVIRONMENT(isSharedEnv)
         OMPVV_TEST_VERBOSE(test_program_map_to_array() .ne. 0)
         OMPVV_TEST_VERBOSE(test_program_map_from_array() .ne. 0)
         OMPVV_TEST_VERBOSE(test_program_map_tofrom_array() .ne. 0)
@@ -29,7 +27,7 @@
         OMPVV_REPORT_AND_RETURN()
 
 
-        CONTAINS 
+        CONTAINS
           ! Function to tests the map (to:...)
           INTEGER FUNCTION  test_program_map_to_array()
             INTEGER :: helper_array_1d(N)
@@ -38,7 +36,7 @@
             INTEGER :: err_before, err_after
 
             OMPVV_GET_ERRORS(err_before)
-            
+
             OMPVV_INFOMSG("testing map(to...) of array in program")
 
             array_1d(:) = 10
@@ -63,13 +61,9 @@
             OMPVV_TEST_VERBOSE(ANY(helper_array_3d /= 10))
 
             ! check that it did not copy back
-            IF (.not. isSharedEnv) THEN
-              OMPVV_TEST_VERBOSE(ANY(array_1d /= 10))
-              OMPVV_TEST_VERBOSE(ANY(array_2d /= 10))
-              OMPVV_TEST_VERBOSE(ANY(array_3d /= 10))
-            ELSE
-              OMPVV_WARNING("Part of test ommited: shared data env")
-            END IF
+            OMPVV_TEST_VERBOSE(ANY(array_1d /= 10))
+            OMPVV_TEST_VERBOSE(ANY(array_2d /= 10))
+            OMPVV_TEST_VERBOSE(ANY(array_3d /= 10))
 
             OMPVV_GET_ERRORS(err_after)
 
@@ -85,7 +79,7 @@
             CHARACTER(len=400) :: msgHelper
 
             OMPVV_GET_ERRORS(err_before)
-            
+
             OMPVV_INFOMSG("testing map(from...) of array in program")
 
             array_1d(:) = 999
@@ -106,13 +100,11 @@
             !$omp end target
 
             ! Checking that data is not copied to the device
-            IF (.not. isSharedEnv) THEN
-              WRITE(msgHelper, *) "Array seemed to have been copied to &
-                & the device when using the from modifier."
-              OMPVV_WARNING_IF(ALL(helper_array_1d == 999), msgHelper)
-              OMPVV_WARNING_IF(ALL(helper_array_2d == 999), msgHelper)
-              OMPVV_WARNING_IF(ALL(helper_array_3d == 999), msgHelper)
-            END IF
+            WRITE(msgHelper, *) "Array seemed to have been copied to &
+              & the device when using the from modifier."
+            OMPVV_WARNING_IF(ALL(helper_array_1d == 999), msgHelper)
+            OMPVV_WARNING_IF(ALL(helper_array_2d == 999), msgHelper)
+            OMPVV_WARNING_IF(ALL(helper_array_3d == 999), msgHelper)
 
             OMPVV_TEST_VERBOSE(ANY(array_1d /= 20))
             OMPVV_TEST_VERBOSE(ANY(array_2d /= 20))
@@ -131,7 +123,7 @@
             INTEGER :: err_before, err_after
 
             OMPVV_GET_ERRORS(err_before)
-            
+
             OMPVV_INFOMSG("testing map(tofrom...) of array in program")
 
             array_1d(:) = 10
@@ -156,7 +148,7 @@
             OMPVV_TEST_VERBOSE(ANY(helper_array_2d /= 10))
             OMPVV_TEST_VERBOSE(ANY(helper_array_3d /= 10))
 
-            ! Testing the from functionality 
+            ! Testing the from functionality
             OMPVV_TEST_VERBOSE(ANY(array_1d /= 20))
             OMPVV_TEST_VERBOSE(ANY(array_2d /= 20))
             OMPVV_TEST_VERBOSE(ANY(array_3d /= 20))
@@ -167,4 +159,3 @@
 
           END FUNCTION test_program_map_tofrom_array
       END PROGRAM test_target_map_program_array
-

--- a/tests/4.5/target/test_target_map_subroutines_arrays.F90
+++ b/tests/4.5/target/test_target_map_subroutines_arrays.F90
@@ -1,5 +1,5 @@
 !===--test_target_map_subroutine_array.F90 -------mapping of arrays insubroutines--===!
-! 
+!
 ! OpenMP API Version 4.5 Nov 2015
 !
 ! Testing the mapping of arrays that are created inside subroutine
@@ -9,13 +9,12 @@
 #include "ompvv.F90"
 
 #define N 100
-      
+
       PROGRAM test_target_map_subroutine_array
         USE iso_fortran_env
         USE ompvv_lib
         USE omp_lib
         implicit none
-        LOGICAL :: isSharedEnv
         INTEGER :: array_1d(N)
         INTEGER :: array_2d(N,N)
         INTEGER :: array_3d(N,N,N)
@@ -24,9 +23,8 @@
         INTEGER :: helper_array_3d(N,N,N)
         INTEGER :: err_before, err_after
         CHARACTER(len=400) :: msgHelper
-        
+
         OMPVV_TEST_OFFLOADING
-        OMPVV_TEST_AND_SET_SHARED_ENVIRONMENT(isSharedEnv)
 
         OMPVV_TEST_VERBOSE(test_subroutine_map_to_array() .ne. 0)
         OMPVV_TEST_VERBOSE(test_subroutine_map_from_array() .ne. 0)
@@ -34,11 +32,11 @@
 
         OMPVV_REPORT_AND_RETURN()
 
-        CONTAINS 
+        CONTAINS
           ! Function to tests the map (to:...)
           INTEGER FUNCTION  test_subroutine_map_to_array()
             OMPVV_GET_ERRORS(err_before)
-            
+
             OMPVV_INFOMSG("testing map(to...) array in subroutine")
 
             array_1d(:) = 10
@@ -52,13 +50,9 @@
             OMPVV_TEST_VERBOSE(ANY(helper_array_3d /= 10))
 
             ! check that it did not copy back
-            IF (.not. isSharedEnv) THEN
-              OMPVV_TEST_VERBOSE(ANY(array_1d /= 10))
-              OMPVV_TEST_VERBOSE(ANY(array_2d /= 10))
-              OMPVV_TEST_VERBOSE(ANY(array_3d /= 10))
-            ELSE
-              OMPVV_WARNING("Part of test ommited: shared data env")
-            END IF
+            OMPVV_TEST_VERBOSE(ANY(array_1d /= 10))
+            OMPVV_TEST_VERBOSE(ANY(array_2d /= 10))
+            OMPVV_TEST_VERBOSE(ANY(array_3d /= 10))
 
             OMPVV_GET_ERRORS(err_after)
 
@@ -69,7 +63,7 @@
           INTEGER FUNCTION  test_subroutine_map_from_array()
 
             OMPVV_GET_ERRORS(err_before)
-            
+
             OMPVV_INFOMSG("testing map(from...) array in subroutine")
 
             array_1d(:) = 999
@@ -79,13 +73,11 @@
             CALL subroutine_from()
 
             ! Checking that data is not copied to the device
-            IF (.not. isSharedEnv) THEN
-              WRITE(msgHelper, *) "Array seemed to have been copied to &
-                & the device when using the from modifier."
-              OMPVV_WARNING_IF(ALL(helper_array_1d == 999), msgHelper)
-              OMPVV_WARNING_IF(ALL(helper_array_2d == 999), msgHelper)
-              OMPVV_WARNING_IF(ALL(helper_array_3d == 999), msgHelper)
-            END IF
+            WRITE(msgHelper, *) "Array seemed to have been copied to &
+              & the device when using the from modifier."
+            OMPVV_WARNING_IF(ALL(helper_array_1d == 999), msgHelper)
+            OMPVV_WARNING_IF(ALL(helper_array_2d == 999), msgHelper)
+            OMPVV_WARNING_IF(ALL(helper_array_3d == 999), msgHelper)
 
             OMPVV_TEST_VERBOSE(ANY(array_1d /= 20))
             OMPVV_TEST_VERBOSE(ANY(array_2d /= 20))
@@ -100,7 +92,7 @@
           INTEGER FUNCTION  test_subroutine_map_tofrom_array()
 
             OMPVV_GET_ERRORS(err_before)
-            
+
             OMPVV_INFOMSG("testing map(tofrom...) array in subroutine")
 
             array_1d(:) = 10
@@ -114,7 +106,7 @@
             OMPVV_TEST_VERBOSE(ANY(helper_array_2d /= 10))
             OMPVV_TEST_VERBOSE(ANY(helper_array_3d /= 10))
 
-            ! Testing the from functionality 
+            ! Testing the from functionality
             OMPVV_TEST_VERBOSE(ANY(array_1d /= 20))
             OMPVV_TEST_VERBOSE(ANY(array_2d /= 20))
             OMPVV_TEST_VERBOSE(ANY(array_3d /= 20))
@@ -169,4 +161,3 @@
             !$omp end target
           END SUBROUTINE subroutine_tofrom
       END PROGRAM test_target_map_subroutine_array
-

--- a/tests/4.5/target_data/test_target_data_if.F90
+++ b/tests/4.5/target_data/test_target_data_if.F90
@@ -1,24 +1,24 @@
 !===---- test_target_if.F90 -  ------------------------------------------===//
-! 
+!
 ! OpenMP API Version 4.5 Nov 2015
-! 
-! The if clause determines if the section should be executed in the host or 
-! the device. There are three things to test here: 
+!
+! The if clause determines if the section should be executed in the host or
+! the device. There are three things to test here:
 ! (a) with offloading when 'if' clause evaluates to true then code
-! be executed on the device 
+! be executed on the device
 ! (b) with offloading when 'if' clause evaluates to false then code should
 ! be executed on the host
 ! (c) without offloading all the code should be executed on the device
 ! The if clause is evaluated on runtime which means that variables could
-! determine this behavior. We use a SIZE_THRESHOLD variable to check if we 
-! should execute on the device or the host. Before starting the test we 
+! determine this behavior. We use a SIZE_THRESHOLD variable to check if we
+! should execute on the device or the host. Before starting the test we
 ! sample offloading to see if it was enabled or not. If the code is executed
-! in the device, the result should be c(i) = a(i) + b(i) = i + 1. 
+! in the device, the result should be c(i) = a(i) + b(i) = i + 1.
 ! If the code is executed on the host the result should be c(i) = -1
 !
 !===----------------------------------------------------------------------===//
 
-#include "ompvv.F90" 
+#include "ompvv.F90"
 
 #define SIZE_ARRAY 1024
 #define THRESHOLD 512
@@ -28,46 +28,40 @@
         USE ompvv_lib
         USE omp_lib
         implicit none
-       
-         LOGICAL :: isOffloading, isHost, isSharedEnv
+
+         LOGICAL :: isOffloading, isHost
          INTEGER :: a(1:SIZE_ARRAY)
          INTEGER :: b(1:SIZE_ARRAY)
          INTEGER :: c(1:SIZE_ARRAY)
          INTEGER :: alpha, errors(3), i, j, s
          CHARACTER(len=300) :: infoMessage
-        
+
          OMPVV_TEST_AND_SET_OFFLOADING(isOffloading)
-         OMPVV_TEST_AND_SET_SHARED_ENVIRONMENT(isSharedEnv)
-         IF (isSharedEnv) THEN 
-           WRITE(infoMessage, *) " working on a shared memory &
-           & environment. Test might be inconclusive"
-           OMPVV_WARNING(infoMessage)
-         END IF
          IF (.NOT. isOffloading) THEN 
            WRITE(infoMessage, *) "Offloading is off. Mighth not be&
            & possible to test if clause correctly "
            OMPVV_WARNING(infoMessage)
          END IF
-         OMPVV_TEST_VERBOSE(tests_target_data_if_simple() .NE. 0) 
-         OMPVV_TEST_VERBOSE(tests_target_data_if_nested() .NE. 0) 
-         
+         OMPVV_TEST_VERBOSE(tests_target_data_if_simple() .NE. 0)
+         OMPVV_TEST_VERBOSE(tests_target_data_if_nested() .NE. 0)
+
          OMPVV_REPORT_AND_RETURN()
 
-       CONTAINS 
+       CONTAINS
          INTEGER FUNCTION tests_target_data_if_simple()
            errors(:) = 0
-           ! check multiple sizes. 
+           ! check multiple sizes.
            DO s = 256, 1024, 256
              ! a, b and c arrays initialization
              a(:) = (/ (SIZE_ARRAY - i, i = 1, SIZE_ARRAY) /)
-             b(:) = (/ (i - 1, i = 1, SIZE_ARRAY) /) 
+             b(:) = (/ (i - 1, i = 1, SIZE_ARRAY) /)
              c(:) = -1
              !$omp target data if(s > THRESHOLD) &
              !$omp map(to: a(1:s), b(1:s)) &
              !$omp map(tofrom: c(1:s)) map(tofrom: isHost, s)
-                 
-               ! If the condition is false, data mapping should not 
-               ! occur. We need to avoid a tofrom default mapping on 
+
+               ! If the condition is false, data mapping should not
+               ! occur. We need to avoid a tofrom default mapping on
                ! a, b and c, we use alloc
                !$omp target map(alloc: a(1:s), b(1:s), c(1:s)) &
                !$omp map(tofrom: isHost, s)
@@ -84,35 +78,34 @@
 
                ! Should not exec in host if isOffloading is true
                IF (isOffloading) THEN
-                 OMPVV_TEST_AND_SET_VERBOSE(errors(1), isHost) 
+                 OMPVV_TEST_AND_SET_VERBOSE(errors(1), isHost)
                END IF
              !$omp end target data
-       
-             ! Checking data mapping 
-             
+
+             ! Checking data mapping
+
              DO i = 1, s
                IF (s > THRESHOLD .OR. &
-                  & isSharedEnv .OR. &
                   & .NOT. isOffloading) THEN
                  ! Should have done data maping of a, b, and c
                  OMPVV_TEST_AND_SET(errors(2), (c(i) /= SIZE_ARRAY))
                ELSE
                  ! Should have not done data mapping of a, b or c
                  OMPVV_TEST_AND_SET(errors(3), (c(i) /= -1))
-               END IF 
+               END IF
              END DO ! i
            END DO ! s
-      
+
            IF (errors(1) /= 0) THEN
              infoMessage = "Test did not offload to the device. if &
              & clause might be affecting the target offloading as well &
              & and it should not"
              OMPVV_ERROR(infoMessage)
-           END IF 
+           END IF
            infoMessage = MERGE("enabled ", "disabled", isOffloading)
            IF (errors(1) == 0 .AND. &
                & errors(2) == 0 .AND. &
-               & errors(3) == 0) THEN 
+               & errors(3) == 0) THEN
              infoMessage = "Test passed with offloading "//infoMessage
              OMPVV_INFOMSG(infoMessage)
            ELSE IF (errors(2) /= 0 .AND. errors(3) == 0) THEN
@@ -131,19 +124,19 @@
            END IF
            tests_target_data_if_simple = SUM(errors)
          END FUNCTION tests_target_data_if_simple
-           
+
          INTEGER FUNCTION tests_target_data_if_nested()
            errors(:) = 0
-           ! check multiple sizes. 
+           ! check multiple sizes.
            DO s = 256, 1024, 256
              ! a, b and c arrays initialization
              a(:) = (/ (SIZE_ARRAY - i, i = 1, SIZE_ARRAY) /)
-             b(:) = (/ (i - 1, i = 1, SIZE_ARRAY) /) 
+             b(:) = (/ (i - 1, i = 1, SIZE_ARRAY) /)
              c(:) = -10
              !$omp target data if(s > THRESHOLD) &
              !$omp map(to: a(1:s), b(1:s)) &
-             !$omp map(tofrom: c(1:s)) 
-                 
+             !$omp map(tofrom: c(1:s))
+
                !$omp target if(s > THRESHOLD) &
                !$omp map(alloc: a(1:s), b(1:s), c(1:s)) &
                !$omp map(tofrom: isHost, s)
@@ -163,34 +156,34 @@
                IF (isOffloading) THEN
                  IF (s > THRESHOLD) THEN
                    OMPVV_TEST_AND_SET_VERBOSE(errors(1), isHost )
-                 ELSE 
+                 ELSE
                    OMPVV_TEST_AND_SET_VERBOSE(errors(1), (.NOT. isHost))
                  END IF
                END IF
              !$omp end target data
-       
-             ! Checking data mapping 
-             
+
+             ! Checking data mapping
+
              DO i = 1, s
                IF (s > THRESHOLD .AND. isOffloading) THEN
                  ! Should have done data maping of a, b, and c
                  OMPVV_TEST_AND_SET(errors(2), (c(i) /= SIZE_ARRAY))
-               ELSE 
+               ELSE
                  ! Should have not done data mapping of a, b or c
                  OMPVV_TEST_AND_SET(errors(3), (c(i) /= -1))
-               END IF 
+               END IF
              END DO ! i
            END DO ! s
-      
+
            IF (errors(1) /= 0) THEN
              infoMessage = "IF statement inside of the inner target&
              & region did not handled offloading correctly"
              OMPVV_ERROR(infoMessage)
-           END IF 
+           END IF
            infoMessage = MERGE("enabled ", "disabled", isOffloading)
            IF (errors(1) == 0 .AND. &
                & errors(2) == 0 .AND. &
-               & errors(3) == 0) THEN 
+               & errors(3) == 0) THEN
              infoMessage = "Test passed with offloading "//infoMessage
              OMPVV_INFOMSG(infoMessage)
            ELSE IF (errors(2) /= 0 .AND. errors(3) == 0) THEN

--- a/tests/4.5/target_data/test_target_data_map_components_from.F90
+++ b/tests/4.5/target_data/test_target_data_map_components_from.F90
@@ -1,10 +1,10 @@
 !===--test_target_data_map_components_from.F90 - derived data type map to -===!
-! 
+!
 ! OpenMP API Version 4.5 Nov 2015
 !
 ! This test check for the to mapping of components in both regular
 ! variables and arrays
-! 
+!
 !!===----------------------------------------------------------------------===!
 #include "ompvv.F90"
 
@@ -17,10 +17,9 @@
         implicit none
         INTEGER :: err_bf, err_af, i
         INTEGER, TARGET :: justATarget
-        LOGICAL :: isSharedEnv
-        CHARACTER(len=400) :: auxMessage 
+        CHARACTER(len=400) :: auxMessage
         ! Defining a component for the test
-        TYPE :: testingType 
+        TYPE :: testingType
           INTEGER, POINTER :: myPtr
           INTEGER :: myInt
           CHARACTER(len=100) :: myStr
@@ -31,19 +30,14 @@
         TYPE(testingType) :: cpyStruct
         TYPE(testingType), dimension(10) :: myStructArr
         TYPE(testingType), dimension(10) :: cpyStructArr
-        
+
         OMPVV_TEST_OFFLOADING
-        OMPVV_TEST_AND_SET_SHARED_ENVIRONMENT(isSharedEnv)
-        WRITE(auxMessage, *) "Shared data environment will cause &
-          &this test to not check if the data is not copied to the & 
-          & using the from map modifier"
-        OMPVV_WARNING_IF(isSharedEnv, auxMessage)
-        
+
         OMPVV_TEST_VERBOSE(test_map_derived_type_from() .ne. 0)
 
         OMPVV_REPORT_AND_RETURN()
 
-        CONTAINS 
+        CONTAINS
           ! Default mapping
           INTEGER FUNCTION test_map_derived_type_from()
 
@@ -63,8 +57,8 @@
             cpyStruct%myReal = 0.0
             cpyStruct%myArr(:) = 0
             cpyStruct%myPtr => justATarget
-            
-            DO i = 1, 10 
+
+            DO i = 1, 10
               myStructArr(i)%myInt = 5
               myStructArr(i)%myStr = "there"
               myStructArr(i)%myReal = 4.4
@@ -89,21 +83,21 @@
                 cpyStruct%myReal = myStruct%myReal
                 cpyStruct%myArr(:) = myStruct%myArr(:)
 
-                DO i = 1, 10 
+                DO i = 1, 10
                   cpyStructArr(i)%myInt = myStructArr(i)%myInt
                   cpyStructArr(i)%myStr = myStructArr(i)%myStr
                   cpyStructArr(i)%myReal = myStructArr(i)%myReal
                   cpyStructArr(i)%myArr(1:N) = myStructArr(i)%myArr(1:N)
                 END DO
 
-                ! Modify myStruct and array to get the value from the 
-                ! host 
+                ! Modify myStruct and array to get the value from the
+                ! host
                 myStruct%myInt = 6
                 myStruct%myStr = "you"
                 myStruct%myReal = 6.4
                 myStruct%myArr(:) = 100
-  
-                DO i = 1, 10 
+
+                DO i = 1, 10
                   myStructArr(i)%myInt = 6
                   myStructArr(i)%myStr = "you"
                   myStructArr(i)%myReal = 6.4
@@ -114,23 +108,21 @@
 
 
             ! Checking that the data was copied to the device
-            IF (.NOT. isSharedEnv) THEN
-              WRITE(auxMessage, *) "Array seemed to have been copied to &
-                & the device when using the from modifier."
-              OMPVV_WARNING_IF(cpyStruct%myInt == 5, auxMessage)
-              OMPVV_WARNING_IF(cpyStruct%myStr .EQ. 'there', auxMessage)
-              OMPVV_WARNING_IF(ABS(cpyStruct%myReal - 4.4) .LT. 0.0001, auxMessage)
-              OMPVV_WARNING_IF(ALL(cpyStruct%myArr == 10), auxMessage)
-              OMPVV_WARNING_IF(.NOT. ASSOCIATED(cpyStruct%myPtr, justATarget), auxMessage)
+            WRITE(auxMessage, *) "Array seemed to have been copied to &
+                 & the device when using the from modifier."
+            OMPVV_WARNING_IF(cpyStruct%myInt == 5, auxMessage)
+            OMPVV_WARNING_IF(cpyStruct%myStr .EQ. 'there', auxMessage)
+            OMPVV_WARNING_IF(ABS(cpyStruct%myReal - 4.4) .LT. 0.0001, auxMessage)
+            OMPVV_WARNING_IF(ALL(cpyStruct%myArr == 10), auxMessage)
+            OMPVV_WARNING_IF(.NOT. ASSOCIATED(cpyStruct%myPtr, justATarget), auxMessage)
 
-              DO i = 1, 10 
-                OMPVV_WARNING_IF(cpyStructArr(i)%myInt == 5, auxMessage)
-                OMPVV_WARNING_IF(cpyStructArr(i)%myStr .EQ. 'there', auxMessage)
-                OMPVV_WARNING_IF(ABS(cpyStructArr(i)%myReal - 4.4) .LT. 0.0001, auxMessage)
-                OMPVV_WARNING_IF(ANY(cpyStructArr(i)%myArr == 10), auxMessage)
-                OMPVV_WARNING_IF(.NOT. ASSOCIATED(cpyStructArr(i)%myPtr, justATarget), auxMessage)
-              END DO
-            END IF
+            DO i = 1, 10
+               OMPVV_WARNING_IF(cpyStructArr(i)%myInt == 5, auxMessage)
+               OMPVV_WARNING_IF(cpyStructArr(i)%myStr .EQ. 'there', auxMessage)
+               OMPVV_WARNING_IF(ABS(cpyStructArr(i)%myReal - 4.4) .LT. 0.0001, auxMessage)
+               OMPVV_WARNING_IF(ANY(cpyStructArr(i)%myArr == 10), auxMessage)
+               OMPVV_WARNING_IF(.NOT. ASSOCIATED(cpyStructArr(i)%myPtr, justATarget), auxMessage)
+            END DO
 
             ! Checking that the data was copied from the device
             OMPVV_TEST_VERBOSE(myStruct%myInt /= 6)
@@ -139,7 +131,7 @@
             OMPVV_TEST_VERBOSE(ANY(myStruct%myArr /= 100))
             OMPVV_TEST_VERBOSE(ASSOCIATED(myStruct%myPtr, justATarget))
 
-            DO i = 1, 10 
+            DO i = 1, 10
               OMPVV_TEST_VERBOSE(myStructArr(i)%myInt /= 6)
               OMPVV_TEST_VERBOSE(myStructArr(i)%myStr .NE. 'you')
               OMPVV_TEST_VERBOSE(ABS(myStructArr(i)%myReal - 6.4) .GT. 0.0001)
@@ -152,4 +144,3 @@
 
           END FUNCTION test_map_derived_type_from
       END PROGRAM test_target_data_map_components_from
-

--- a/tests/4.5/target_data/test_target_data_map_components_to.F90
+++ b/tests/4.5/target_data/test_target_data_map_components_to.F90
@@ -1,10 +1,10 @@
 !===--test_target_data_map_components_to.F90 - derived data type map to -===!
-! 
+!
 ! OpenMP API Version 4.5 Nov 2015
 !
 ! This test check for the to mapping of components in both regular
 ! variables and arrays
-! 
+!
 !!===----------------------------------------------------------------------===!
 #include "ompvv.F90"
 
@@ -17,10 +17,9 @@
         implicit none
         INTEGER :: err_bf, err_af, i
         INTEGER, TARGET :: justATarget
-        LOGICAL :: isSharedEnv
-        CHARACTER(len=400) :: auxMessage 
+        CHARACTER(len=400) :: auxMessage
         ! Defining a component for the test
-        TYPE :: testingType 
+        TYPE :: testingType
           INTEGER, POINTER :: myPtr
           INTEGER :: myInt
           CHARACTER(len=100) :: myStr
@@ -31,19 +30,14 @@
         TYPE(testingType) :: cpyStruct
         TYPE(testingType), dimension(10) :: myStructArr
         TYPE(testingType), dimension(10) :: cpyStructArr
-        
+
         OMPVV_TEST_OFFLOADING
-        OMPVV_TEST_AND_SET_SHARED_ENVIRONMENT(isSharedEnv)
-        WRITE(auxMessage, *) "Shared data environment will cause &
-          &this test to not check if the data is not copied back when& 
-          & using the to map modifier"
-        OMPVV_WARNING_IF(isSharedEnv, auxMessage)
-        
+
         OMPVV_TEST_VERBOSE(test_map_derived_type_to() .ne. 0)
 
         OMPVV_REPORT_AND_RETURN()
 
-        CONTAINS 
+        CONTAINS
           ! Default mapping
           INTEGER FUNCTION test_map_derived_type_to()
 
@@ -63,8 +57,8 @@
             cpyStruct%myReal = 0.0
             cpyStruct%myArr(:) = 0
             cpyStruct%myPtr => justATarget
-            
-            DO i = 1, 10 
+
+            DO i = 1, 10
               myStructArr(i)%myInt = 5
               myStructArr(i)%myStr = "there"
               myStructArr(i)%myReal = 4.4
@@ -87,7 +81,7 @@
                 cpyStruct%myReal = myStruct%myReal
                 cpyStruct%myArr(:) = myStruct%myArr(:)
 
-                DO i = 1, 10 
+                DO i = 1, 10
                   cpyStructArr(i)%myInt = myStructArr(i)%myInt
                   cpyStructArr(i)%myStr = myStructArr(i)%myStr
                   cpyStructArr(i)%myReal = myStructArr(i)%myReal
@@ -95,20 +89,17 @@
                 END DO
 
                 ! Modifying it to check if it is copied back
-                ! only if it is not shared environment
-                IF (.NOT. isSharedEnv) THEN
-                  myStruct%myInt = 0
-                  myStruct%myStr = "f"
-                  myStruct%myReal = 0.0
-                  myStruct%myArr(:) = 0
-  
-                  DO i = 1, 10 
-                    myStructArr(i)%myInt = 0
-                    myStructArr(i)%myStr = "f"
-                    myStructArr(i)%myReal = 0.0
-                    myStructArr(i)%myArr(1:N) = 0
-                  END DO
-                END IF
+                myStruct%myInt = 0
+                myStruct%myStr = "f"
+                myStruct%myReal = 0.0
+                myStruct%myArr(:) = 0
+
+                DO i = 1, 10
+                   myStructArr(i)%myInt = 0
+                   myStructArr(i)%myStr = "f"
+                   myStructArr(i)%myReal = 0.0
+                   myStructArr(i)%myArr(1:N) = 0
+                END DO
               !$omp end target
             !$omp end target data
 
@@ -120,7 +111,7 @@
             OMPVV_TEST_VERBOSE(ANY(cpyStruct%myArr /= 10))
             OMPVV_TEST_VERBOSE(.NOT. ASSOCIATED(cpyStruct%myPtr, justATarget))
 
-            DO i = 1, 10 
+            DO i = 1, 10
               OMPVV_TEST_VERBOSE(cpyStructArr(i)%myInt /= 5)
               OMPVV_TEST_VERBOSE(cpyStructArr(i)%myStr .NE. 'there')
               OMPVV_TEST_VERBOSE(ABS(cpyStructArr(i)%myReal - 4.4) .GT. 0.0001)
@@ -135,7 +126,7 @@
             OMPVV_TEST_VERBOSE(ANY(myStruct%myArr /= 10))
             OMPVV_TEST_VERBOSE(.NOT. ASSOCIATED(myStruct%myPtr, justATarget))
 
-            DO i = 1, 10 
+            DO i = 1, 10
               OMPVV_TEST_VERBOSE(myStructArr(i)%myInt /= 5)
               OMPVV_TEST_VERBOSE(myStructArr(i)%myStr .NE. 'there')
               OMPVV_TEST_VERBOSE(ABS(myStructArr(i)%myReal - 4.4) .GT. 0.0001)
@@ -148,4 +139,3 @@
 
           END FUNCTION test_map_derived_type_to
       END PROGRAM test_target_data_map_components_to
-

--- a/tests/4.5/target_data/test_target_data_map_devices.F90
+++ b/tests/4.5/target_data/test_target_data_map_devices.F90
@@ -15,12 +15,11 @@
         USE ompvv_lib
         USE omp_lib
         implicit none
-        LOGICAL :: isOffloading, isSharedEnv
+        LOGICAL :: isOffloading
         INTEGER :: i, j, num_dev
         CHARACTER(len=500) :: msgHelper
 
         OMPVV_TEST_AND_SET_OFFLOADING(isOffloading)
-        OMPVV_TEST_AND_SET_SHARED_ENVIRONMENT(isSharedEnv)
 
         ! Reporting the number of devices
         num_dev = omp_get_num_devices()
@@ -31,10 +30,6 @@
         WRITE(msgHelper, *) "The number of devices is 1, this test &
         &is inconclussive"
         OMPVV_WARNING_IF(num_dev == 1, msgHelper)
-
-        WRITE(msgHelper,*) "Using shared data environment. This test &
-        &has some limitations"
-        OMPVV_WARNING_IF(isSharedEnv, msgHelper)
 
         !starting the tests
         ! Warning for the number of devices
@@ -78,7 +73,7 @@
                     ! When on other devices different to the 
                     ! default device of the target data region
                     ! this operation would not be reflected on the host
-                    IF (.NOT. isSharedEnv .OR. devComp == devData) THEN
+                    IF (devComp == devData) THEN
                       anArray(1:N) = anArray(1:N) + 1
                     END IF
 
@@ -120,7 +115,7 @@
                   !$omp target map(alloc: anArray(1:N)) &
                   !$omp device(dev_comp)
                     ! Increase only in the current tested device
-                    IF (.NOT. isSharedEnv .OR. dev_comp == dev_data) THEN
+                    IF (dev_comp == dev_data) THEN
                       ! This should not affect result as it should happen in
                       ! other devices
                       anArray(1:N) = anArray(1:N) + 1
@@ -136,4 +131,3 @@
 
           END FUNCTION test_device_clause
       END PROGRAM test_target_data_devices
-

--- a/tests/4.5/target_data/test_target_data_map_from_array_sections.F90
+++ b/tests/4.5/target_data/test_target_data_map_from_array_sections.F90
@@ -1,9 +1,9 @@
 !===---- test_target_data_map_from_array_sections.F90 - mapping array sections ---===//
-! 
+!
 ! OpenMP API Version 4.5 Nov 2015
-! 
+!
 ! Testing array sections mapping from. This tests must cover dynamically allocated
-! arrays, 1D, 2D and 3D arrays. As well as sections mapping 
+! arrays, 1D, 2D and 3D arrays. As well as sections mapping
 !
 !===-------------------------------------------------------------------------===//
 #include "ompvv.F90"
@@ -15,12 +15,11 @@
         USE ompvv_lib
         USE omp_lib
         implicit none
-        LOGICAL :: isOffloading, isSharedEnv
+        LOGICAL :: isOffloading
         INTEGER :: i,j
         CHARACTER(len=500) :: msgHelper
-        
+
         OMPVV_TEST_AND_SET_OFFLOADING(isOffloading)
-        OMPVV_TEST_AND_SET_SHARED_ENVIRONMENT(isSharedEnv)
         OMPVV_TEST_VERBOSE(test_array_sections_pointer_1D() .NE. 0)
         OMPVV_TEST_VERBOSE(test_array_sections_pointer_2D() .NE. 0)
         OMPVV_TEST_VERBOSE(test_array_sections_pointer_3D() .NE. 0)
@@ -30,8 +29,7 @@
 
         OMPVV_REPORT_AND_RETURN()
 
-
-        CONTAINS 
+        CONTAINS
           ! Testing pointer array sections 1D
           INTEGER FUNCTION test_array_sections_pointer_1D()
             INTEGER, ALLOCATABLE, DIMENSION(:) :: my1DPtr
@@ -61,7 +59,7 @@
               !$omp target map(alloc: my1DPtr(10:N-10)) &
               !$omp map(alloc: my1DPtr2(10:), my1DPtr3(:N-10)) &
               !$omp map(tofrom: myTmpArray)
-                ! This should result in garbage writes to myTmpArray. 
+                ! This should result in garbage writes to myTmpArray.
                 ! Since the arrays are not copied to, they should not
                 ! have the value of the host.
                 myTmpArray(10:N-10) = myTmpArray(10:N-10) + &
@@ -69,7 +67,7 @@
                 myTmpArray(10:) = myTmpArray(10:) + my1DPtr2(10:)
                 myTmpArray(:N-10) = myTmpArray(:N-10) + my1DPtr3(:N-10)
 
-                ! Asign a value to the region and 
+                ! Asign a value to the region and
                 ! checking for this value on the host
                 my1DPtr(10:N-10) = 0
                 my1DPtr2(10:) = 0
@@ -77,10 +75,10 @@
               !$omp end target
 
             !$omp end target data
-            
+
             !testing that the array is just copied from and not to
-            IF (.NOT. isSharedEnv .AND. isOffloading) THEN
-              testVal = (N-19)*10 + & 
+            IF (isOffloading) THEN
+              testVal = (N-19)*10 + &
               &         (N-9)*10 + &
               &         (N-10)*10
               ! Since the data should not have been copied over the device
@@ -130,11 +128,11 @@
               !$omp target data map(from: my2DPtr(10:N-10, i)) &
               !$omp map(from: my2DPtr2(10:, i), my2DPtr3(:N-10, i)) &
               !$omp map(tofrom: myTmpArray)
-  
+
                 !$omp target map(alloc: my2DPtr(10:N-10, i)) &
                 !$omp map(alloc: my2DPtr2(10:, i), my2DPtr3(:N-10, i)) &
                 !$omp map(tofrom: myTmpArray)
-                  ! This should result in garbage writes to myTmpArray. 
+                  ! This should result in garbage writes to myTmpArray.
                   ! Since the arrays are not copied to, they should not
                   ! have the value of the host.
                   myTmpArray(10:N-10, i) = &
@@ -146,7 +144,7 @@
                   myTmpArray(:N-10, i) = &
                   &    myTmpArray(:N-10, i) + &
                   &    my2DPtr3(:N-10, i)
-                  ! Asign a value to the region and 
+                  ! Asign a value to the region and
                   ! checking for this value on the host
                   my2DPtr(10:N-10, i) = 0
                   my2DPtr2(10:, i) = 0
@@ -156,15 +154,15 @@
             END DO
 
             !testing that the array is just copied from and not to
-            IF (.NOT. isSharedEnv .AND. isOffloading) THEN
-              testVal = N*(N-19)*10 + & 
+            IF (isOffloading) THEN
+              testVal = N*(N-19)*10 + &
               &         N*(N-9)*10 + &
               &         N*(N-10)*10
               WRITE(msgHelper,*) "When using map from, the arrays might &
               & have been moved to the deice as well."
               OMPVV_WARNING_IF(SUM(myTmpArray) == testVal, msgHelper)
             END IF
-           
+
             OMPVV_TEST_AND_SET_VERBOSE(errors, ANY(my2DPtr(10:N-10,:) /= 0))
             OMPVV_TEST_AND_SET_VERBOSE(errors, ANY(my2DPtr2(10:,:) /= 0))
             OMPVV_TEST_AND_SET_VERBOSE(errors, ANY(my2DPtr3(:N-10,:) /= 0))
@@ -209,7 +207,7 @@
                   !$omp target map(alloc: my3DPtr(10:N-10, i, j)) &
                   !$omp map(alloc: my3DPtr2(10:, i, j), my3DPtr3(:N-10, i, j)) &
                   !$omp map(tofrom: myTmpArray)
-                    ! This should result in garbage writes to myTmpArray. 
+                    ! This should result in garbage writes to myTmpArray.
                     ! Since the arrays are not copied to, they should not
                     ! have the value of the host.
                     myTmpArray(10:N-10, i, j) = &
@@ -222,7 +220,7 @@
                     &    myTmpArray(:N-10, i, j) + &
                     &    my3DPtr3(:N-10, i, j)
 
-                    ! Asign a value to the region and 
+                    ! Asign a value to the region and
                     ! checking for this value on the host
                     my3DPtr(10:N-10, i, j) = 0
                     my3DPtr2(10:, i, j) = 0
@@ -234,15 +232,15 @@
 
 
             !testing that the array is just copied from and not to
-            IF (.NOT. isSharedEnv .AND. isOffloading) THEN
-              testVal = N*N*(N-19)*10 + & 
+            IF (isOffloading) THEN
+              testVal = N*N*(N-19)*10 + &
               &         N*N*(N-9)*10 + &
               &         N*N*(N-10)*10
               WRITE(msgHelper,*) "When using map from, the arrays might &
               & have been moved to the deice as well."
               OMPVV_WARNING_IF(SUM(myTmpArray) == testVal, msgHelper)
             END IF
-           
+
             OMPVV_TEST_AND_SET_VERBOSE(errors, ANY(my3DPtr(10:N-10,:,:) /= 0))
             OMPVV_TEST_AND_SET_VERBOSE(errors, ANY(my3DPtr2(10:,:,:) /= 0))
             OMPVV_TEST_AND_SET_VERBOSE(errors, ANY(my3DPtr3(:N-10,:,:) /= 0))
@@ -278,7 +276,7 @@
               !$omp target map(alloc: my1DArray(10:N-10)) &
               !$omp map(alloc: my1DArray2(10:), my1DArray3(:N-10)) &
               !$omp map(tofrom: myTmpArray)
-                ! This should result in garbage writes to myTmpArray. 
+                ! This should result in garbage writes to myTmpArray.
                 ! Since the arrays are not copied to, they should not
                 ! have the value of the host.
                 myTmpArray(10:N-10) = &
@@ -290,7 +288,7 @@
                 myTmpArray(:N-10) = &
                 &    myTmpArray(:N-10) + &
                 &    my1DArray3(:N-10)
-                ! Asign a value to the region and 
+                ! Asign a value to the region and
                 ! checking for this value on the host
                 my1DArray(10:N-10) = 0
                 my1DArray2(10:) = 0
@@ -298,17 +296,17 @@
               !$omp end target
 
             !$omp end target data
-            
+
             !testing that the array is just copied from and not to
-            IF (.NOT. isSharedEnv .AND. isOffloading) THEN
-              testVal = (N-19)*10 + & 
+            IF (isOffloading) THEN
+              testVal = (N-19)*10 + &
               &         (N-9)*10 + &
               &         (N-10)*10
               WRITE(msgHelper,*) "When using map from, the arrays might &
               & have been moved to the deice as well."
               OMPVV_WARNING_IF(SUM(myTmpArray) == testVal, msgHelper)
             END IF
-           
+
             OMPVV_TEST_AND_SET_VERBOSE(errors, ANY(my1DArray(10:N-10) /= 0))
             OMPVV_TEST_AND_SET_VERBOSE(errors, ANY(my1DArray2(10:) /= 0))
             OMPVV_TEST_AND_SET_VERBOSE(errors, ANY(my1DArray3(:N-10) /= 0))
@@ -338,11 +336,11 @@
               !$omp target data map(from: my2DArray(10:N-10, i)) &
               !$omp map(from: my2DArray2(10:, i), my2DArray3(:N-10, i)) &
               !$omp map(tofrom: myTmpArray)
-  
+
                 !$omp target map(alloc: my2DArray(10:N-10, i)) &
                 !$omp map(alloc: my2DArray2(10:, i), my2DArray3(:N-10, i)) &
                 !$omp map(tofrom: myTmpArray)
-                  ! This should result in garbage writes to myTmpArray. 
+                  ! This should result in garbage writes to myTmpArray.
                   ! Since the arrays are not copied to, they should not
                   ! have the value of the host.
                   myTmpArray(10:N-10, i) = &
@@ -354,7 +352,7 @@
                   myTmpArray(:N-10, i) = &
                   &    myTmpArray(:N-10, i) + &
                   &    my2DArray3(:N-10, i)
-                  ! Asign a value to the region and 
+                  ! Asign a value to the region and
                   ! checking for this value on the host
                   my2DArray(10:N-10, i) = 0
                   my2DArray2(10:, i) = 0
@@ -364,15 +362,15 @@
             END DO
 
             !testing that the array is just copied from and not to
-            IF (.NOT. isSharedEnv .AND. isOffloading) THEN
-              testVal = N*(N-19)*10 + & 
+            IF (isOffloading) THEN
+              testVal = N*(N-19)*10 + &
               &         N*(N-9)*10 + &
               &         N*(N-10)*10
               WRITE(msgHelper,*) "When using map from, the arrays might &
               & have been moved to the deice as well."
               OMPVV_WARNING_IF(SUM(myTmpArray) == testVal, msgHelper)
             END IF
-           
+
             OMPVV_TEST_AND_SET_VERBOSE(errors, ANY(my2DArray(10:N-10,:) /= 0))
             OMPVV_TEST_AND_SET_VERBOSE(errors, ANY(my2DArray2(10:,:) /= 0))
             OMPVV_TEST_AND_SET_VERBOSE(errors, ANY(my2DArray3(:N-10,:) /= 0))
@@ -409,7 +407,7 @@
                   !$omp target map(alloc: my3DArray(10:N-10, i, j)) &
                   !$omp map(alloc: my3DArray2(10:, i, j), my3DArray3(:N-10, i, j)) &
                   !$omp map(tofrom: myTmpArray)
-                    ! This should result in garbage writes to myTmpArray. 
+                    ! This should result in garbage writes to myTmpArray.
                     ! Since the arrays are not copied to, they should not
                     ! have the value of the host.
                     myTmpArray(10:N-10, i, j) = &
@@ -421,7 +419,7 @@
                     myTmpArray(:N-10, i, j) = &
                     &    myTmpArray(:N-10, i, j) + &
                     &    my3DArray3(:N-10, i, j)
-                    ! Asign a value to the region and 
+                    ! Asign a value to the region and
                     ! checking for this value on the host
                     my3DArray(10:N-10, i, j) = 0
                     my3DArray2(10:, i, j) = 0
@@ -431,17 +429,17 @@
               END DO
             END DO
 
-            !testing that the array is just copied to and not from 
-            IF (.NOT. isSharedEnv .AND. isOffloading) THEN
+            !testing that the array is just copied to and not from
+            IF (isOffloading) THEN
               OMPVV_INFOMSG("test array sections pointer 3D")
-              testVal = N*N*(N-19)*10 + & 
+              testVal = N*N*(N-19)*10 + &
               &         N*N*(N-9)*10 + &
               &         N*N*(N-10)*10
               WRITE(msgHelper,*) "When using map from, the arrays might &
               & have been moved to the deice as well."
               OMPVV_WARNING_IF(SUM(myTmpArray) == testVal, msgHelper)
             END IF
-           
+
             OMPVV_TEST_AND_SET_VERBOSE(errors, ANY(my3DArray(10:N-10,:,:) /= 0))
             OMPVV_TEST_AND_SET_VERBOSE(errors, ANY(my3DArray2(10:,:,:) /= 0))
             OMPVV_TEST_AND_SET_VERBOSE(errors, ANY(my3DArray3(:N-10,:,:) /= 0))
@@ -449,4 +447,3 @@
             test_array_sections_3D = errors
           END FUNCTION test_array_sections_3D
       END PROGRAM
-

--- a/tests/4.5/target_data/test_target_data_map_set_default_device.F90
+++ b/tests/4.5/target_data/test_target_data_map_set_default_device.F90
@@ -1,7 +1,7 @@
 !===---- test_target_data_map_set_default_device.F90 - set_default_device() API --===//
-! 
+!
 ! OpenMP API Version 4.5 Nov 2015
-! 
+!
 ! This test check if by calling the set_default_device the target_data
 ! is mapped to the default device selected by this API call
 !
@@ -15,12 +15,11 @@
         USE ompvv_lib
         USE omp_lib
         implicit none
-        LOGICAL :: isOffloading, isSharedEnv
+        LOGICAL :: isOffloading
         INTEGER :: i, j, num_dev
         CHARACTER(len=500) :: msgHelper
 
         OMPVV_TEST_AND_SET_OFFLOADING(isOffloading)
-        OMPVV_TEST_AND_SET_SHARED_ENVIRONMENT(isSharedEnv)
 
         ! Reporting the number of devices
         num_dev = omp_get_num_devices()
@@ -37,7 +36,7 @@
 
         OMPVV_REPORT_AND_RETURN()
 
-        CONTAINS 
+        CONTAINS
           ! Testing set default device API
           INTEGER FUNCTION test_set_default_device()
             INTEGER :: def_dev, dev_data, dev_comp
@@ -48,7 +47,7 @@
             def_dev = omp_get_default_device()
             WRITE(msgHelper, '(A,I0)') "default device = ", def_dev
             OMPVV_INFOMSG(msgHelper)
-            
+
             ! Initialize the array
             anArray(:) = 1
 
@@ -59,7 +58,7 @@
               !$omp target data map(tofrom: anArray(1:N))
 
                 ! Iterate over all the devices doing comp
-                ! to guarantee that the right data env is 
+                ! to guarantee that the right data env is
                 ! being copied back and forth
                 DO dev_comp = 0, (num_dev - 1)
                   !$omp target map(alloc: anArray(1:N)) &
@@ -68,25 +67,24 @@
                     ! Increase only in the current tested device
                     IF (dev_comp == dev_data) THEN
                       anArray(1:N) = anArray(1:N) + 1
-                    ELSE IF (.NOT. isSharedEnv) THEN
+                    ELSE
                       ! This should not affect result as it should happen in
                       ! other devices
                       anArray(1:N) = anArray(1:N) - 10
                     END IF
-                    
+
                   !$omp end target
                 END DO ! dev_comp
               !$omp end target data
             END DO ! dev_data
-              
+
             OMPVV_TEST_VERBOSE(ANY(anArray /= num_dev + 1))
 
-            ! return the default device to the 
-            ! original default 
+            ! return the default device to the
+            ! original default
             CALL omp_set_default_device(def_dev)
 
             OMPVV_GET_ERRORS(test_set_default_device)
 
           END FUNCTION test_set_default_device
       END PROGRAM test_target_data_map_set_default_device
-

--- a/tests/4.5/target_data/test_target_data_map_to_array_sections.F90
+++ b/tests/4.5/target_data/test_target_data_map_to_array_sections.F90
@@ -1,9 +1,9 @@
 !===---- test_target_data_map_to_array_sections.F90 - mapping array sections ---===//
-! 
+!
 ! OpenMP API Version 4.5 Nov 2015
-! 
+!
 ! Testing array sections mapping to. This tests must cover dynamically allocated
-! arrays, 1D, 2D and 3D arrays. As well as sections mapping 
+! arrays, 1D, 2D and 3D arrays. As well as sections mapping
 !
 !===-------------------------------------------------------------------------===//
 #include "ompvv.F90"
@@ -15,11 +15,10 @@
         USE ompvv_lib
         USE omp_lib
         implicit none
-        LOGICAL :: isOffloading, isSharedEnv
+        LOGICAL :: isOffloading
         INTEGER :: i,j
-        
+
         OMPVV_TEST_AND_SET_OFFLOADING(isOffloading)
-        OMPVV_TEST_AND_SET_SHARED_ENVIRONMENT(isSharedEnv)
         OMPVV_TEST_VERBOSE(test_array_sections_pointer_1D() .NE. 0)
         OMPVV_TEST_VERBOSE(test_array_sections_pointer_2D() .NE. 0)
         OMPVV_TEST_VERBOSE(test_array_sections_pointer_3D() .NE. 0)
@@ -30,7 +29,7 @@
         OMPVV_REPORT_AND_RETURN()
 
 
-        CONTAINS 
+        CONTAINS
           ! Testing pointer array sections 1D
           INTEGER FUNCTION test_array_sections_pointer_1D()
             INTEGER, ALLOCATABLE, DIMENSION(:) :: my1DPtr
@@ -72,14 +71,14 @@
               !$omp end target
 
             !$omp end target data
-            
-            testVal = (N-19)*10 + & 
+
+            testVal = (N-19)*10 + &
             &         (N-9)*10 + &
             &         (N-10)*10
             OMPVV_TEST_AND_SET_VERBOSE(errors, SUM(myTmpArray) /= testVal)
 
-            !testing that the array is just copied to and not from 
-            IF (.NOT. isSharedEnv .AND. isOffloading) THEN
+            !testing that the array is just copied to and not from
+            IF (isOffloading) THEN
               OMPVV_TEST_AND_SET_VERBOSE(errors, ANY(my1DPtr(10:N-10) /= 10))
               OMPVV_TEST_AND_SET_VERBOSE(errors, ANY(my1DPtr2(10:) /= 10))
               OMPVV_TEST_AND_SET_VERBOSE(errors, ANY(my1DPtr3(:N-10) /= 10))
@@ -121,7 +120,7 @@
               !$omp target data map(to: my2DPtr(10:N-10, i)) &
               !$omp map(to: my2DPtr2(10:, i), my2DPtr3(:N-10, i)) &
               !$omp map(tofrom: myTmpArray)
-  
+
                 !$omp target map(alloc: my2DPtr(10:N-10, i)) &
                 !$omp map(alloc: my2DPtr2(10:, i), my2DPtr3(:N-10, i)) &
                 !$omp map(tofrom: myTmpArray)
@@ -143,13 +142,13 @@
               !$omp end target data
             END DO
 
-            testVal = N*(N-19)*10 + & 
+            testVal = N*(N-19)*10 + &
             &         N*(N-9)*10 + &
             &         N*(N-10)*10
             OMPVV_TEST_AND_SET_VERBOSE(errors, SUM(myTmpArray) /= testVal)
-           
-            !testing that the array is just copied to and not from 
-            IF (.NOT. isSharedEnv .AND. isOffloading) THEN
+
+            !testing that the array is just copied to and not from
+            IF (isOffloading) THEN
               OMPVV_TEST_AND_SET_VERBOSE(errors, ANY(my2DPtr(:,:) /= 10))
               OMPVV_TEST_AND_SET_VERBOSE(errors, ANY(my2DPtr2(:,:) /= 10))
               OMPVV_TEST_AND_SET_VERBOSE(errors, ANY(my2DPtr3(:,:) /= 10))
@@ -214,13 +213,13 @@
               END DO
             END DO
 
-            testVal = N*N*(N-19)*10 + & 
+            testVal = N*N*(N-19)*10 + &
             &         N*N*(N-9)*10 + &
             &         N*N*(N-10)*10
             OMPVV_TEST_AND_SET_VERBOSE(errors, SUM(myTmpArray) /= testVal)
-           
-            !testing that the array is just copied to and not from 
-            IF (.NOT. isSharedEnv .AND. isOffloading) THEN
+
+            !testing that the array is just copied to and not from
+            IF (isOffloading) THEN
               OMPVV_TEST_AND_SET_VERBOSE(errors, ANY(my3DPtr(:,:,:) /= 10))
               OMPVV_TEST_AND_SET_VERBOSE(errors, ANY(my3DPtr2(:,:,:) /= 10))
               OMPVV_TEST_AND_SET_VERBOSE(errors, ANY(my3DPtr3(:,:,:) /= 10))
@@ -274,15 +273,15 @@
               !$omp end target
 
             !$omp end target data
-            
+
             ! Counting all the areas, the sum should be:
-            testVal = (N-19)*10 + & 
+            testVal = (N-19)*10 + &
             &         (N-9)*10 + &
             &         (N-10)*10
             OMPVV_TEST_AND_SET_VERBOSE(errors, SUM(myTmpArray) /= testVal)
-           
-            !testing that the array is just copied to and not from 
-            IF (.NOT. isSharedEnv .AND. isOffloading) THEN
+
+            !testing that the array is just copied to and not from
+            IF (isOffloading) THEN
               OMPVV_TEST_AND_SET_VERBOSE(errors, ANY(my1DArray /= 10))
               OMPVV_TEST_AND_SET_VERBOSE(errors, ANY(my1DArray2 /= 10))
               OMPVV_TEST_AND_SET_VERBOSE(errors, ANY(my1DArray3 /= 10))
@@ -313,7 +312,7 @@
               !$omp target data map(to: my2DArray(10:N-10, i)) &
               !$omp map(to: my2DArray2(10:, i), my2DArray3(:N-10, i)) &
               !$omp map(tofrom: myTmpArray)
-  
+
                 !$omp target map(alloc: my2DArray(10:N-10, i)) &
                 !$omp map(alloc: my2DArray2(10:, i), my2DArray3(:N-10, i)) &
                 !$omp map(tofrom: myTmpArray)
@@ -335,13 +334,13 @@
               !$omp end target data
             END DO
 
-            testVal = N*(N-19)*10 + & 
+            testVal = N*(N-19)*10 + &
             &         N*(N-9)*10 + &
             &         N*(N-10)*10
             OMPVV_TEST_AND_SET_VERBOSE(errors, SUM(myTmpArray) /= testVal)
-           
-            !testing that the array is just copied to and not from 
-            IF (.NOT. isSharedEnv .AND. isOffloading) THEN
+
+            !testing that the array is just copied to and not from
+            IF (isOffloading) THEN
               OMPVV_TEST_AND_SET_VERBOSE(errors, ANY(my2DArray(:,:) /= 10))
               OMPVV_TEST_AND_SET_VERBOSE(errors, ANY(my2DArray2(:,:) /= 10))
               OMPVV_TEST_AND_SET_VERBOSE(errors, ANY(my2DArray3(:,:) /= 10))
@@ -399,13 +398,13 @@
             END DO
 
             OMPVV_INFOMSG("test array sections pointer 3D")
-            testVal = N*N*(N-19)*10 + & 
+            testVal = N*N*(N-19)*10 + &
             &         N*N*(N-9)*10 + &
             &         N*N*(N-10)*10
             OMPVV_TEST_AND_SET_VERBOSE(errors, SUM(myTmpArray) /= testVal)
-           
-            !testing that the array is just copied to and not from 
-            IF (.NOT. isSharedEnv .AND. isOffloading) THEN
+
+            !testing that the array is just copied to and not from
+            IF (isOffloading) THEN
               OMPVV_TEST_AND_SET_VERBOSE(errors, ANY(my3DArray(:,:,:) /= 10))
               OMPVV_TEST_AND_SET_VERBOSE(errors, ANY(my3DArray2(:,:,:) /= 10))
               OMPVV_TEST_AND_SET_VERBOSE(errors, ANY(my3DArray3(:,:,:) /= 10))
@@ -414,4 +413,3 @@
             test_array_sections_3D = errors
           END FUNCTION test_array_sections_3D
       END PROGRAM
-

--- a/tests/4.5/target_data/test_target_data_pointer_swap.c
+++ b/tests/4.5/target_data/test_target_data_pointer_swap.c
@@ -1,7 +1,7 @@
 //===--- test_target_data_pointer_swap.c------------------------------------===//
 //
 // OpenMP API Version 4.5 Nov 2015
-// 
+//
 // This test swaps two pointers' values inside a target data region, testing
 // that the map clauses are applied to their original list items. The address
 // used at the entrance to the data region should be the same used at the exit
@@ -20,11 +20,10 @@ int test_pointer_swap() {
   int* a = (int *) malloc(N * sizeof(int));
   int* b = (int *) malloc(N * sizeof(int));
   int* temp;
-  int is_offloading, is_shared_env;
+  int is_offloading;
   int errors = 0;
 
   OMPVV_TEST_AND_SET_OFFLOADING(is_offloading);
-  OMPVV_TEST_AND_SET_SHARED_ENVIRONMENT(is_shared_env);
 
   for (int x = 0; x < N; ++x) {
     a[x] = x;
@@ -44,7 +43,7 @@ int test_pointer_swap() {
 
   for (int x = 0; x < N; ++x) {
     OMPVV_TEST_AND_SET(errors, b[x] != x);
-    if (is_offloading && !is_shared_env) {
+    if (is_offloading) {
       OMPVV_TEST_AND_SET(errors, a[x] != 0);
     } else {
       OMPVV_TEST_AND_SET(errors, a[x] != 2*x);


### PR DESCRIPTION
This is working towards fixing issue #94. In most cases this was straightfoward to fix but there are some tests which will now fail when run on the host due to changes made here. However, for all of these tests I cross-checked the list of tests already failing on the host (issue #12) and they are already there.

Also, I removed the macro from the test templates.

These changes are tested and passing on Summit.

There are also some whitespace cleanups in these tests, so I recommend hiding whitespace changes when reviewing the files.