### PR TITLE
Issue 177: Fix test_target_teams_distribute_reduction_neqv.F90

### DIFF
--- a/tests/5.0/target_teams_distribute/test_target_teams_distribute_reduction_neqv.F90
+++ b/tests/5.0/target_teams_distribute/test_target_teams_distribute_reduction_neqv.F90
@@ -54,7 +54,7 @@ CONTAINS
           result = a(x) .neqv. result
        END DO
 
-       OMPVV_TEST_AND_SET_VERBOSE(errors, result .ne. host_result)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, result .neqv. host_result)
     END DO
 
     test_neqv = errors


### PR DESCRIPTION
Issue #177
* tests/5.0/target_teams_distribute/test_target_teams_distribute_reduction_neqv.F90:
  Use '.neqv.' instead of '.ne.' for logical comparisons.