### PR TITLE
Issue 195: Fix test_declare_target_nested.c syntax

### DIFF
--- a/tests/5.0/declare_target/test_declare_target_nested.c
+++ b/tests/5.0/declare_target/test_declare_target_nested.c
@@ -32,13 +32,12 @@ int test_target() { //function in declare target statement
 
 //change values on device
 #pragma omp parallel for 
-{
   for (i = 0; i < N; i++) {
     a[i] = 5;
     b[i] = 10;
     c[i] = 15;
   }
-}
+
   //confirm updated values on host
   for (i = 0; i < N; i++) {
     if ( a[i] != 5 || b[i] != 10 || c[i] != 15) {


### PR DESCRIPTION
Issue #195
* tests/5.0/declare_target/test_declare_target_nested.c
	(test_target): Remove invalid '{' enclosing for-loop.