### PR TITLE
Issue #214: Init vars in test_target_teams_distribute_reduction_*.c

### DIFF
--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_bitand.c
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_bitand.c
@@ -23,7 +23,7 @@ int test_bitand() {
   int errors = 0;                               // an exaplantion of this math.
   int num_teams[N];
   int num_attempts = 0;
-  int have_true, have_false;
+  int have_true = 0, have_false = 0;
   srand(1);
 
   while ((!have_true || !have_false) && (num_attempts < THRESHOLD)) {

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_bitor.c
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_bitor.c
@@ -24,7 +24,7 @@ int test_bitor() {
   int errors = 0;
   int num_teams[N];
   int num_attempts = 0;
-  int have_true, have_false;
+  int have_true = 0, have_false = 0;
   srand(1);
 
   while ((!have_true || !have_false) && (num_attempts < THRESHOLD)) {

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_or.c
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_or.c
@@ -22,9 +22,9 @@ int test_or() {
   double true_margin = pow(exp(1), log(.5)/N);   // See the 'and' operator test for
   int errors = 0;                                // an explanation of this math.
   int num_teams[N];
-  int tested_true;
-  int tested_false;
-  int itr_count;
+  int tested_true = 0;
+  int tested_false = 0;
+  int itr_count = 0;
   srand(1);
 
   while ((!tested_true || !tested_false) && (itr_count < THRESHOLD)) {

--- a/tests/5.0/target_teams_distribute/test_target_teams_distribute_reduction_bitand.c
+++ b/tests/5.0/target_teams_distribute/test_target_teams_distribute_reduction_bitand.c
@@ -22,7 +22,7 @@ int test_bitand() {
   double false_margin = pow(exp(1), log(.5)/N); // See the 'and' operator test for
   int errors = 0;                               // an exaplantion of this math.
   int num_teams[N];
-  int have_true, have_false;
+  int have_true = 0, have_false = 0;
   int num_attempts = 0;
   srand(1);
 

--- a/tests/5.0/target_teams_distribute/test_target_teams_distribute_reduction_bitor.c
+++ b/tests/5.0/target_teams_distribute/test_target_teams_distribute_reduction_bitor.c
@@ -23,7 +23,7 @@ int test_bitor() {
   double true_margin = pow(exp(1), log(.5)/N);
   int errors = 0;
   int num_teams[N];
-  int have_true, have_false;
+  int have_true = 0, have_false = 0;
   int num_attempts = 0;
   srand(1);
 


### PR DESCRIPTION
Issue #214
* tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_or.c:
  Initialize tested_true, tested_false, and itr_count.
* tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_bitand.c:
  Initialize have_true and have_false.
* tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_bitor.c:
  Likewise.
* tests/5.0/target_teams_distribute/test_target_teams_distribute_reduction_bitand.c:
  Likewise.
* tests/5.0/target_teams_distribute/test_target_teams_distribute_reduction_bitor.c:
  Likewise.