### PR TITLE
test_declare_target_nested.c globals must be declared for target

### DIFF
--- a/tests/5.0/declare_target/test_declare_target_nested.c
+++ b/tests/5.0/declare_target/test_declare_target_nested.c
@@ -52,7 +52,13 @@ int test_wrapper() { //wrapper for declare target function
   {
     test_target();
   }
-  #pragma omp target update from(errors)
+  #pragma omp target update from(errors, a, b, c)
+  
+  for (i = 0; i < N; i++) { //check array values on host
+    if ( a[i] != 5 || b[i] != 10 || c[i] != 15) {
+      errors++;  
+    } 
+  }
   return errors;
 }
 

--- a/tests/5.0/declare_target/test_declare_target_nested.c
+++ b/tests/5.0/declare_target/test_declare_target_nested.c
@@ -21,13 +21,13 @@
 
 #pragma omp declare target
 int a[N], b[N], c[N]; // implicit map 3 variables 
+int errors = 0;
+int i = 0;
   #pragma omp declare target
      int test_target();
   #pragma omp end declare target
 #pragma omp end declare target
 
-int errors = 0;
-int i = 0;
 int test_target() { //function in declare target statement 
 
 //change values on device
@@ -39,7 +39,7 @@ int test_target() { //function in declare target statement
     c[i] = 15;
   }
 }
-  //confirm updated values on host
+
   for (i = 0; i < N; i++) {
     if ( a[i] != 5 || b[i] != 10 || c[i] != 15) {
       errors++;  
@@ -54,6 +54,7 @@ int test_wrapper() { //wrapper for declare target function
   {
     test_target();
   }
+  #pragma omp target update from(errors)
   return errors;
 }
 


### PR DESCRIPTION
The `test_declare_target_nested.c` test declares global variables `int i, error` after the `end declare target` pragma. However, these variables are subsequently used from `int test_target()`, which is called from inside of a `target` region. In order to use these variables from the target device, they should be declared for the target first. Furthermore, since the `errors` variable is used by both the host and the target, its value must be copied back to the host before being returned.

I also noticed that `int test_target()` is called from a target region (and therefore may be offloaded from the host), so the comment

    //confirm updated values on host

is not accurate since this check happens on the target.

Fixes #200 