### PR TITLE
Add 5.0 test of simd inside atomic for C

### DIFF
--- a/tests/5.0/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_simd_atomic.c
+++ b/tests/5.0/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_simd_atomic.c
@@ -2,10 +2,10 @@
 //
 // OpenMP API Version 5.0 Nov 2018
 //
-// Adapted from OpenMP examples acquire_release.2.c
-// When the atomic read operation on thread 1 reads a non-zero value from y,
-// this results in a release/acquire synchronization that in turn implies that
-// the assignment to x on thread 0 happens before the read of x on thread 1.
+// This test checks that the atomic construct can be used within the target
+// teams distribute parallel for construct with simd to avoid a race
+// condition in updating a shared variable, whose value is checked after
+// updating.
 //
 ////===----------------------------------------------------------------------===//
 #include <assert.h>

--- a/tests/5.0/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_simd_atomic.c
+++ b/tests/5.0/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_simd_atomic.c
@@ -1,0 +1,40 @@
+//===--- test_target_teams_distribute_parallel_for_simd_atomic.c ------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// Adapted from OpenMP examples acquire_release.2.c
+// When the atomic read operation on thread 1 reads a non-zero value from y,
+// this results in a release/acquire synchronization that in turn implies that
+// the assignment to x on thread 0 happens before the read of x on thread 1.
+//
+////===----------------------------------------------------------------------===//
+#include <assert.h>
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+int test_target_teams_distribute_parallel_for_simd_atomic() {
+  OMPVV_INFOMSG("test_target_teams_distribute_parallel_for_simd_atomic");
+  int errors = 0, x = 0;
+
+#pragma omp target teams distribute parallel for simd map(tofrom: x) shared(x) num_teams(OMPVV_NUM_TEAMS_DEVICE) num_threads(OMPVV_NUM_THREADS_DEVICE)
+  for (int i = 0; i < N; i++) {
+#pragma omp atomic update
+    x += 1;
+  }
+
+  OMPVV_TEST_AND_SET_VERBOSE(errors, x != N)
+
+  return errors;
+}
+
+
+int main() {
+  int errors = 0;
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_target_teams_distribute_parallel_for_simd_atomic());
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}


### PR DESCRIPTION
This test simply checks that the simd construct can be used to avoid a race condition inside a parallel for simd construct on the device, a 5.0 feature.