### PR TITLE
Mutiple fixes

### DIFF
--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_bitand.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_bitand.F90
@@ -17,8 +17,6 @@ PROGRAM test_target_teams_distribute_device
   USE ompvv_lib
   USE omp_lib
   implicit none
-  INTEGER :: errors
-  errors = 0
 
   OMPVV_TEST_OFFLOADING
 

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_bitand.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_bitand.F90
@@ -33,6 +33,7 @@ CONTAINS
     LOGICAL:: tested_true, tested_false
     REAL(8):: false_margin
     result = 0
+    errors = 0
 
     tested_true = .FALSE.
     tested_false = .FALSE.

--- a/tests/4.5/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_firstprivate.c
+++ b/tests/4.5/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_firstprivate.c
@@ -42,7 +42,7 @@ int test_target_teams_distribute_parallel_for_firstprivate() {
   // check multiple sizes. 
 #pragma omp target data map(to: a[0:SIZE_N], b[0:SIZE_N], c[0:SIZE_N])
   {
-#pragma omp target teams distribute parallel for firstprivate(privatized, firstized) num_teams(10) num_threads(256)
+#pragma omp target teams distribute parallel for firstprivate(privatized, firstized, i) num_teams(10) num_threads(256)
       for (j = 0; j < SIZE_N; ++j) {
         reported_num_teams[j] = omp_get_num_teams();
         reported_num_threads[j] = omp_get_num_threads();

--- a/tests/4.5/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_private.c
+++ b/tests/4.5/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_private.c
@@ -45,8 +45,8 @@ int test_target_teams_distribute_parallel_for_private() {
   {
 #pragma omp target teams distribute parallel for private(privatized) num_threads(OMPVV_NUM_THREADS_DEVICE) num_teams(OMPVV_NUM_TEAMS_DEVICE)
     for (j = 0; j < SIZE_N; ++j) {
-      num_teams[i] = omp_get_num_teams();
-      num_threads[i] = omp_get_num_threads();
+      num_teams[j] = omp_get_num_teams();
+      num_threads[j] = omp_get_num_threads();
 
       privatized = 0;
       for (i = 0; i < a[j] + b[j]; ++i) {

--- a/tests/4.5/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_private.c
+++ b/tests/4.5/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_private.c
@@ -43,7 +43,7 @@ int test_target_teams_distribute_parallel_for_private() {
   // check multiple sizes.
 #pragma omp target data map(to: a[0:SIZE_N], b[0:SIZE_N], c[0:SIZE_N]) map(from: d[0:SIZE_N])
   {
-#pragma omp target teams distribute parallel for private(privatized) num_threads(OMPVV_NUM_THREADS_DEVICE) num_teams(OMPVV_NUM_TEAMS_DEVICE)
+#pragma omp target teams distribute parallel for private(privatized, i) num_threads(OMPVV_NUM_THREADS_DEVICE) num_teams(OMPVV_NUM_TEAMS_DEVICE)
     for (j = 0; j < SIZE_N; ++j) {
       num_teams[j] = omp_get_num_teams();
       num_threads[j] = omp_get_num_threads();

--- a/tests/5.0/target_teams_distribute/test_target_teams_distribute_reduction_bitand.F90
+++ b/tests/5.0/target_teams_distribute/test_target_teams_distribute_reduction_bitand.F90
@@ -33,6 +33,7 @@ CONTAINS
     LOGICAL:: tested_true, tested_false
     REAL(8):: false_margin
     result = 0
+    errors = 0
 
     tested_true = .FALSE.
     tested_false = .FALSE.


### PR DESCRIPTION
Hi guys,

a couple of small fixes:

- Two of the tests declare the "errors" variable within the CONTAINS scope but they are never initialized.
- Used wrong index variable within for-loop
- Inner loop variable should be privatized as it is shared within the parallel region.

Let me know if you agree.

Thanks!
Simone