### PR TITLE
Issue 183: test_declare_variant.c add 'end declare target'

### DIFF
--- a/tests/5.0/declare_variant/test_declare_variant.c
+++ b/tests/5.0/declare_variant/test_declare_variant.c
@@ -42,6 +42,7 @@ void t_fn(int *arr) {            // variant for use on target
     arr[i] = i + 2;
   }
 }
+#pragma omp end declare target
 
 int main() {
   OMPVV_TEST_OFFLOADING;


### PR DESCRIPTION
Issue #183
* tests/5.0/declare_variant/test_declare_variant.c: Add missing
  'omp end declare target'.