### PR TITLE
Fixing make.def to load modules before getting version info for gcc, clang

### DIFF
--- a/sys/make/make.def
+++ b/sys/make/make.def
@@ -34,7 +34,7 @@
 # Loading modules
 ##################################################
 define loadModules
-       $(if $(MODULE_LOAD), module load $(1) $(CUDA_MODULE) $(if $(or $(QUIET), $(2)), > /dev/null 2> /dev/null,);,)
+  $(if $(MODULE_LOAD), module load $(CUDA_MODULE) $(1) $(if $(or $(QUIET), $(2)), > /dev/null 2> /dev/null,);,)
 endef
 
 ##################################################
@@ -91,7 +91,7 @@ ifeq ($(CC), gcc)
   CFLAGS += -O3 -std=c99 -fopenmp $(COFFLOADING)
   CLINK = gcc
   CLINKFLAGS += -O3 -fopenmp $(COFFLOADING)
-  C_VERSION = echo "$(shell gcc --version | head -n 1 | sed 's/.* \([0-9]*\.[0-9]*\.[0-9]*\).*/\1/g')"
+  C_VERSION = echo "$(shell $(call loadModules,$(C_COMPILER_MODULE),"shut up") gcc --version | head -n 1 | sed 's/.* \([0-9]*\.[0-9]*\.[0-9]*\).*/\1/g')"
 endif
 
 # IBM XL compiler
@@ -112,13 +112,13 @@ ifeq ($(CC), clang)
   CFLAGS +=  -D__NO_MATH_INLINES -U__SSE2_MATH__ -U__SSE_MATH__
   CLINK = clang
   CLINKFLAGS += -lm -O3 -fopenmp $(COFFLOADING)
-  C_VERSION = echo "$(shell clang --version | head -n 1 | sed 's/clang version \([0-9]*\.[0-9]*\.[0-9]*\)/\1/g')"
+  C_VERSION = echo "$(shell $(call loadModules,$(C_COMPILER_MODULE),"shut up") clang --version | head -n 1 | sed 's/clang version \([0-9]*\.[0-9]*\.[0-9]*\)/\1/g')"
 endif
 
 # AOMP compiler
 ifeq ($(CC), aomp)
   $(warning "AOMP is still experimental. AOMP uses clang front end, make sure the clang aomp is selected")
-  INSTALLED_GPU  = $(shell $(call loadModules, $(C_COMPILER_MODULE)) mygpu -d gfx900 2> /dev/null)
+  INSTALLED_GPU  = $(shell $(call loadModules, $(C_COMPILER_MODULE),"shut up") mygpu -d gfx900 2> /dev/null)
   AOMP_GPU       ?= $(INSTALLED_GPU)
   AOMP_CPUTARGET ?= x86_64-pc-linux-gnu
   ifeq (sm_,$(findstring sm_,$(AOMP_GPU)))
@@ -180,7 +180,7 @@ ifeq ($(CXX), g++)
   CXXFLAGS += -std=c++11 -O3 -fopenmp $(CXXOFFLOADING)
   CXXLINK = g++
   CXXLINKFLAGS += -O3 -fopenmp $(CXXOFFLOADING)
-  CXX_VERSION = echo "$(shell g++ --version | head -n 1 | sed 's/.* \([0-9]*\.[0-9]*\.[0-9]*\).*/\1/g')"
+  CXX_VERSION = echo "$(shell $(call loadModules,$(CXX_COMPILER_MODULE),"shut up") g++ --version | head -n 1 | sed 's/.* \([0-9]*\.[0-9]*\.[0-9]*\).*/\1/g')"
 endif
 
 # IBM XL compiler
@@ -201,13 +201,13 @@ ifeq ($(CXX), clang++)
   CXXFLAGS +=  -D__NO_MATH_INLINES -U__SSE2_MATH__ -U__SSE_MATH__
   CXXLINK = clang++
   CXXLINKFLAGS += -lm -O3 -fopenmp $(CXXOFFLOADING)
-  CXX_VERSION = echo "$(shell clang++ --version | head -n 1 | sed 's/clang version \([0-9]*\.[0-9]*\.[0-9]*\)/\1/g')"
+  CXX_VERSION = echo "$(shell $(call loadModules,$(CXX_COMPILER_MODULE),"shut up") clang++ --version | head -n 1 | sed 's/clang version \([0-9]*\.[0-9]*\.[0-9]*\)/\1/g')"
 endif
 
 # AOMP compiler
 ifeq ($(CXX), aomp)
   $(warning "AOMP is still experimental. AOMP uses clang front end, make sure the clang aomp is selected")
-  INSTALLED_GPU  = $(shell $(call loadModules, $(C_COMPILER_MODULE)) mygpu -d gfx900 2> /dev/null)
+  INSTALLED_GPU  = $(shell $(call loadModules, $(C_COMPILER_MODULE),"shut up") mygpu -d gfx900 2> /dev/null)
   AOMP_GPU       ?= $(INSTALLED_GPU)
   AOMP_CPUTARGET ?= x86_64-pc-linux-gnu
   ifeq (sm_,$(findstring sm_,$(AOMP_GPU)))
@@ -252,7 +252,7 @@ ifeq ($(FC), gfortran)
   FFLAGS += -O3 -fopenmp $(FOFFLOADING) -ffree-line-length-none -J./ompvv
   FLINK = gcc
   FLINKFLAGS += -O3 -fopenmp $(FOFFLOADING)
-  F_VERSION = echo "$(shell gfortran --version | head -n 1 | sed 's/.* \([0-9]*\.[0-9]*\.[0-9]*\).*/\1/g')"
+  F_VERSION = echo "$(shell $(call loadModules,$(F_COMPILER_MODULE),"shut up") gfortran --version | head -n 1 | sed 's/.* \([0-9]*\.[0-9]*\.[0-9]*\).*/\1/g')"
 endif
 
 # IBM XLF compiler

--- a/sys/systems/summit.def
+++ b/sys/systems/summit.def
@@ -16,21 +16,28 @@ CCOMPILERS="clang, gcc, xlc"
 
 # GCC compiler
 ifeq ($(CC), gcc)
-  C_COMPILER_MODULE = gcc/9.1.0
+  C_COMPILER_MODULE = gcc/10.2.0
   C_VERSION = gcc -dumpversion
 endif
 
 # IBM XL compiler
 ifeq ($(CC), xlc)
-  C_COMPILER_MODULE = xl/16.1.1-7
-  C_VERSION = xlc -qversion | grep "Version: .*$$" | sed "s/Version: //g"
+  C_COMPILER_MODULE = xl/16.1.1-8
+  C_VERSION = xlc -qversion | grep "Version: .*" | sed "s/Version: //g"
 endif
 
 # Clang compiler
+# ifeq ($(CC), clang)
+#   C_COMPILER_MODULE = llvm/1.0-20190225
+#   C_VERSION = clang -v 2>&1 | grep -oh "clang version [0-9.]*"| grep -oh "version .*" | sed "s/.*/& CORAL/"
+# endif
+
+# Clang compiler
 ifeq ($(CC), clang)
-  C_COMPILER_MODULE = llvm/1.0-20190225
-  C_VERSION = clang -v 2>&1 | grep -oh 'clang version [0-9.]*'| grep -oh 'version .*' | sed 's/.*/& CORAL/'
+  C_COMPILER_MODULE = llvm/11.0.0-rc1; module load cuda/10.1.243
+  C_VERSION = clang -v 2>&1 | grep -oh "clang version [0-9.]*" | grep -oh "version .*"
 endif
+
 
 #---------------------------------------------------------------------------
 # C++ compilers
@@ -39,20 +46,26 @@ CXXCOMPILERS="clang++, g++, xlc++"
 
 # GCC compiler
 ifeq ($(CXX), g++)
-  CXX_COMPILER_MODULE = gcc/9.1.0
+  CXX_COMPILER_MODULE = gcc/10.2.0
   CXX_VERSION = g++ -dumpversion
 endif
 
 # IBM XL compiler
 ifeq ($(CXX), xlc++)
-  CXX_COMPILER_MODULE =  xl/16.1.1-7
-  CXX_VERSION = xlc -qversion | grep "Version: .*$$" | sed "s/Version: //g"
+  CXX_COMPILER_MODULE =  xl/16.1.1-8
+  CXX_VERSION = xlc -qversion | grep "Version: .*" | sed "s/Version: //g"
 endif
 
 # Clang compiler
+# ifeq ($(CXX), clang)
+#   CXX_COMPILER_MODULE = llvm/1.0-20190225
+#   CXX_VERSION = clang -v 2>&1 | grep -oh "clang version [0-9.]*"| grep -oh "version .*" | sed "s/.*/& CORAL/"
+# endif
+
+# Clang compiler
 ifeq ($(CXX), clang++)
-  CXX_COMPILER_MODULE = llvm/1.0-20190225
-  CXX_VERSION = clang++ -v 2>&1 | grep -oh 'clang version [0-9.]*' | grep -oh 'version .*' | sed 's/.*/& CORAL/'
+  CXX_COMPILER_MODULE = llvm/11.0.0-rc1; module load cuda/10.1.243
+  CXX_VERSION = clang++ -v 2>&1 | grep -oh "clang version [0-9.]*" | grep -oh "version .*"
 endif
 
 #---------------------------------------------------------------------------
@@ -62,14 +75,14 @@ FCOMPILERS="gfortran, xlf"
 
 # GCC compiler
 ifeq ($(FC), gfortran)
-  F_COMPILER_MODULE = gcc/9.1.0
+  F_COMPILER_MODULE = gcc/10.2.0
   F_VERSION = gfortran -dumpversion
 endif
 
 # IBM XL compiler
-# Summitdev happens to have a wrapper that without it we cannot execute
-# xlf with OMP 4.5 support. This wrapper is xlf_r
+# Summit happens to have a wrapper that we need in order to execute
+# xlf with OMP 4.5 support. This wrapper is xlf_r.
 ifeq ($(FC), $(filter $(FC), xlf xlf_r))
-  F_COMPILER_MODULE = xl/16.1.1-7
-  F_VERSION = xlf -qversion | grep 'Version: .*$$' | sed 's/Version: //g'
+  F_COMPILER_MODULE = xl/16.1.1-8
+  F_VERSION = xlf -qversion | grep "Version: .*" | sed "s/Version: //g"
 endif


### PR DESCRIPTION
This is a fix for a small issue with compiler version logging introduced by PR #132. We need to load the appropriate modules before collecting version information when `MODULE_LOAD` is enabled for the logs to have the right compiler versions.

For some reason after these changes there is a lot of unneeded `module load` output when using Clang on Summit without running `module purge` first. I am unsure how to get rid of it, but for now it is just a mild nuisance.

Also, I updated the compiler versions in `summit.def`