### PR TITLE
Add test for declare variant directive

### DIFF
--- a/tests/5.0/declare_variant/test_declare_variant.c
+++ b/tests/5.0/declare_variant/test_declare_variant.c
@@ -1,0 +1,75 @@
+//===--- test_declare_variant.c ---------------------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// This test uses the declare variant clause to create two variants of a
+// simple base function, one for use in a parallel region, and one for use
+// in a target region. The function sets each element of an array to its
+// index. Each variant is called on a separate array and the results are
+// checked.
+//
+////===----------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+void p_fn(int *arr);
+void t_fn(int *arr);
+
+#pragma omp declare variant(p_fn) match(construct = {parallel})
+#pragma omp declare variant(t_fn) match(construct = {target})
+void fn(int *arr) {              // base for use on the host in sequence
+  for (int i = 0; i < N; i++) {
+    arr[i] = i;
+  }
+}
+
+void p_fn(int *arr) {            // variant for use on host in parallel
+#pragma omp for
+  for (int i = 0; i < N; i++) {
+    arr[i] = i;
+  }
+}
+
+#pragma omp declare target
+void t_fn(int *arr) {            // variant for use on target
+#pragma omp distribute
+  for (int i = 0; i < N; i++) {
+    arr[i] = i;
+  }
+}
+
+int main() {
+  OMPVV_TEST_OFFLOADING;
+
+  int errors = 0;
+  int a[N], b[N], c[N];
+
+  for (int i = 0; i < N; i++) {
+    a[i] = 0;
+    b[i] = 0;
+    c[i] = 0;
+  }
+
+  fn(a);
+
+#pragma omp parallel
+  {
+    fn(b);
+  }
+
+#pragma omp target teams map(tofrom: c[0:N])
+  {
+    fn(c);
+  }
+
+  for (int i = 0; i < N; i++) {
+    OMPVV_TEST_AND_SET_VERBOSE(errors, a[i] != i || b[i] != i || c[i] != i);
+  }
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.0/declare_variant/test_declare_variant.c
+++ b/tests/5.0/declare_variant/test_declare_variant.c
@@ -31,7 +31,7 @@ void fn(int *arr) {              // base for use on the host in sequence
 void p_fn(int *arr) {            // variant for use on host in parallel
 #pragma omp for
   for (int i = 0; i < N; i++) {
-    arr[i] = i;
+    arr[i] = i + 1;
   }
 }
 
@@ -39,7 +39,7 @@ void p_fn(int *arr) {            // variant for use on host in parallel
 void t_fn(int *arr) {            // variant for use on target
 #pragma omp distribute
   for (int i = 0; i < N; i++) {
-    arr[i] = i;
+    arr[i] = i + 2;
   }
 }
 
@@ -68,7 +68,7 @@ int main() {
   }
 
   for (int i = 0; i < N; i++) {
-    OMPVV_TEST_AND_SET_VERBOSE(errors, a[i] != i || b[i] != i || c[i] != i);
+    OMPVV_TEST_AND_SET_VERBOSE(errors, a[i] != i || b[i] != (i + 1) || c[i] != (i + 2));
   }
 
   OMPVV_REPORT_AND_RETURN(errors);


### PR DESCRIPTION
Partially derived from the 5.0 examples document, this test checks the declare variant clause (with the match(context-selector-specification)). It creates two variants of a simple base function for use in target and parallel regions, and tests that the variants are used correctly.

This test does not compile on any Summit compiler due to lack of support for the declare variant feature.