### PR TITLE
Minor fixes to detect GCC and clang versions

### DIFF
--- a/sys/make/make.def
+++ b/sys/make/make.def
@@ -81,7 +81,7 @@ ifeq ($(CC), gcc)
   CFLAGS += -O3 -std=c99 -fopenmp $(COFFLOADING)
   CLINK = gcc
   CLINKFLAGS += -O3 -fopenmp $(COFFLOADING)
-  C_VERSION = echo "$(shell gcc --version | head -1 | sed 's/.* \([0-9]*\.[0-9]*\.[0-9]*\)/\1/g')"
+  C_VERSION = echo "$(shell gcc --version | head -n 1 | sed 's/.* \([0-9]*\.[0-9]*\.[0-9]*\).*/\1/g')"
 endif
 
 # IBM XL compiler
@@ -102,7 +102,7 @@ ifeq ($(CC), clang)
   CFLAGS +=  -D__NO_MATH_INLINES -U__SSE2_MATH__ -U__SSE_MATH__
   CLINK = clang
   CLINKFLAGS += -lm -O3 -fopenmp $(COFFLOADING)
-  C_VERSION = echo "$(shell clang --version | head -1 | sed 's/clang version \([0-9]*\.[0-9]*\.[0-9]*\)/\1/g')"
+  C_VERSION = echo "$(shell clang --version | head -n 1 | sed 's/clang version \([0-9]*\.[0-9]*\.[0-9]*\)/\1/g')"
 endif
 
 # AOMP compiler
@@ -160,7 +160,7 @@ ifeq ($(CXX), g++)
   CXXFLAGS += -std=c++11 -O3 -fopenmp $(CXXOFFLOADING)
   CXXLINK = g++
   CXXLINKFLAGS += -O3 -fopenmp $(CXXOFFLOADING)
-  CXX_VERSION = echo "$(shell g++ --version | head -1 | sed 's/.* \([0-9]*\.[0-9]*\.[0-9]*\)/\1/g')"
+  CXX_VERSION = echo "$(shell g++ --version | head -n 1 | sed 's/.* \([0-9]*\.[0-9]*\.[0-9]*\).*/\1/g')"
 endif
 
 # IBM XL compiler
@@ -181,7 +181,7 @@ ifeq ($(CXX), clang++)
   CXXFLAGS +=  -D__NO_MATH_INLINES -U__SSE2_MATH__ -U__SSE_MATH__
   CXXLINK = clang++
   CXXLINKFLAGS += -lm -O3 -fopenmp $(CXXOFFLOADING)
-  CXX_VERSION = echo "$(shell clang++ --version | head -1 | sed 's/clang version \([0-9]*\.[0-9]*\.[0-9]*\)/\1/g')"
+  CXX_VERSION = echo "$(shell clang++ --version | head -n 1 | sed 's/clang version \([0-9]*\.[0-9]*\.[0-9]*\)/\1/g')"
 endif
 
 # AOMP compiler
@@ -232,7 +232,7 @@ ifeq ($(FC), gfortran)
   FFLAGS += -O3 -fopenmp $(FOFFLOADING) -ffree-line-length-none -J./ompvv
   FLINK = gcc
   FLINKFLAGS += -O3 -fopenmp $(FOFFLOADING)
-  F_VERSION = echo "$(shell gfortran --version | head -1 | sed 's/.* \([0-9]*\.[0-9]*\.[0-9]*\)/\1/g')"
+  F_VERSION = echo "$(shell gfortran --version | head -n 1 | sed 's/.* \([0-9]*\.[0-9]*\.[0-9]*\).*/\1/g')"
 endif
 
 # IBM XLF compiler


### PR DESCRIPTION
Followup to Pull Req. #132
	* sys/make/make.def (C_VERSION, CXX_VERSION, F_VERSION): Use
	'-n 1' instead of '-1' for 'head' for better POSIX compatibility;
	strip-off date and git version for GCC.