### PR TITLE
Issue 178: Remove defaultmap from test_teams_distribute_default_none.c

### DIFF
--- a/tests/5.0/teams/test_teams_distribute_default_none.c
+++ b/tests/5.0/teams/test_teams_distribute_default_none.c
@@ -56,7 +56,7 @@ int main() {
     }
   }
 
-#pragma omp teams distribute num_teams(4) default(none) shared(share, b, num_teams) defaultmap(tofrom:scalar)
+#pragma omp teams distribute num_teams(4) default(none) shared(share, b, num_teams)
     for (int x = 0; x < N; ++x) {
 #pragma omp atomic update
       share = share + b[x];


### PR DESCRIPTION
Issue #178
* tests/5.0/teams/test_teams_distribute_default_none.c: Remove invalid
  defaultmap clause, valid for target only, from an 'omp teams' construct.