### PR TITLE
Add LINK_OMPVV_LIB flag to enable static lib and test of static lib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,11 @@ endif
 
 ifeq "$(SOURCES)" ""
 # Getting all the source files in the project
+ifdef LINK_OMPVV_LIB
 SOURCES_C := $(shell find $(CURDIR)/tests/$(OMP_VERSION) -name *.c)
+else
+SOURCES_C := $(shell find $(CURDIR)/tests/$(OMP_VERSION) ! -name qmcpack_target_static_lib.c -name *.c)
+endif
 SOURCES_CPP := $(shell find $(CURDIR)/tests/$(OMP_VERSION) -name *.cpp)
 SOURCES_F := $(shell find $(CURDIR)/tests/$(OMP_VERSION) -name "*.F90" -o -name "*.F95" -o -name "*.F03" -o -name "*.F" -o -name "*.FOR" | grep -v "ompvv.F90")
 
@@ -238,8 +242,12 @@ endif
 # OMPVV static library
 ##################################################
 
-OMPVVLIB=-L$(CURDIR)/ompvv -lompvv
-OMPVVLIB_DEP=$(CURDIR)/ompvv/libompvv.a
+OMPVVLIB=
+OMPVVLIB_DEP=
+ifdef LINK_OMPVV_LIB
+	OMPVVLIB=-L$(CURDIR)/ompvv -lompvv
+	OMPVVLIB_DEP=$(CURDIR)/ompvv/libompvv.a
+endif
 
 $(BINDIR)/libompvv.o: $(CURDIR)/ompvv/libompvv.c $(BINDIR)
 	@echo -e $(TXTYLW)"\n\n" compile: $< $(TXTNOC)
@@ -472,6 +480,7 @@ help:
 	@echo "  MODULE_LOAD=1             Before compiling or running, module load is called"
 	@echo "  ADD_BATCH_SCHED=1         Add the jsrun command before the execution of the running script to send it to a compute node"
 	@echo "  NO_OFFLOADING=1           Turn off offloading"
+	@echo "  LINK_OMPVV_LIB=1          Link the OMPVV static library (in ompvv folder) and run the static lib test"
 	@echo "  NUM_THREADS_HOST=n        Specify n, requested number of threads for tests that use num_threads() on host constructs"
 	@echo "  NUM_THREADS_DEVICE=n      Specify n, requested number of threads for tests that use num_threads() on device constructs"
 	@echo "  NUM_TEAMS_DEVICE=n        Specify n, requested number of threads for tests that use num_teams() on device constructs"

--- a/Makefile
+++ b/Makefile
@@ -242,12 +242,8 @@ endif
 # OMPVV static library
 ##################################################
 
-OMPVVLIB=
-OMPVVLIB_DEP=
-ifdef LINK_OMPVV_LIB
-	OMPVVLIB=-L$(CURDIR)/ompvv -lompvv
-	OMPVVLIB_DEP=$(CURDIR)/ompvv/libompvv.a
-endif
+OMPVVLIB=-L$(CURDIR)/ompvv -lompvv
+OMPVVLIB_DEP=$(CURDIR)/ompvv/libompvv.a
 
 $(BINDIR)/libompvv.o: $(CURDIR)/ompvv/libompvv.c $(BINDIR)
 	@echo -e $(TXTYLW)"\n\n" compile: $< $(TXTNOC)
@@ -266,7 +262,17 @@ $(CURDIR)/ompvv/libompvv.a: $(BINDIR)/libompvv.o
 # Compilation rules
 ##################################################
 # c files rule
-%.c.o: %.c $(BINDIR) $(LOGDIR) $(OMPVVLIB_DEP)
+%.c.o: %.c $(BINDIR) $(LOGDIR)
+	@echo -e $(TXTYLW)"\n\n" compile: $< $(TXTNOC)
+	$(call log_section_header,"COMPILE CC="${CCOMPILE},$(SYSTEM),$<,$(CC) $(shell $(call loadModules,$(C_COMPILER_MODULE),"shut up") $(C_VERSION)),$(notdir $(@:.o=.log)))
+	-$(QUIET)$(call loadModules,$(C_COMPILER_MODULE)) $(CCOMPILE) $(VERBOSE_MODE) $(DTHREADS) $(DTEAMS) $(HTHREADS) $< -o $(BINDIR)/$(notdir $@) $(if $(LOG),$(RECORD)$(notdir $(@:.o=.log))\
+		&& echo "PASS" > $(LOGTEMPFILE) \
+		|| echo "FAIL" > $(LOGTEMPFILE))
+	-$(call log_section_footer,"COMPILE CC="${CCOMPILE},$(SYSTEM),$$(cat $(LOGTEMPFILE)),$(LOG_NOTE),$(notdir $(@:.o=.log)))
+	-@$(if $(LOG), rm $(LOGTEMPFILE))
+
+# Special rule for test that needs OMPVV lib
+$(CURDIR)/tests/4.5/application_kernels/qmcpack_target_static_lib.c.o: $(CURDIR)/tests/4.5/application_kernels/qmcpack_target_static_lib.c $(BINDIR) $(LOGDIR) $(OMPVVLIB_DEP)
 	@echo -e $(TXTYLW)"\n\n" compile: $< $(TXTNOC)
 	$(call log_section_header,"COMPILE CC="${CCOMPILE},$(SYSTEM),$<,$(CC) $(shell $(call loadModules,$(C_COMPILER_MODULE),"shut up") $(C_VERSION)),$(notdir $(@:.o=.log)))
 	-$(QUIET)$(call loadModules,$(C_COMPILER_MODULE)) $(CCOMPILE) $(VERBOSE_MODE) $(DTHREADS) $(DTEAMS) $(HTHREADS) $< -o $(BINDIR)/$(notdir $@) $(OMPVVLIB) $(if $(LOG),$(RECORD)$(notdir $(@:.o=.log))\


### PR DESCRIPTION
By adding LINK_OMPVV_LIB=1 when using the Makefile, linking the static library can now be disabled. This is a quick patch for issue #148.

This will also remove the QMCPACK target static lib test from the list of sources when not using the SOURCES= flag.

Tested and working on Summit.