### PR TITLE
Fixing data race and order issues in task detach test

### DIFF
--- a/tests/5.0/task/test_task_detach.c
+++ b/tests/5.0/task/test_task_detach.c
@@ -59,9 +59,9 @@ int test_task_detach() {
   OMPVV_WARNING_IF(num_threads == 1, "Test ran with one thread, so the results are not conclusive");
 
   OMPVV_TEST_AND_SET_VERBOSE(errors, record_x != 1);
-  OMPVV_ERROR_IF(record_x == 0, "Depend did not wait for associated event to be fulfilled");
-  OMPVV_ERROR_IF(record_y == 0, "Depend did not wait for task body to execute");
-  OMPVV_ERROR_IF(record_x == -1 || record_y == -1, "Recording variables were not set correctly")
+  OMPVV_ERROR_IF(record_x == 0, "Dependent task preceded callback, so detach did not work correctly.");
+  OMPVV_ERROR_IF(record_y == 0, "Dependent task preceded detached task body, so depend did not work correctly.");
+  OMPVV_ERROR_IF(record_x == -1 || record_y == -1, "Recording variables were not set correctly.")
 
     return errors;
 }

--- a/tests/5.0/task/test_task_detach.c
+++ b/tests/5.0/task/test_task_detach.c
@@ -59,11 +59,12 @@ int test_task_detach() {
   OMPVV_WARNING_IF(num_threads == 1, "Test ran with one thread, so the results are not conclusive");
 
   OMPVV_TEST_AND_SET_VERBOSE(errors, record_x != 1);
-  OMPVV_ERROR_IF(record_x == 0, "Dependent task preceded callback, so detach did not work correctly.");
+  OMPVV_ERROR_IF(record_x == 0, "Dependent task preceded event-fulfilling task, so detach did not work correctly.");
   OMPVV_ERROR_IF(record_y == 0, "Dependent task preceded detached task body, so depend did not work correctly.");
-  OMPVV_ERROR_IF(record_x == -1 || record_y == -1, "Recording variables were not set correctly.")
+  OMPVV_ERROR_IF(record_x == -1, "Event-fulfilling task's recording variable was not set in the final task.");
+  OMPVV_ERROR_IF(record_x == -1, "Detached task's recording variable was not set in the final task.");
 
-    return errors;
+  return errors;
 }
 
 int main() {

--- a/tests/5.0/task/test_task_detach.c
+++ b/tests/5.0/task/test_task_detach.c
@@ -23,7 +23,7 @@
 #define N 1024
 
 int test_callback(omp_event_handle_t event) {
-  omp_fulfill_event( event);
+  omp_fulfill_event(event);
   return 1;
 }
 

--- a/tests/5.0/task/test_task_detach.c
+++ b/tests/5.0/task/test_task_detach.c
@@ -42,10 +42,13 @@ int test_task_detach() {
     }
 #pragma omp task
     {
-      x = test_callback(flag_event);
+      x = 1;
+#pragma omp flush
+      test_callback(flag_event);
     }
 #pragma omp task depend(inout: y)
     {
+#pragma omp flush
       record_x = x;
       record_y = y;
       num_threads = omp_get_num_threads();
@@ -60,7 +63,7 @@ int test_task_detach() {
   OMPVV_ERROR_IF(record_y == 0, "Depend did not wait for task body to execute");
   OMPVV_ERROR_IF(record_x == -1 || record_y == -1, "Recording variables were not set correctly")
 
-  return errors;
+    return errors;
 }
 
 int main() {


### PR DESCRIPTION
This is an attempt to fix the data race in test_task_detach.c mentioned in issue #228. I changed the test structure substantially. The detached task now has its event fulfilled through a function call in another task. The event-fulfilling function is called "test_callback" (although this name is a bit misleading) as the test is inspired by the examples shown in [this presentation](https://openmpcon.org/wp-content/uploads/2018_Session2_Klemm.pdf). The order is checked by a writes to variables in the first two tasks which are checked in the third task. Data races on x between the second and third task are prevented using flush directives and by ordering the write to x before the event_fulfill.

The test passes Clang 11 only. XL and GCC do not seem to have the features implemented in the versions on Summit.