### PR TITLE
Target teams distribute parallel for thread team macros (issue #22)

### DIFF
--- a/tests/4.5/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for.F90
+++ b/tests/4.5/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for.F90
@@ -36,7 +36,8 @@
             OMPVV_INFOMSG("target_teams_distribute_parallel_for")
             OMPVV_GET_ERRORS(errors_bf)
 
-            !$omp target teams distribute parallel do map(from:num_teams, num_threads)
+            !$omp target teams distribute parallel do map(from:num_teams, num_threads) &
+            !$omp& num_teams(OMPVV_NUM_TEAMS_DEVICE) num_threads(OMPVV_NUM_THREADS_DEVICE)
             DO i = 1, ARRAY_SIZE, 1
               !$omp atomic write 
               num_teams = omp_get_num_teams()

--- a/tests/4.5/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for.c
+++ b/tests/4.5/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for.c
@@ -36,7 +36,7 @@ int test_target_teams_distribute_parallel_for() {
   }
 
 
-#pragma omp target teams distribute parallel for map(from:num_teams, num_threads)
+#pragma omp target teams distribute parallel for map(from:num_teams, num_threads) num_teams(OMPVV_NUM_TEAMS_DEVICE) num_threads(OMPVV_NUM_THREADS_DEVICE)
   for (i = 0; i < ARRAY_SIZE; ++i) {
 #pragma omp atomic write
     num_teams = omp_get_num_teams();

--- a/tests/4.5/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_firstprivate.c
+++ b/tests/4.5/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_firstprivate.c
@@ -42,7 +42,7 @@ int test_target_teams_distribute_parallel_for_firstprivate() {
   // check multiple sizes. 
 #pragma omp target data map(to: a[0:SIZE_N], b[0:SIZE_N], c[0:SIZE_N])
   {
-#pragma omp target teams distribute parallel for firstprivate(privatized, firstized, i) num_teams(10) num_threads(256)
+#pragma omp target teams distribute parallel for firstprivate(privatized, firstized, i) num_teams(OMPVV_NUM_TEAMS_DEVICE) num_threads(OMPVV_NUM_THREADS_DEVICE)
       for (j = 0; j < SIZE_N; ++j) {
         reported_num_teams[j] = omp_get_num_teams();
         reported_num_threads[j] = omp_get_num_threads();

--- a/tests/4.5/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_if_no_modifier.c
+++ b/tests/4.5/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_if_no_modifier.c
@@ -48,12 +48,12 @@ int checkPreconditions() {
   // Get the init_num_threads for host and device. If it is 1, then we 
   // cannot test the if parallel 
   // See section 2.5.1 of the ref manual
-#pragma omp target teams distribute parallel for num_threads(10)
+#pragma omp target teams distribute parallel for num_threads(OMPVV_NUM_THREADS_DEVICE)
   for (i = 0; i < SIZE_N; i++) {
     init_num_threads_dev[i] = omp_get_num_threads();
   }
 
-#pragma omp parallel for num_threads(10)
+#pragma omp parallel for num_threads(OMPVV_NUM_THREADS_DEVICE)
   for (i = 0; i < SIZE_N; i++) {
     init_num_threads_host[i] = omp_get_num_threads();
   }
@@ -100,7 +100,7 @@ int test_target_teams_distribute_if_no_modifier() {
   // greather than ATTEMPT_THRESHOLD, and we make sure the number of threads is 1. 
   for (attempt = 0; attempt < NUM_ATTEMPTS; ++attempt) {
 #pragma omp target teams distribute parallel for if(attempt >= ATTEMPT_THRESHOLD)\
-    map(tofrom: a, warning) num_threads(10)
+    map(tofrom: a, warning) num_threads(OMPVV_NUM_THREADS_DEVICE)
     for (i = 0; i < SIZE_N; i++) {
       if (omp_is_initial_device()) {
         // if(false): We should execute in the host 

--- a/tests/4.5/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_if_parallel_modifier.c
+++ b/tests/4.5/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_if_parallel_modifier.c
@@ -48,12 +48,12 @@ void checkPreconditions() {
   // Get the init_num_threads for host and device. If it is 1, then we 
   // cannot test the if parallel 
   // See section 2.5.1 of the ref manual
-#pragma omp target teams distribute parallel for num_threads(10)
+#pragma omp target teams distribute parallel for num_threads(OMPVV_NUM_THREADS_DEVICE)
   for (i = 0; i < SIZE_N; i++) {
     init_num_threads_dev[i] = omp_get_num_threads();
   }
 
-#pragma omp parallel for num_threads(10)
+#pragma omp parallel for num_threads(OMPVV_NUM_THREADS_DEVICE)
   for (i = 0; i < SIZE_N; i++) {
     init_num_threads_host[i] = omp_get_num_threads();
   }
@@ -102,7 +102,7 @@ int test_target_teams_distribute_if_parallel_modifier() {
   // warning if the number of threads is 1 when the condition evaluates to true. 
   for (attempt = 0; attempt < NUM_ATTEMPTS; ++attempt) {
 #pragma omp target teams distribute parallel for if(parallel: attempt >= ATTEMPT_THRESHOLD)\
-    map(tofrom: a, warning) num_threads(10)
+    map(tofrom: a, warning) num_threads(OMPVV_NUM_THREADS_DEVICE)
     for (i = 0; i < SIZE_N; i++) {
       if (omp_is_initial_device())
         a[i] += 10; // This +10 should not happen

--- a/tests/4.5/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_if_target_modifier.c
+++ b/tests/4.5/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_if_target_modifier.c
@@ -61,7 +61,7 @@ int test_target_teams_distribute_if_target_modifier() {
   // greather than ATTEMPT_THRESHOLD
   for (attempt = 0; attempt < NUM_ATTEMPTS; ++attempt) {
 #pragma omp target teams distribute parallel for if(target: attempt >= ATTEMPT_THRESHOLD)\
-    map(tofrom: a) num_threads(10)
+    map(tofrom: a) num_threads(OMPVV_NUM_THREADS_DEVICE)
     for (i = 0; i < SIZE_N; i++) {
       warning[i] += (omp_get_num_threads() == 1) ? 1 : 0; // Ideally we should not change the number of threads at any point
       if (attempt >= ATTEMPT_THRESHOLD) {

--- a/tests/4.5/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_num_teams.c
+++ b/tests/4.5/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_num_teams.c
@@ -31,8 +31,8 @@ int test_target_teams_distribute_parallel_for_num_teams() {
     for (i = 0; i < SIZE_N; i++) {
       num_teams[i] = -1;
     }
-#pragma omp target teams distribute parallel for\
-        map(tofrom: num_teams) num_teams(tested_num_teams[nt])
+#pragma omp target teams distribute parallel for          \
+  map(tofrom: num_teams) num_teams(tested_num_teams[nt])
     for (i = 0; i < SIZE_N; i++) {
       num_teams[i] = omp_get_num_teams();
     }

--- a/tests/4.5/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_schedule_private.c
+++ b/tests/4.5/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_schedule_private.c
@@ -31,7 +31,7 @@ int test_target_teams_distribute_parallel_for_sched_private() {
   }
 
   // check multiple sizes. 
-#pragma omp target teams distribute parallel for firstprivate(firstprivatized) num_teams(8) num_threads(32) schedule(static,8)
+#pragma omp target teams distribute parallel for firstprivate(firstprivatized) num_teams(OMPVV_NUM_TEAMS_DEVICE) num_threads(OMPVV_NUM_THREADS_DEVICE) schedule(static,8)
     for (int j = 0; j < SIZE_N; ++j) {
       reported_num_teams[j] = omp_get_num_teams();
       reported_num_threads[j] = omp_get_num_threads();

--- a/tests/5.0/teams/test_teams.c
+++ b/tests/5.0/teams/test_teams.c
@@ -13,34 +13,35 @@
 #include <stdlib.h>
 #include "ompvv.h"
 
-#define N 4
-
 int main() {
-  int num_teams[N];
-  int num_threads[N];
+  int num_teams[OMPVV_NUM_TEAMS_DEVICE];
+  int num_threads[OMPVV_NUM_THREADS_DEVICE];
   int errors[2] = {0,0};
   int is_offloading;
 
 
-  for (int x = 0; x < N; ++x) {
+  for (int x = 0; x < OMPVV_NUM_TEAMS_DEVICE; ++x) {
     num_teams[x] = -99;
+  }
+
+  for (int x = 0; x < OMPVV_NUM_THREADS_DEVICE; ++x) {
     num_threads[x] = -99;
   }
 
-#pragma omp teams num_teams(N) thread_limit(N)
+#pragma omp teams num_teams(OMPVV_NUM_TEAMS_DEVICE) thread_limit(OMPVV_NUM_THREADS_DEVICE)
   {
     num_teams[omp_get_team_num()] = omp_get_num_teams();
     num_threads[omp_get_team_num()]= omp_get_num_threads();
   }
 
   if (num_teams[0] == 1) {
-    OMPVV_WARNING("Test operated with one team. num_teams requested were %d.", N);
+    OMPVV_WARNING("Test operated with one team. num_teams requested were %d.", OMPVV_NUM_TEAMS_DEVICE);
   } else if (num_teams[0] < 1) {
     OMPVV_ERROR("omp_get_num_teams() reported a value less than one.");
   }
 
   if (num_threads[0] == 1) {
-    OMPVV_WARNING("Team 0 reported only 1 thread. thread_limit was set to %d.",N);
+    OMPVV_WARNING("Team 0 reported only 1 thread. thread_limit was set to %d.", OMPVV_NUM_THREADS_DEVICE);
   } else if (num_threads[0] < 1) {
     OMPVV_ERROR("omp_get_num_threads() reported a value below one.");
   }

--- a/tests/5.0/teams/test_teams_distribute_default_none.c
+++ b/tests/5.0/teams/test_teams_distribute_default_none.c
@@ -35,7 +35,7 @@ int main() {
     d[x] = 0;
   }
 
-#pragma omp teams distribute num_teams(4) default(none) shared(a, b, c, d, num_teams) private(privatized)
+#pragma omp teams distribute num_teams(OMPVV_NUM_TEAMS_DEVICE) default(none) shared(a, b, c, d, num_teams) private(privatized)
     for (int x = 0; x < N; ++x) {
       privatized = 0;
       for (int y = 0; y < a[x] + b[x]; ++y) {
@@ -56,7 +56,7 @@ int main() {
     }
   }
 
-#pragma omp teams distribute num_teams(4) default(none) shared(share, b, num_teams)
+#pragma omp teams distribute num_teams(OMPVV_NUM_TEAMS_DEVICE) default(none) shared(share, b, num_teams)
     for (int x = 0; x < N; ++x) {
 #pragma omp atomic update
       share = share + b[x];


### PR DESCRIPTION
Add thread/teams selection macros for the target teams distribute tests. Also added for the 5.0 standalone teams tests. See issue  #22.