### PR TITLE
test_target_map_*_arrays.F90: Update comments

### DIFF
--- a/tests/4.5/target/test_target_map_program_arrays.F90
+++ b/tests/4.5/target/test_target_map_program_arrays.F90
@@ -51,6 +51,8 @@
               helper_array_3d = array_3d
 
               ! This value should not be copied back
+              ! Assumes that that the target region is neither
+              ! executed on the host nor with unified-shared memory
               array_1d(:) = 0
               array_2d(:,:) = 0
               array_3d(:,:,:) = 0
@@ -89,17 +91,21 @@
             !$omp target map(from: array_1d, array_2d, array_3d) &
             !$omp map(from: helper_array_1d, helper_array_2d) &
             !$omp map(from: helper_array_3d)
+              ! NOTE: array_1d/2d/3d is uninitialized,
+              ! unless distributed-shared memory or executed on the host
               helper_array_1d = array_1d
               helper_array_2d = array_2d
               helper_array_3d = array_3d
 
-              ! This value should not be copied back
               array_1d(:) = 20
               array_2d(:,:) = 20
               array_3d(:,:,:) = 20
             !$omp end target
 
             ! Checking that data is not copied to the device
+            ! Assumes that that the target region is neither
+            ! executed on the host nor with unified-shared memory
+            ! Assumes additionally that an uninit array has not 999 for all elems
             WRITE(msgHelper, *) "Array seemed to have been copied to &
               & the device when using the from modifier."
             OMPVV_WARNING_IF(ALL(helper_array_1d == 999), msgHelper)
@@ -137,7 +143,6 @@
               helper_array_2d = array_2d
               helper_array_3d = array_3d
 
-              ! This value should not be copied back
               array_1d(:) = 20
               array_2d(:,:) = 20
               array_3d(:,:,:) = 20

--- a/tests/4.5/target/test_target_map_subroutines_arrays.F90
+++ b/tests/4.5/target/test_target_map_subroutines_arrays.F90
@@ -50,6 +50,8 @@
             OMPVV_TEST_VERBOSE(ANY(helper_array_3d /= 10))
 
             ! check that it did not copy back
+            ! Assumes that that the target region is neither
+            ! executed on the host nor with unified-shared memory
             OMPVV_TEST_VERBOSE(ANY(array_1d /= 10))
             OMPVV_TEST_VERBOSE(ANY(array_2d /= 10))
             OMPVV_TEST_VERBOSE(ANY(array_3d /= 10))
@@ -73,6 +75,9 @@
             CALL subroutine_from()
 
             ! Checking that data is not copied to the device
+            ! Assumes that that the target region is neither
+            ! executed on the host nor with unified-shared memory
+            ! Assumes additionally that an uninit array has not 999 for all elems
             WRITE(msgHelper, *) "Array seemed to have been copied to &
               & the device when using the from modifier."
             OMPVV_WARNING_IF(ALL(helper_array_1d == 999), msgHelper)
@@ -136,11 +141,12 @@
             !$omp target map(from: array_1d, array_2d, array_3d) &
             !$omp map(from: helper_array_1d, helper_array_2d) &
             !$omp map(from: helper_array_3d)
+              ! NOTE: array_1d/2d/3d is uninitialized,
+              ! unless distributed-shared memory or executed on the host
               helper_array_1d = array_1d
               helper_array_2d = array_2d
               helper_array_3d = array_3d
 
-              ! This value should not be copied back
               array_1d(:) = 20
               array_2d(:,:) = 20
               array_3d(:,:,:) = 20
@@ -154,7 +160,6 @@
               helper_array_2d = array_2d
               helper_array_3d = array_3d
 
-              ! This value should not be copied back
               array_1d(:) = 20
               array_2d(:,:) = 20
               array_3d(:,:,:) = 20


### PR DESCRIPTION
* tests/4.5/target/test_target_map_program_arrays.F90: Update comments
  regarding copy out and assumptions for those tests.
* tests/4.5/target/test_target_map_subroutines_arrays.F90: Likewise.

In each program, two comments about `This value should not be copied back` were wrong (copy'n'paste from first function; first: `to:`, others: `from:` and `tofrom:`). Additionally, the code has the assumption that it does not run on the host nor runs on a shared-memory system — and that unitialized memory never happens to be 999.

I think that's fine, but I makes sense to document this in the source code. (`omp_is_initial_device` could be used to check whether it is run on the host, i.e. it is known to use shared memory, but for unified-shared memory, I have no idea how this could be checked – except trying it, but that's what the test does.)