### PR TITLE
test_target_mapping_before_delete.c: Fix expected value

### DIFF
--- a/tests/5.0/target/test_target_mapping_before_delete.c
+++ b/tests/5.0/target/test_target_mapping_before_delete.c
@@ -89,7 +89,7 @@ int to_from_before_delete(){
     }
   }	 
   
-  OMPVV_TEST_AND_SET_VERBOSE(errors, x != 20);
+  OMPVV_TEST_AND_SET_VERBOSE(errors, x != 30);
   OMPVV_TEST_AND_SET_VERBOSE(errors, y != sum);
   OMPVV_TEST_AND_SET_VERBOSE(errors, z != (sum + 1));
 


### PR DESCRIPTION
Issue #185
* tests/5.0/target/test_target_mapping_before_delete.c
  (to_from_before_delete): Check with the same value the 'x' value
  as the the one has been used for 'scalar' before 'x = scalar'.