### PR TITLE
Fix minor issues in test_target_update_mapper_to_discontiguous.c

### DIFF
--- a/tests/5.0/target_update/test_target_update_mapper_to_discontiguous.c
+++ b/tests/5.0/target_update/test_target_update_mapper_to_discontiguous.c
@@ -41,7 +41,7 @@ int target_update_to_mapper() {
     s.data[i] = i;
   }
 
-#pragma omp target update to(mapper(v))
+#pragma omp target update to(s)
 
 #pragma omp target map(tofrom: errors)
 {
@@ -58,7 +58,7 @@ int target_update_to_mapper() {
 
 int main() {
   
-  OMPVV_TEST_OFFlOADING;
+  OMPVV_TEST_OFFLOADING;
   
   int errors = 0;
   OMPVV_TEST_AND_SET_VERBOSE(errors, target_update_to_mapper());


### PR DESCRIPTION
The mapper declared on line 28 is not given an explicit name, and therefore should have the name `default` per the OpenMP 5.0 spec (section 2.19.7.3):
> If the _mapper-identifier_ is not specified, then `default` is used.

Since there is no mapper with the name `v`, the `to` clause on line 44 is non-conforming. The spec (section 2.12.6) seems to indicate two possibilities for this situation: `to(mapper(default): v)` and `to(v)`. The latter was chosen for its brevity.

I also corrected a small typo in a macro name.