### PR TITLE
Add 5.0 test for mapping order

### DIFF
--- a/tests/5.0/target/test_target_mapping_before_alloc.c
+++ b/tests/5.0/target/test_target_mapping_before_alloc.c
@@ -1,0 +1,59 @@
+//===--- test_target_mapping_before_alloc.c ------------------------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// The description of the map clause was modified to clarify the mapping order when
+// multiple map-types are specified for a variable or structure members of a variable
+// on the same construct.
+//
+// For a given construct, the effect of a map clause with the to, from, or tofrom map-type
+// is ordered before the effect of a map clause with the alloc map-type.
+////===--------------------------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+int errors;
+
+int to_before_alloc() {
+
+  int i;
+  int scalar = 80;
+  int a[N];
+
+  struct {
+  int var;
+  int b[N];
+  } member; 
+
+  member.var = 1;
+  
+  for (i = 0; i < N; i++) { 
+    a[i] = i;
+    member.b[i] = i;
+  }
+
+#pragma omp target  map (alloc: scalar, a, member) map(to: scalar, a, member) 
+  {
+    if (scalar != 80 || a[1] != 2 || member.var != 1 || member.b[1] != 2) {
+      errors++;
+    }
+  }	 
+  return errors; 
+}
+
+int main () {
+  
+  int errors = 0;
+  
+  OMPVV_TEST_OFFLOADING;
+  OMPVV_TEST_AND_SET_VERBOSE(errors, to_before_alloc());
+  OMPVV_REPORT_AND_RETURN(errors);
+}
+
+
+

--- a/tests/5.0/target/test_target_mapping_before_delete.c
+++ b/tests/5.0/target/test_target_mapping_before_delete.c
@@ -58,6 +58,59 @@ int to_before_delete () {
 
 } 
 
+int to_from_before_delete(){
+
+  int x, y, z, i;
+  int scalar = 30;
+  int c[N];
+  int sum;
+
+  struct {
+    int var;
+    int d[N];
+  } member;
+
+  member.var = 1;
+
+  for (i = 0; i < N; i++) { 
+    c[i] = i;
+    sum += i;
+    member.d[i] = i;
+  }
+
+#pragma omp target map (tofrom: scalar, c, member) map (from: x, y, z) //map (delete: scalar, a, member)
+  {
+    x = scalar;
+    z += member.var;
+
+    for (i = 0; i < N; i++) {
+      y += c[i];
+      z += member.d[i];
+    }
+  }	 
+  
+  OMPVV_TEST_AND_SET_VERBOSE(errors, x != 30);
+  OMPVV_TEST_AND_SET_VERBOSE(errors, y != sum);
+  OMPVV_TEST_AND_SET_VERBOSE(errors, z != (sum + 1));
+
+  return errors;
+
+}
+
+ 
+int main () {
+  
+  int errors = 0;
+  
+  OMPVV_TEST_OFFLOADING;
+  OMPVV_TEST_AND_SET_VERBOSE(errors, to_before_delete());
+  //OMPVV_TEST_AND_SET_VERBOSE(errors, to_before_alloc());
+  OMPVV_TEST_AND_SET_VERBOSE(errors, to_from_before_delete());
+  OMPVV_REPORT_AND_RETURN(errors);
+}
+
+
+/*
 int to_before_alloc() {
 
   int i;
@@ -76,7 +129,7 @@ int to_before_alloc() {
     member.b[i] = i;
   }
 
-#pragma omp target map (alloc: scalar, a, member) (to: scalar, a, member) 
+#pragma omp target  map (alloc: scalar, a, member) map(to: scalar, a, member) 
   {
     if (scalar != 80 || a[1] != 2 || member.var != 1 || member.b[1] != 2) {
       errors++;
@@ -85,55 +138,4 @@ int to_before_alloc() {
   
   return errors; 
 }
-/*
-int to_from_before_delete(){
-
-  int x, y, z, i;
-  int scalar = 70;
-  int a[N];
-  int sum;
-
-  struct {
-    int var;
-    int b[N];
-  } member;
-
-  member.var = 1;
-
-  for (i = 0; i < N; i++) { 
-    a[i] = i;
-    sum += i;
-    member.b[i] = i;
-  }
-
-#pragma omp target map (tofrom: scalar, a, member) map (from: x, y, z) //(delete: scalar, a, member)
-  {
-    x = scalar;
-    z += member.var;
-
-    for (i = 0; i < N; i++) {
-      y += a[i];
-      z += member.b[i];
-    }
-  }	 
-  
-  OMPVV_TEST_AND_SET_VERBOSE(errors, x != 70);
-  OMPVV_TEST_AND_SET_VERBOSE(errors, y != sum);
-  OMPVV_TEST_AND_SET_VERBOSE(errors, z != (sum + 1));
-
-  return errors;
-
-}
 */
- 
-int main () {
-  
-  int errors = 0;
-  
-  OMPVV_TEST_OFFLOADING;
-  OMPVV_TEST_AND_SET_VERBOSE(errors, to_before_delete());
-  OMPVV_TEST_AND_SET_VERBOSE(errors, to_before_alloc());
- // OMPVV_TEST_AND_SET_VERBOSE(errors, to_from_before_delete());
-  OMPVV_REPORT_AND_RETURN(errors);
-
-}

--- a/tests/5.0/target/test_target_mapping_before_delete.c
+++ b/tests/5.0/target/test_target_mapping_before_delete.c
@@ -78,7 +78,7 @@ int to_from_before_delete(){
     member.d[i] = i;
   }
 
-#pragma omp target map (tofrom: scalar, c, member) map (from: x, y, z) map (delete: scalar, a, member)
+#pragma omp target map (tofrom: scalar, c, member) map (from: x, y, z) map (delete: scalar, c, member)
   {
     x = scalar;
     z += member.var;

--- a/tests/5.0/target/test_target_mapping_before_delete.c
+++ b/tests/5.0/target/test_target_mapping_before_delete.c
@@ -39,7 +39,7 @@ int to_before_delete () {
     member.b[i] = i;
   }
 
-#pragma omp target map (to: scalar, a, member) map (from: x, y, z) //(delete: scalar, a, member)
+#pragma omp target map (to: scalar, a, member) map (from: x, y, z) map(delete: scalar, a, member)
   {
     x = scalar;
     z += member.var;
@@ -78,7 +78,7 @@ int to_from_before_delete(){
     member.d[i] = i;
   }
 
-#pragma omp target map (tofrom: scalar, c, member) map (from: x, y, z) //map (delete: scalar, a, member)
+#pragma omp target map (tofrom: scalar, c, member) map (from: x, y, z) map (delete: scalar, a, member)
   {
     x = scalar;
     z += member.var;
@@ -89,7 +89,7 @@ int to_from_before_delete(){
     }
   }	 
   
-  OMPVV_TEST_AND_SET_VERBOSE(errors, x != 30);
+  OMPVV_TEST_AND_SET_VERBOSE(errors, x != 20);
   OMPVV_TEST_AND_SET_VERBOSE(errors, y != sum);
   OMPVV_TEST_AND_SET_VERBOSE(errors, z != (sum + 1));
 

--- a/tests/5.0/target/test_target_mapping_before_delete.c
+++ b/tests/5.0/target/test_target_mapping_before_delete.c
@@ -1,4 +1,4 @@
-//===--- test_target_mapping_order.c---------------------------------------------------------===//
+//===--- test_target_mapping_before_delete.c ------------------------------------------------===//
 //
 // OpenMP API Version 5.0 Nov 2018
 //
@@ -7,7 +7,7 @@
 // on the same construct.
 //
 // For a given construct, the effect of a map clause with the to, from, or tofrom map-type
-// is ordered before the effect of a map clause with the alloc, release, or delete map-type.
+// is ordered before the effect of a map clause with the delete map-type.
 ////===--------------------------------------------------------------------------------------===//
 
 #include <omp.h>
@@ -104,38 +104,7 @@ int main () {
   
   OMPVV_TEST_OFFLOADING;
   OMPVV_TEST_AND_SET_VERBOSE(errors, to_before_delete());
-  //OMPVV_TEST_AND_SET_VERBOSE(errors, to_before_alloc());
   OMPVV_TEST_AND_SET_VERBOSE(errors, to_from_before_delete());
   OMPVV_REPORT_AND_RETURN(errors);
 }
 
-
-/*
-int to_before_alloc() {
-
-  int i;
-  int scalar = 80;
-  int a[N];
-
-  struct {
-  int var;
-  int b[N];
-  } member; 
-
-  member.var = 1;
-  
-  for (i = 0; i < N; i++) { 
-    a[i] = i;
-    member.b[i] = i;
-  }
-
-#pragma omp target  map (alloc: scalar, a, member) map(to: scalar, a, member) 
-  {
-    if (scalar != 80 || a[1] != 2 || member.var != 1 || member.b[1] != 2) {
-      errors++;
-    }
-  }	 
-  
-  return errors; 
-}
-*/

--- a/tests/5.0/target/test_target_mapping_order.c
+++ b/tests/5.0/target/test_target_mapping_order.c
@@ -1,0 +1,72 @@
+//===--- test_target_mapping_order.c---------------------------------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// The description of the map clause was modified to clarify the mapping order when
+// multiple map-types are specified for a variable or structure members of a variable
+// on the same construct.
+//
+// For a given construct, the effect of a map clause with the to, from, or tofrom map-type
+// is ordered before the effect of a map clause with the alloc, release, or delete map-type.
+////===--------------------------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+int errors;
+
+int to_before_delete () {
+
+  int x, y, z, i;
+  int scalar = 70;
+
+  int a[N];
+  int sum;
+
+  struct {
+    int var;
+    int b[N];
+  } member;
+
+  for (i = 0; i < N; i++) { 
+    a[i] = i;
+    sum += i;
+    member.b[i] = i;
+  }
+
+  member.var = 1;
+
+
+
+#pragma omp target map (to: scalar, a, member) map (from: x, y, z) (delete: scalar, a, member)
+  {
+    x = scalar;
+    z += member.var;
+
+    for (i = 0; i < N; i++) {
+      y += a[i];
+      z += member.b[i];
+    }
+  }	 
+  
+  OMPVV_TEST_AND_SET_VERBOSE(errors, x != 70);
+  OMPVV_TEST_AND_SET_VERBOSE(errors, y != sum);
+  OMPVV_TEST_AND_SET_VERBOSE(errors, z != (sum + 1));
+
+  return errors;
+
+} 
+
+int main () {
+  
+  int errors = 0;
+  
+  OMPVV_TEST_OFFLOADING;
+  OMPVV_TEST_AND_SET_VERBOSE(errors, to_before_delete());
+  OMPVV_REPORT_AND_RETURN(errors);
+
+}

--- a/tests/5.0/target/test_target_mapping_order.c
+++ b/tests/5.0/target/test_target_mapping_order.c
@@ -85,7 +85,47 @@ int to_before_alloc() {
   
   return errors; 
 }
+/*
+int to_from_before_delete(){
 
+  int x, y, z, i;
+  int scalar = 70;
+  int a[N];
+  int sum;
+
+  struct {
+    int var;
+    int b[N];
+  } member;
+
+  member.var = 1;
+
+  for (i = 0; i < N; i++) { 
+    a[i] = i;
+    sum += i;
+    member.b[i] = i;
+  }
+
+#pragma omp target map (tofrom: scalar, a, member) map (from: x, y, z) //(delete: scalar, a, member)
+  {
+    x = scalar;
+    z += member.var;
+
+    for (i = 0; i < N; i++) {
+      y += a[i];
+      z += member.b[i];
+    }
+  }	 
+  
+  OMPVV_TEST_AND_SET_VERBOSE(errors, x != 70);
+  OMPVV_TEST_AND_SET_VERBOSE(errors, y != sum);
+  OMPVV_TEST_AND_SET_VERBOSE(errors, z != (sum + 1));
+
+  return errors;
+
+}
+*/
+ 
 int main () {
   
   int errors = 0;
@@ -93,6 +133,7 @@ int main () {
   OMPVV_TEST_OFFLOADING;
   OMPVV_TEST_AND_SET_VERBOSE(errors, to_before_delete());
   OMPVV_TEST_AND_SET_VERBOSE(errors, to_before_alloc());
+ // OMPVV_TEST_AND_SET_VERBOSE(errors, to_from_before_delete());
   OMPVV_REPORT_AND_RETURN(errors);
 
 }

--- a/tests/5.0/target/test_target_mapping_order.c
+++ b/tests/5.0/target/test_target_mapping_order.c
@@ -23,7 +23,6 @@ int to_before_delete () {
 
   int x, y, z, i;
   int scalar = 70;
-
   int a[N];
   int sum;
 
@@ -32,17 +31,15 @@ int to_before_delete () {
     int b[N];
   } member;
 
+  member.var = 1;
+
   for (i = 0; i < N; i++) { 
     a[i] = i;
     sum += i;
     member.b[i] = i;
   }
 
-  member.var = 1;
-
-
-
-#pragma omp target map (to: scalar, a, member) map (from: x, y, z) (delete: scalar, a, member)
+#pragma omp target map (to: scalar, a, member) map (from: x, y, z) //(delete: scalar, a, member)
   {
     x = scalar;
     z += member.var;
@@ -61,12 +58,41 @@ int to_before_delete () {
 
 } 
 
+int to_before_alloc() {
+
+  int i;
+  int scalar = 80;
+  int a[N];
+
+  struct {
+  int var;
+  int b[N];
+  } member; 
+
+  member.var = 1;
+  
+  for (i = 0; i < N; i++) { 
+    a[i] = i;
+    member.b[i] = i;
+  }
+
+#pragma omp target map (alloc: scalar, a, member) (to: scalar, a, member) 
+  {
+    if (scalar != 80 || a[1] != 2 || member.var != 1 || member.b[1] != 2) {
+      errors++;
+    }
+  }	 
+  
+  return errors; 
+}
+
 int main () {
   
   int errors = 0;
   
   OMPVV_TEST_OFFLOADING;
   OMPVV_TEST_AND_SET_VERBOSE(errors, to_before_delete());
+  OMPVV_TEST_AND_SET_VERBOSE(errors, to_before_alloc());
   OMPVV_REPORT_AND_RETURN(errors);
 
 }


### PR DESCRIPTION
Tested on Obiwan with aomp, passes without delete clause. Need to decide whether to rename this test test_target_mapping_to_before_delete.c or to make this a very large test. Also, is /target appropriate directory?