### PR TITLE
Issue 212: test_target_teams_distribute_reduction_bitor.c use inited var

### DIFF
--- a/tests/5.0/target_teams_distribute/test_target_teams_distribute_reduction_bitor.c
+++ b/tests/5.0/target_teams_distribute/test_target_teams_distribute_reduction_bitor.c
@@ -49,7 +49,7 @@ int test_bitor() {
 
   unsigned int b = 0;
 
-#pragma omp target teams distribute reduction(|:b) map(to: a[0:N]) map(from: b, num_teams[0:N])
+#pragma omp target teams distribute reduction(|:b) map(to: a[0:N]) map(tofrom: b) map(from: num_teams[0:N])
   for (int x = 0; x < N; ++x) {
     num_teams[x] = omp_get_num_teams();
     b = b | a[x];


### PR DESCRIPTION
Issue #212
* tests/5.0/target_teams_distribute/test_target_teams_distribute_reduction_bitor.c
	(test_bitor): Use 'tofrom' instead of 'from:' to work on an initialized variable.