### PR TITLE
New feature/target thread team macros (for issue #22)

### DIFF
--- a/tests/4.5/target/test_target_firstprivate.F90
+++ b/tests/4.5/target/test_target_firstprivate.F90
@@ -25,7 +25,7 @@ PROGRAM test_target_firstprivate
 
 CONTAINS
   INTEGER FUNCTION test_target_firstprivate_clause()
-    INTEGER :: compute_array(N,OMPVV_NUM_THREADS_DEVICE)
+    INTEGER :: compute_array(N,OMPVV_NUM_THREADS_HOST)
     INTEGER :: p_val
     INTEGER :: actualThreadCnt = 0
     CHARACTER(len=400) :: messageHelper
@@ -34,7 +34,7 @@ CONTAINS
 
     compute_array(:,:) = 0
 
-    call omp_set_num_threads(OMPVV_NUM_THREADS_DEVICE)
+    call omp_set_num_threads(OMPVV_NUM_THREADS_HOST)
     !$omp parallel private(p_val) shared(actualThreadCnt)
     ! each p_val is private to a thread
     p_val = omp_get_thread_num() + 1

--- a/tests/4.5/target/test_target_firstprivate.F90
+++ b/tests/4.5/target/test_target_firstprivate.F90
@@ -1,5 +1,5 @@
 !===---- test_target_firstprivate.F90 -  -----------------------------------===//
-! 
+!
 ! OpenMP API Version 4.5 Nov 2015
 !
 ! test for the firstprivate clause used inside the target construct. This clause
@@ -7,64 +7,62 @@
 ! create a private storage location per thread
 !
 !===----------------------------------------------------------------------===//
-#include "ompvv.F90" 
+#include "ompvv.F90"
 
 #define N 10
-#define NUM_THREADS_TEST 10
-      PROGRAM test_target_firstprivate
-        USE iso_fortran_env
-        USE ompvv_lib
-        USE omp_lib
-        implicit none
-        
-        OMPVV_TEST_OFFLOADING
-        OMPVV_TEST_VERBOSE(test_target_firstprivate_clause() .ne. 0)
 
-        OMPVV_REPORT_AND_RETURN()
+PROGRAM test_target_firstprivate
+  USE iso_fortran_env
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
 
+  OMPVV_TEST_OFFLOADING
+  OMPVV_TEST_VERBOSE(test_target_firstprivate_clause() .ne. 0)
 
-        CONTAINS 
-          INTEGER FUNCTION test_target_firstprivate_clause()
-            INTEGER :: compute_array(N,NUM_THREADS_TEST)
-            INTEGER :: p_val
-            INTEGER :: actualThreadCnt = 0
-            CHARACTER(len=400) :: messageHelper
-
-            OMPVV_INFOMSG("Testing firstprivate clause with target")
-            
-            compute_array(:,:) = 0
-
-            call omp_set_num_threads(NUM_THREADS_TEST)
-            !$omp parallel private(p_val) shared(actualThreadCnt)
-              ! each p_val is private to a thread
-              p_val = omp_get_thread_num() + 1
-              actualThreadCnt = omp_get_num_threads()
-              !$omp target map(tofrom:compute_array(:, p_val)) firstprivate(p_val)
-                ! the p_val should be private and initialized to the p_val
-                ! before the target region
-                compute_array(:,p_val) = 100
-                ! Testing the privatization
-                p_val = p_val + 1
-              !$omp end target
-              ! Testing that the target region did not modify the original value
-              ! of p_val
-              IF (p_val == omp_get_thread_num() + 1) THEN
-                compute_array(:, p_val) = compute_array(:, p_val) + 1
-              END IF
-            !$omp end parallel 
-
-            WRITE(messageHelper, '(A,I0,A,I0)') "Test ran with ", &
-            actualThreadCnt, " threads out of ", omp_get_thread_limit()
-            OMPVV_INFOMSG(messageHelper)
-
-            WRITE(messageHelper, *) "The number of threads in the &
-            & host is 1. Test is inconclusive"
-            OMPVV_WARNING_IF(actualThreadCnt <= 1, messageHelper)
-
-            OMPVV_TEST_VERBOSE(ANY(compute_array(:,1:actualThreadCnt) /= 101))
-
-            OMPVV_GET_ERRORS(test_target_firstprivate_clause)
-          END FUNCTION test_target_firstprivate_clause
-      END PROGRAM test_target_firstprivate
+  OMPVV_REPORT_AND_RETURN()
 
 
+CONTAINS
+  INTEGER FUNCTION test_target_firstprivate_clause()
+    INTEGER :: compute_array(N,OMPVV_NUM_THREADS_DEVICE)
+    INTEGER :: p_val
+    INTEGER :: actualThreadCnt = 0
+    CHARACTER(len=400) :: messageHelper
+
+    OMPVV_INFOMSG("Testing firstprivate clause with target")
+
+    compute_array(:,:) = 0
+
+    call omp_set_num_threads(OMPVV_NUM_THREADS_DEVICE)
+    !$omp parallel private(p_val) shared(actualThreadCnt)
+    ! each p_val is private to a thread
+    p_val = omp_get_thread_num() + 1
+    actualThreadCnt = omp_get_num_threads()
+    !$omp target map(tofrom:compute_array(:, p_val)) firstprivate(p_val)
+    ! the p_val should be private and initialized to the p_val
+    ! before the target region
+    compute_array(:,p_val) = 100
+    ! Testing the privatization
+    p_val = p_val + 1
+    !$omp end target
+    ! Testing that the target region did not modify the original value
+    ! of p_val
+    IF (p_val == omp_get_thread_num() + 1) THEN
+       compute_array(:, p_val) = compute_array(:, p_val) + 1
+    END IF
+    !$omp end parallel
+
+    WRITE(messageHelper, '(A,I0,A,I0)') "Test ran with ", &
+         actualThreadCnt, " threads out of ", omp_get_thread_limit()
+    OMPVV_INFOMSG(messageHelper)
+
+    WRITE(messageHelper, *) "The number of threads in the &
+         & host is 1. Test is inconclusive"
+    OMPVV_WARNING_IF(actualThreadCnt <= 1, messageHelper)
+
+    OMPVV_TEST_VERBOSE(ANY(compute_array(:,1:actualThreadCnt) /= 101))
+
+    OMPVV_GET_ERRORS(test_target_firstprivate_clause)
+  END FUNCTION test_target_firstprivate_clause
+END PROGRAM test_target_firstprivate

--- a/tests/4.5/target/test_target_firstprivate.c
+++ b/tests/4.5/target/test_target_firstprivate.c
@@ -19,9 +19,11 @@ int main() {
 
   OMPVV_TEST_OFFLOADING;
 
-  for (i=0; i<OMPVV_NUM_THREADS_HOST; i++)
-    for (j=0; j<N; j++)
+  for (i=0; i<OMPVV_NUM_THREADS_HOST; i++) {
+    for (j=0; j<N; j++) {
       compute_array[i][j] = 0;
+    }
+  }
 
   omp_set_num_threads(OMPVV_NUM_THREADS_HOST);
 #pragma omp parallel private(i)

--- a/tests/4.5/target/test_target_firstprivate.c
+++ b/tests/4.5/target/test_target_firstprivate.c
@@ -1,5 +1,5 @@
 //===--test_target_firstprivate.c ------------------------------------------------===//
-// 
+//
 // OpenMP API Version 4.5 Nov 2015
 //
 //Testing first private clause with target directive
@@ -10,43 +10,42 @@
 #include "ompvv.h"
 
 #define N 10
-#define NUM_THREADS 10
 
 int main() {
-  int compute_array[NUM_THREADS][N];
+  int compute_array[OMPVV_NUM_THREADS_DEVICE][N];
   int errors = 0;
   int i,j;
   int actualNumThreads;
 
   OMPVV_TEST_OFFLOADING;
- 
-  for (i=0; i<NUM_THREADS; i++) 
-    for (j=0; j<N; j++) 
+
+  for (i=0; i<OMPVV_NUM_THREADS_DEVICE; i++)
+    for (j=0; j<N; j++)
       compute_array[i][j] = 0;
 
-  omp_set_num_threads(NUM_THREADS);
+  omp_set_num_threads(OMPVV_NUM_THREADS_DEVICE);
 #pragma omp parallel private(i)
-{
-  int p_val = omp_get_thread_num();
-  actualNumThreads = omp_get_num_threads();
+  {
+    int p_val = omp_get_thread_num();
+    actualNumThreads = omp_get_num_threads();
 
 #pragma omp target map(tofrom:compute_array[p_val:1][0:N]) firstprivate(p_val)
-  {
-    for (i = 0; i < N; i++)
-      compute_array[p_val][i] = 100;
-    // Checking if the value is not copied back
-    p_val++;
-  } // End target
+    {
+      for (i = 0; i < N; i++)
+        compute_array[p_val][i] = 100;
+      // Checking if the value is not copied back
+      p_val++;
+    } // End target
 
-  // Checking the results 
-  if (p_val == omp_get_thread_num()) {
-    for (i = 0; i < N; i++)
-      compute_array[p_val][i]++;
-  }
-} //end-parallel
+    // Checking the results
+    if (p_val == omp_get_thread_num()) {
+      for (i = 0; i < N; i++)
+        compute_array[p_val][i]++;
+    }
+  } //end-parallel
 
   OMPVV_WARNING_IF(actualNumThreads == 1, "The number of threads in the host is 1. This tests is inconclusive");
-  for (i=0; i<actualNumThreads; i++){ 
+  for (i=0; i<actualNumThreads; i++) {
     for (j=0; j<N; j++){
       OMPVV_TEST_AND_SET(errors, compute_array[i][j] != 101);
       OMPVV_ERROR_IF(compute_array[i][j] == 100, "p_val changed after target region for thread %d",i);

--- a/tests/4.5/target/test_target_firstprivate.c
+++ b/tests/4.5/target/test_target_firstprivate.c
@@ -12,18 +12,18 @@
 #define N 10
 
 int main() {
-  int compute_array[OMPVV_NUM_THREADS_DEVICE][N];
+  int compute_array[OMPVV_NUM_THREADS_HOST][N];
   int errors = 0;
   int i,j;
   int actualNumThreads;
 
   OMPVV_TEST_OFFLOADING;
 
-  for (i=0; i<OMPVV_NUM_THREADS_DEVICE; i++)
+  for (i=0; i<OMPVV_NUM_THREADS_HOST; i++)
     for (j=0; j<N; j++)
       compute_array[i][j] = 0;
 
-  omp_set_num_threads(OMPVV_NUM_THREADS_DEVICE);
+  omp_set_num_threads(OMPVV_NUM_THREADS_HOST);
 #pragma omp parallel private(i)
   {
     int p_val = omp_get_thread_num();

--- a/tests/4.5/target/test_target_private.F90
+++ b/tests/4.5/target/test_target_private.F90
@@ -22,7 +22,7 @@ PROGRAM test_target_private
 
 CONTAINS
   INTEGER FUNCTION test_target_private_clause()
-    INTEGER :: compute_array(N,OMPVV_NUM_THREADS_DEVICE)
+    INTEGER :: compute_array(N,OMPVV_NUM_THREADS_HOST)
     INTEGER :: actualThreadCnt = 0
     INTEGER :: errors, i, j, p_val, fp_val
     CHARACTER(len=400) :: messageHelper
@@ -30,7 +30,7 @@ CONTAINS
     compute_array(:,:) = 0
     errors = 0
 
-    CALL omp_set_num_threads(OMPVV_NUM_THREADS_DEVICE)
+    CALL omp_set_num_threads(OMPVV_NUM_THREADS_HOST)
 
     !$omp parallel private(p_val, fp_val) shared(actualThreadCnt)
     fp_val = omp_get_thread_num() + 1

--- a/tests/4.5/target/test_target_private.F90
+++ b/tests/4.5/target/test_target_private.F90
@@ -1,5 +1,5 @@
 !===--test_target_private.F90 - private clause in the target construct --===!
-! 
+!
 ! OpenMP API Version 4.5 Nov 2015
 !
 ! Testing the private functionality when used in the target construct
@@ -8,58 +8,56 @@
 #include "ompvv.F90"
 
 #define N 1000
-#define NUM_THREADS 10
 
-      PROGRAM test_target_private
-        USE iso_fortran_env
-        USE ompvv_lib
-        USE omp_lib
-        implicit none
-        
-        OMPVV_TEST_OFFLOADING
-        OMPVV_TEST_VERBOSE(test_target_private_clause() .ne. 0)
+PROGRAM test_target_private
+  USE iso_fortran_env
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
 
-        OMPVV_REPORT_AND_RETURN()
+  OMPVV_TEST_OFFLOADING
+  OMPVV_TEST_VERBOSE(test_target_private_clause() .ne. 0)
 
-        CONTAINS 
-          INTEGER FUNCTION test_target_private_clause()
-            INTEGER :: compute_array(N,NUM_THREADS)
-            INTEGER :: actualThreadCnt = 0
-            INTEGER :: errors, i, j, p_val, fp_val
-            CHARACTER(len=400) :: messageHelper
-           
-            compute_array(:,:) = 0
-            errors = 0
+  OMPVV_REPORT_AND_RETURN()
 
-            CALL omp_set_num_threads(NUM_THREADS)
+CONTAINS
+  INTEGER FUNCTION test_target_private_clause()
+    INTEGER :: compute_array(N,OMPVV_NUM_THREADS_DEVICE)
+    INTEGER :: actualThreadCnt = 0
+    INTEGER :: errors, i, j, p_val, fp_val
+    CHARACTER(len=400) :: messageHelper
 
-            !$omp parallel private(p_val, fp_val) shared(actualThreadCnt)
-              fp_val = omp_get_thread_num() + 1
-              IF (omp_get_thread_num() == 0) THEN
-                actualThreadCnt = omp_get_num_threads()
-              END IF
-              !$omp target map(tofrom:compute_array(:,fp_val)) map(to:fp_val) private(p_val)
-                p_val = fp_val 
-                compute_array(:,p_val) = p_val
-              !$omp end target
-            !$omp end parallel 
-          
-            WRITE(messageHelper, '(A,I0,A,I0)') "Test ran with ", &
-            actualThreadCnt, " threads out of ", omp_get_thread_limit()
-            OMPVV_INFOMSG(messageHelper)
+    compute_array(:,:) = 0
+    errors = 0
 
-            WRITE(messageHelper, *) "The number of threads in the &
-            & host is 1. Test is inconclusive"
-            OMPVV_WARNING_IF(actualThreadCnt <= 1, messageHelper)
+    CALL omp_set_num_threads(OMPVV_NUM_THREADS_DEVICE)
 
-            DO j=1,actualThreadCnt
-              DO i=1, N
-                OMPVV_TEST_AND_SET_VERBOSE(errors, compute_array(i,j) .ne. j)
-              END DO
-            END DO
- 
-          test_target_private_clause = errors
+    !$omp parallel private(p_val, fp_val) shared(actualThreadCnt)
+    fp_val = omp_get_thread_num() + 1
+    IF (omp_get_thread_num() == 0) THEN
+       actualThreadCnt = omp_get_num_threads()
+    END IF
+    !$omp target map(tofrom:compute_array(:,fp_val)) map(to:fp_val) private(p_val)
+    p_val = fp_val
+    compute_array(:,p_val) = p_val
+    !$omp end target
+    !$omp end parallel
 
-          END FUNCTION test_target_private_clause
-      END PROGRAM test_target_private
+    WRITE(messageHelper, '(A,I0,A,I0)') "Test ran with ", &
+         actualThreadCnt, " threads out of ", omp_get_thread_limit()
+    OMPVV_INFOMSG(messageHelper)
 
+    WRITE(messageHelper, *) "The number of threads in the &
+         & host is 1. Test is inconclusive"
+    OMPVV_WARNING_IF(actualThreadCnt <= 1, messageHelper)
+
+    DO j=1,actualThreadCnt
+       DO i=1, N
+          OMPVV_TEST_AND_SET_VERBOSE(errors, compute_array(i,j) .ne. j)
+       END DO
+    END DO
+
+    test_target_private_clause = errors
+
+  END FUNCTION test_target_private_clause
+END PROGRAM test_target_private

--- a/tests/4.5/target/test_target_private.c
+++ b/tests/4.5/target/test_target_private.c
@@ -1,12 +1,12 @@
 //===--test_target_private.c ----------------------------------------------------===//
-// 
+//
 // OpenMP API Version 4.5 Nov 2015
 //
 // Testing private clause with target directive. The test begins by initializing
 // and filling a 2-D array with all zeros and generating four threads. In a parallel
-// region, each thread is assigned a thread number and an integer. At the beginning 
-// of the parallel region, the 2-D array is mapped to device alongside the private 
-// integer value and firstprivate unqiue thread number. The integer value is set 
+// region, each thread is assigned a thread number and an integer. At the beginning
+// of the parallel region, the 2-D array is mapped to device alongside the private
+// integer value and firstprivate unqiue thread number. The integer value is set
 // equal to the thread number inside of the target region and each column of the
 // array is filled based on which thread is currently operating. Finally, back on the
 // host, we check that array is properly filled.
@@ -21,7 +21,7 @@
 
 int main() {
 
-  int compute_array[4][N];
+  int compute_array[OMPVV_NUM_THREADS_DEVICE][N];
   int errors = 0;
   int i, j;
   int real_num_threads;
@@ -30,33 +30,33 @@ int main() {
   int is_offloading;
   OMPVV_TEST_AND_SET_OFFLOADING(is_offloading);
 
-  for (i = 0; i < 4; i++) 
-    for (j = 0; j < N; j++) 
+  for (i = 0; i < 4; i++) {
+    for (j = 0; j < N; j++) {
       compute_array[i][j] = 0;
+    }
+  }
 
-
-  omp_set_num_threads(4);
+  omp_set_num_threads(OMPVV_NUM_THREADS_DEVICE);
 #pragma omp parallel
-{
-  int fp_val = omp_get_thread_num();
-  int p_val=0;
-  real_num_threads = omp_get_num_threads();  
+  {
+    int fp_val = omp_get_thread_num();
+    int p_val=0;
+    real_num_threads = omp_get_num_threads();
 
 #pragma omp target map(tofrom:compute_array[fp_val][0:N]) firstprivate(fp_val) private(p_val)
-  {
-    p_val = fp_val;
-    for (i = 0; i < N; i++)
-      compute_array[p_val][i] += p_val;
-  } // end target
-}//end parallel
+    {
+      p_val = fp_val;
+      for (i = 0; i < N; i++)
+        compute_array[p_val][i] += p_val;
+    } // end target
+  }//end parallel
 
-  for (i = 0; i < real_num_threads; i++){ 
+  for (i = 0; i < real_num_threads; i++) {
     for (j = 0; j < N; j++){
       OMPVV_TEST_AND_SET_VERBOSE(errors, (compute_array[i][j] != i));
     }
   }//end for
-  
+
   OMPVV_REPORT_AND_RETURN(errors);
 
 }
-

--- a/tests/4.5/target/test_target_private.c
+++ b/tests/4.5/target/test_target_private.c
@@ -21,7 +21,7 @@
 
 int main() {
 
-  int compute_array[OMPVV_NUM_THREADS_DEVICE][N];
+  int compute_array[OMPVV_NUM_THREADS_HOST][N];
   int errors = 0;
   int i, j;
   int real_num_threads;
@@ -30,13 +30,13 @@ int main() {
   int is_offloading;
   OMPVV_TEST_AND_SET_OFFLOADING(is_offloading);
 
-  for (i = 0; i < 4; i++) {
+  for (i = 0; i < OMPVV_NUM_THREADS_HOST; i++) {
     for (j = 0; j < N; j++) {
       compute_array[i][j] = 0;
     }
   }
 
-  omp_set_num_threads(OMPVV_NUM_THREADS_DEVICE);
+  omp_set_num_threads(OMPVV_NUM_THREADS_HOST);
 #pragma omp parallel
   {
     int fp_val = omp_get_thread_num();


### PR DESCRIPTION
This PR addresses issue #22 for test_target_private and test_target_firstprivate. The main fix is adding the OMPVV_NUM_THREADS_HOST where needed so the user can select these values through the Makefile, but some whitespace cleanup is also present.