### PR TITLE
 Adding in STOP to handle exit codes for Fortran tests 

### DIFF
--- a/ompvv/ompvv.F90
+++ b/ompvv/ompvv.F90
@@ -85,9 +85,9 @@
 #define OMPVV_SET_ERRORS(err) call set_errors(err)
 
 ! Macro for correct exit code
-#define OMPVV_RETURN(err) CALL EXIT(MERGE(EXIT_SUCCESS, EXIT_FAILURE, err == 0))
+#define OMPVV_RETURN(err) if( err .ne. 0) stop EXIT_FAILURE
 
-#define OMPVV_REPORT_AND_RETURN() CALL EXIT(MERGE(EXIT_SUCCESS, EXIT_FAILURE,  report_and_set_errors(__FILENAME__) == 0))
+#define OMPVV_REPORT_AND_RETURN() if( report_and_set_errors(__FILENAME__) .ne. 0) stop EXIT_FAILURE
 
 ! Macro to report warning if it is a shared environment
 #define OMPVV_TEST_SHARED_ENVIRONMENT call test_shared_environment(__FILENAME__, __LINE__)

--- a/tests/4.5/offloading_success.F90
+++ b/tests/4.5/offloading_success.F90
@@ -20,6 +20,6 @@ implicit none
     print*, "Target region executed on the device"
   END IF
 
-  CALL EXIT(errors)
+  if( errors .ne. 0 ) stop 1
 
 END PROGRAM offloading_success

--- a/tests/5.0/target_teams_distribute/test_target_teams_distribute_reduction_bitand.F90
+++ b/tests/5.0/target_teams_distribute/test_target_teams_distribute_reduction_bitand.F90
@@ -79,8 +79,8 @@ CONTAINS
        itr_count = itr_count + 1
     END DO
 
-    OMPVV_TEST_AND_SET_VERBOSE(.NOT. tested_true, "Did not test true case")
-    OMPVV_TEST_AND_SET_VERBOSE(.NOT. tested_false, "Did not test false case")
+    OMPVV_WARNING_IF(.NOT. tested_true, "Did not test true case")
+    OMPVV_WARNING_IF(.NOT. tested_false, "Did not test false case")
 
     test_bitand = errors
   END FUNCTION test_bitand


### PR DESCRIPTION
This contains a proposed solution to Issue #168, since it has been bothering me when running with IBM compilers. (In general, I think using exit codes to see if something passed or failed is really useful.)

The PR changes  `ompvv/ompvv.F90` and `tests/4.5/offloading_success.F90 ` to use `stop [number]` when the test fails. As mentioned in Issue #168, `call exit()` isn't part of the Fortran standard, and IBM doesn't seem to have an extension for it. So with IBM compilers, the tests will pass but have weird exit codes. Using `stop` is a solution.
One difference between the original code and this is that here if the run is successful, it exits by itself, (not `call exit(0)`).  

`tests/5.0/target_teams_distribute/test_target_teams_distribute_reduction_bitand.F90 ` I changed since the I think the syntax was wrong. Left as is, we get a compile-time error like:
```
"/home/bertoni/tmp/sollve_vv/tests/5.0/target_teams_distribute/test_target_teams_distribute_reduction_bitand.F90", line 83.5: 1515-019 (S) Syntax is incorrect.
"/home/bertoni/tmp/sollve_vv/tests/5.0/target_teams_distribute/test_target_teams_distribute_reduction_bitand.F90", line 83.68: 1513-061 (S) Actual argument attributes do not match those specified by an accessible explicit interface. 
```
I changed it to match `test_target_teams_distribute_reduction_bitor.F90`, feel free to adjust if this is wrong. Or I can submit it as another PR.

Alternatively, if you know anyone on the Fortran standard committee, please lobby them to add `call exit(error_code)` to the standard! ;) 