### PR TITLE
Adding one-line fix to address problems described in issue 203

### DIFF
--- a/tests/4.5/target_enter_data/test_target_enter_data_if.F90
+++ b/tests/4.5/target_enter_data/test_target_enter_data_if.F90
@@ -99,7 +99,7 @@
 
              ! This is not part of the test but it is necessary for garbage
              ! collection
-             !$omp target exit data map(delete: a(1:s), b(1:s)) 
+             !$omp target exit data if(s > THRESHOLD) map(delete: a(1:s), b(1:s)) 
 
            END DO ! s
 


### PR DESCRIPTION
Adding if clause onto the target exit data directive, required to match the functionality of the original .c test.
Test passes on device with gcc 9 on summit