### PR TITLE
Target teams distribute thread team macros (issue #22)

### DIFF
--- a/ompvv/ompvv.F90
+++ b/ompvv/ompvv.F90
@@ -48,7 +48,7 @@
 
 ! Macros to provide thread and team nums if they are not specified
 #ifndef OMPVV_NUM_THREADS_DEVICE
-#define OMPVV_NUM_THREADS_DEVICE 128
+#define OMPVV_NUM_THREADS_DEVICE 8
 #endif
 
 #ifndef OMPVV_NUM_TEAMS_DEVICE

--- a/ompvv/ompvv.h
+++ b/ompvv/ompvv.h
@@ -120,7 +120,7 @@ _Pragma("omp target map (from: _ompvv_isOffloadingOn) map(to: _ompvv_isSharedEnv
 
 // Macros to provide thread and team nums if they are not specified
 #ifndef OMPVV_NUM_THREADS_DEVICE
-  #define OMPVV_NUM_THREADS_DEVICE 128
+  #define OMPVV_NUM_THREADS_DEVICE 8
 #endif
 
 #ifndef OMPVV_NUM_TEAMS_DEVICE

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_collapse.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_collapse.F90
@@ -47,7 +47,8 @@
             !Collapse is only for one loop.  Second loop should be sequential
 
             !$omp target teams distribute map(to: a(1:N, 1:N)) map(tofrom: &
-            !$omp& b(1:N, 1:N+1)) map(from: num_teams) collapse(1)
+            !$omp& b(1:N, 1:N+1)) map(from: num_teams) collapse(1) &
+            !$omp& num_teams(OMPVV_NUM_TEAMS_DEVICE)
             DO x = 1, N
               DO y = 1, N
                 b(x, y + 1) = b(x, y) + a(x, y)
@@ -91,7 +92,8 @@
             END DO
 
             !$omp target teams distribute map(to: a(1:N, 1:N, 1:N)) &
-            !$omp& map(tofrom: b(1:N, 1:N, 1:N+1)) collapse(2)
+            !$omp& map(tofrom: b(1:N, 1:N, 1:N+1)) collapse(2) &
+            !$omp& num_teams(OMPVV_NUM_TEAMS_DEVICE)
             DO x = 1, N
               DO y = 1, N
                 DO z = 1, N

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_collapse.c
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_collapse.c
@@ -33,7 +33,7 @@ int test_collapse1() {
     }
   }
 
-#pragma omp target teams distribute map(to: a[0:ARRAY_SIZE][0:ARRAY_SIZE]) map(tofrom: b[0:ARRAY_SIZE][0:ARRAY_SIZE+1]) collapse(1)
+#pragma omp target teams distribute map(to: a[0:ARRAY_SIZE][0:ARRAY_SIZE]) map(tofrom: b[0:ARRAY_SIZE][0:ARRAY_SIZE+1]) collapse(1) num_teams(OMPVV_NUM_TEAMS_DEVICE)
   for (int x = 0; x < ARRAY_SIZE; ++x) {
     for (int y = 0; y < ARRAY_SIZE; ++y) {
       b[x][y + 1] = b[x][y] + a[x][y];
@@ -72,7 +72,7 @@ int test_collapse2() {
     }
   }
 
-#pragma omp target teams distribute map(to: a[0:ARRAY_SIZE][0:ARRAY_SIZE][0:ARRAY_SIZE]) map(tofrom: b[0:ARRAY_SIZE][0:ARRAY_SIZE][0:ARRAY_SIZE+1], num_teams) collapse(2)
+#pragma omp target teams distribute map(to: a[0:ARRAY_SIZE][0:ARRAY_SIZE][0:ARRAY_SIZE]) map(tofrom: b[0:ARRAY_SIZE][0:ARRAY_SIZE][0:ARRAY_SIZE+1], num_teams) collapse(2) num_teams(OMPVV_NUM_TEAMS_DEVICE)
   for (int x = 0; x < ARRAY_SIZE; ++x) {
     for (int y = 0; y < ARRAY_SIZE; ++y) {
       for (int z = 0; z < ARRAY_SIZE; ++z) {

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_default_none.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_default_none.F90
@@ -45,7 +45,7 @@ CONTAINS
 
     !$omp target data map(from: d(1:N)) map(to: a(1:N), b(1:N), c(1:N))
     !$omp target teams distribute default(none) shared(a, b, c, d) &
-    !$omp& private(x, y, privatized)
+    !$omp& private(x, y, privatized) num_teams(OMPVV_NUM_TEAMS_DEVICE)
     DO x = 1, N
        privatized = 0
        DO y = 1, a(x) + b(x)
@@ -74,7 +74,7 @@ CONTAINS
 
     !$omp target data map(to: a(1:N)) map(tofrom: share)
     !$omp target teams distribute default(none) private(x) &
-    !$omp& shared(share, a) defaultmap(tofrom:scalar)
+    !$omp& shared(share, a) defaultmap(tofrom:scalar) num_teams(OMPVV_NUM_TEAMS_DEVICE)
     DO x = 1, N
        !$omp atomic
        share = share + a(x)

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_default_none.c
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_default_none.c
@@ -38,7 +38,7 @@ int main() {
 
 #pragma omp target data map(from: d[0:N], num_teams) map(to: a[0:N], b[0:N], c[0:N])
   {
-#pragma omp target teams distribute default(none) shared(a, b, c, d, num_teams) private(x, privatized)
+#pragma omp target teams distribute default(none) shared(a, b, c, d, num_teams) private(x, privatized) num_teams(OMPVV_NUM_TEAMS_DEVICE)
     for (x = 0; x < N; ++x) {
       privatized = 0;
       for (int y = 0; y < a[x] + b[x]; ++y) {
@@ -62,7 +62,7 @@ int main() {
 
 #pragma omp target data map(from: num_teams) map(to: b[0:N])
   {
-#pragma omp target teams distribute default(none) private(x) shared(share, b, num_teams) defaultmap(tofrom:scalar)
+#pragma omp target teams distribute default(none) private(x) shared(share, b, num_teams) defaultmap(tofrom:scalar) num_teams(OMPVV_NUM_TEAMS_DEVICE)
     for (x = 0; x < N; ++x) {
 #pragma omp atomic update
       share = share + b[x];

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_default_private.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_default_private.F90
@@ -41,7 +41,7 @@ CONTAINS
     END DO
 
     !$omp target teams distribute default(private) shared(a, &
-    !$omp& b, c, d)
+    !$omp& b, c, d) num_teams(OMPVV_NUM_TEAMS_DEVICE)
     DO x = 1, N
        privatized = 0
        DO y = 1, a(x) + b(x)

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_firstprivate.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_firstprivate.F90
@@ -48,7 +48,7 @@ CONTAINS
 
     !$omp target data map(from: d(1:N)) map(to: a(1:N), b(1:N), c(1:N))
     !$omp target teams distribute firstprivate(privatized, privatized_array)&
-    !$omp& map(alloc: a(1:N), b(1:N), c(1:N), d(1:N)) num_teams(10)
+    !$omp& map(alloc: a(1:N), b(1:N), c(1:N), d(1:N)) num_teams(OMPVV_NUM_TEAMS_DEVICE)
     DO x = 1, N
        num_teams(x) = omp_get_num_teams()
        DO y = 1, a(x) + b(x)
@@ -99,7 +99,7 @@ CONTAINS
 
     !$omp target data map(from: d(1:N)) map(to: a(1:N), b(1:N), c(1:N))
     !$omp target teams distribute firstprivate(privatized_array, privatized) &
-    !$omp map(alloc: a(1:N), b(1:N), c(1:N), d(1:N)) num_teams(10)
+    !$omp map(alloc: a(1:N), b(1:N), c(1:N), d(1:N)) num_teams(OMPVV_NUM_TEAMS_DEVICE)
     DO x = 1, N
        num_teams(x) = omp_get_num_teams()
        d(x) = a(x) + b(x) + c(x) + privatized_array(MOD(x, 10)+1) + privatized

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_firstprivate.c
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_firstprivate.c
@@ -44,22 +44,22 @@ int main() {
 #pragma omp target data map(from: d[0:N]) map(to: a[0:N], b[0:N], c[0:N])
   {
 #pragma omp target teams distribute firstprivate(privatized_array, privatized) \
-  map(alloc: a[0:N], b[0:N], c[0:N], d[0:N]) num_teams(10)
+  map(alloc: a[0:N], b[0:N], c[0:N], d[0:N]) num_teams(OMPVV_NUM_TEAMS_DEVICE)
     for (int x = 0; x < N; ++x) {
       num_teams[x] = omp_get_num_teams();
       for (int y = 0; y < a[x] + b[x]; ++y) {
-	privatized++;
-	for (int z = 0; z < 10; ++z) {
-	  privatized_array[z]++;
-	}
+        privatized++;
+        for (int z = 0; z < 10; ++z) {
+          privatized_array[z]++;
+        }
       }
       d[x] = c[x] * privatized;
       for (int z = 0; z < 10; ++z) {
-	d[x] += privatized_array[z];
+        d[x] += privatized_array[z];
       }
       privatized = 0;
       for (int z = 0; z < 10; ++z) {
-	privatized_array[z] = 0;
+        privatized_array[z] = 0;
       }
     }
   }
@@ -85,7 +85,7 @@ int main() {
 #pragma omp target data map(from: d[0:N]) map(to: a[0:N], b[0:N], c[0:N])
   {
 #pragma omp target teams distribute firstprivate(privatized_array, privatized) \
-  map(alloc: a[0:N], b[0:N], c[0:N], d[0:N]) num_teams(10)
+  map(alloc: a[0:N], b[0:N], c[0:N], d[0:N]) num_teams(OMPVV_NUM_TEAMS_DEVICE)
     for (int x = 0; x < N; ++x) {
       num_teams[x] = omp_get_num_teams();
       d[x] = a[x] + b[x] + c[x] + privatized_array[x%10] + privatized;

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_shared.c
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_shared.c
@@ -37,7 +37,7 @@ int main() {
   // The defaultmap(tofrom:scalar) is used here because the OpenMP 4.5 specification
   // forbids the use of map and data-sharing clauses on the same list item in the
   // same construct. See pg. 218, lines 15-16.
-#pragma omp target teams distribute num_teams(10) shared(share, num_teams) map(to: a[0:SIZE]) defaultmap(tofrom:scalar)
+#pragma omp target teams distribute num_teams(OMPVV_NUM_TEAMS_DEVICE) shared(share, num_teams) map(to: a[0:SIZE]) defaultmap(tofrom:scalar)
   for (int x = 0; x < SIZE; ++x) {
 #pragma omp atomic write
     num_teams = omp_get_num_teams();
@@ -56,7 +56,7 @@ int main() {
 
 #pragma omp target data map(tofrom: a[0:SIZE]) map(tofrom: share)
   {
-#pragma omp target teams distribute num_teams(10) shared(share)
+#pragma omp target teams distribute num_teams(OMPVV_NUM_TEAMS_DEVICE) shared(share)
     for (int x = 0; x < SIZE; ++x) {
       a[x] = a[x] + share;
     }


### PR DESCRIPTION
Add the OMPVV_NUM_TEAMS_DEVICE macros to all target teams distribute tests that require it.