### PR TITLE
test_task_detach.c: Fix function + type names

### DIFF
--- a/tests/5.0/task/test_task_detach.c
+++ b/tests/5.0/task/test_task_detach.c
@@ -4,10 +4,10 @@
 //
 // This is a test of the 5.0 task detach clause. The clause should cause the
 // task construct to detach and not complete, causing the following taskwait
-// to block thread0 until thread1 fufills the event the task is detached to.
-// Order of events should be: code before omp_fufill_event() ~~ code in task
+// to block thread0 until thread1 fulfills the event the task is detached to.
+// Order of events should be: code before omp_fulfill_event() ~~ code in task
 // --> code after taskwait. This order is checked by recording the value of
-// variables set before the call to omp_fufill_event() and in the task.
+// variables set before the call to omp_fulfill_event() and in the task.
 //
 ////===----------------------------------------------------------------------===//
 #include <assert.h>
@@ -22,14 +22,14 @@ int test_task_detach() {
   OMPVV_INFOMSG("test_task_detach");
   int errors = 0, x = 0, y = 0;
   int num_threads = -1, record_x = -1, record_y = -1;
-  omp_event_t *flag_event;
+  omp_event_handle_t *flag_event;
 
 #pragma omp parallel num_threads(2) default(shared)
   {
     if (omp_get_thread_num() == 1 || omp_get_num_threads() < 2) {
       num_threads = omp_get_num_threads();
       x++;
-      omp_fufill_event(flag_event);
+      omp_fulfill_event(flag_event);
     }
     if (omp_get_thread_num() == 0) {
 #pragma omp task detach(flag_event)
@@ -46,7 +46,7 @@ int test_task_detach() {
   OMPVV_WARNING_IF(num_threads == 1, "Test ran with one thread, so the results are not conclusive");
 
   OMPVV_TEST_AND_SET_VERBOSE(errors, record_x != 1 || record_y != 1);
-  OMPVV_ERROR_IF(record_x == 0, "Taskwait did not wait for associated event to be fufilled");
+  OMPVV_ERROR_IF(record_x == 0, "Taskwait did not wait for associated event to be fulfilled");
   OMPVV_ERROR_IF(record_y == 0, "Taskwait did not wait for task body to execute");
   OMPVV_ERROR_IF(record_x == -1 || record_y == -1, "Recording variables were not set in the parallel region as expected.")
 


### PR DESCRIPTION
* tests/5.0/task/test_task_detach.c (test_task_detach): Use correct
  function and type names.
Namely:
* omp_fufill_event misses an -l- in "ful"(l) (→ omp_fulfill_event)
* omp_event_t: This was renamed before the final OpenMP 5.0 spec to omp_event_handle_t

See, e.g., https://www.openmp.org/spec-html/5.0/openmpsu162.html — while the pre-OpenMP 5.0 TR7 still had the previous type name: https://www.openmp.org//wp-content/uploads/openmp-TR7.pdf#page=408