### PR TITLE
Makefile: Make find more robust, silence git error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,11 +139,11 @@ endif
 ifeq "$(SOURCES)" ""
 # Getting all the source files in the project
 ifdef LINK_OMPVV_LIB
-SOURCES_C := $(shell find $(CURDIR)/tests/$(OMP_VERSION) -name *.c)
+SOURCES_C := $(shell find $(CURDIR)/tests/$(OMP_VERSION) -name "*.c")
 else
-SOURCES_C := $(shell find $(CURDIR)/tests/$(OMP_VERSION) ! -name qmcpack_target_static_lib.c -name *.c)
+SOURCES_C := $(shell find $(CURDIR)/tests/$(OMP_VERSION) ! -name qmcpack_target_static_lib.c -name "*.c")
 endif
-SOURCES_CPP := $(shell find $(CURDIR)/tests/$(OMP_VERSION) -name *.cpp)
+SOURCES_CPP := $(shell find $(CURDIR)/tests/$(OMP_VERSION) -name "*.cpp")
 SOURCES_F := $(shell find $(CURDIR)/tests/$(OMP_VERSION) -name "*.F90" -o -name "*.F95" -o -name "*.F03" -o -name "*.F" -o -name "*.FOR" | grep -v "ompvv.F90")
 
 # Find all the binary files that have been previously compiled

--- a/sys/make/make.def
+++ b/sys/make/make.def
@@ -42,7 +42,7 @@ endef
 ##################################################
 
 # Check if we are working on a git folder
-OMPVV_IS_GIT=${shell git rev-parse --is-inside-work-tree}
+OMPVV_IS_GIT=${shell git rev-parse --is-inside-work-tree 2> /dev/null}
 ifeq ("${OMPVV_IS_GIT}", "true")
   OMPVV_GIT_COMMIT=${shell git log -n 1 --pretty=format:%h}
 else


### PR DESCRIPTION
	* Makefile (SOURCE_C, SOURCE_CPP): Quote -name arg of find.
	* sys/make/make.def (OMPVV_IS_GIT): Redirect errors to /dev/null.