### PR TITLE
Issue 187: test_target_data_use_device_addr: nested 'map' inside 'dat…

### DIFF
--- a/tests/5.0/target_data/test_target_data_use_device_addr.c
+++ b/tests/5.0/target_data/test_target_data_use_device_addr.c
@@ -23,10 +23,13 @@ int main() {
 
   OMPVV_TEST_OFFLOADING;
 
-#pragma omp target data map(to: device_data) use_device_addr(device_data)
+#pragma omp target data map(to: device_data)
     {
         int *dev_ptr;
-        dev_ptr = &device_data;
+#pragma omp target data use_device_addr(device_data)
+      {
+          dev_ptr = &device_data;
+      }
 #pragma omp target map(to:device_data) map(tofrom: errors) map(from: host_data) is_device_ptr(dev_ptr)
       {
           if(&device_data != dev_ptr)


### PR DESCRIPTION
…a target use_device_addr'

Issue #187

Unless 'requires unified_shared_memory' is fulfilled, a variable (or list-item)
which was in a use_device_addr of a data block cannot be directly used in an
enclosed target section; it would work with OpenMP TR9's/5.1's has_device_addr,
but not with 5.0. Hence, use a separate 'target data' for use_device_addr.

* tests/5.0/target_data/test_target_data_use_device_addr.c:
	Move 'use_device_data' usage into a separate 'omp target data'.