### PR TITLE
F90 5.0 test for requires unified shared memory

### DIFF
--- a/tests/5.0/requires/test_requires_unified_shared_memory.F90
+++ b/tests/5.0/requires/test_requires_unified_shared_memory.F90
@@ -1,0 +1,46 @@
+!===--- test_requires_unified_shared_memory.F90 ----------------------------------===//
+!
+! OpenMP API Version 5.0 Nov 2018
+!
+! This test just uses requries unified_shared_memory in a simple target region
+!  and it is intended to show that this would not break anything in the compiler
+!
+!===------------------------------------------------------------------------------===//
+
+#include "ompvv.F90"
+
+PROGRAM test_requires_unified_shared_memory
+   USE iso_fortran_env
+   USE ompvv_lib
+   USE omp_lib
+   implicit none
+   INTEGER:: errors, test_var
+   LOGICAL:: isOffloading
+
+!$omp requires unified_shared_memory
+
+   OMPVV_TEST_AND_SET_OFFLOADING(isOffloading)
+
+   OMPVV_WARNING_IF(isOffloading .eqv. .false., "With no offloading, unified shared memory is guaranteed due to host execution")
+
+   errors = 0
+
+   test_var = 0
+
+   OMPVV_INFOMSG("Unified shared memory testing")
+
+!$omp target map(tofrom: test_var)
+
+   test_var = test_var + 10
+
+!$omp end target
+
+   test_var = test_var + 10
+
+   OMPVV_TEST_AND_SET_VERBOSE(errors, test_var .ne. 20)
+
+   OMPVV_REPORT_AND_RETURN()
+
+END PROGRAM test_requires_unified_shared_memory
+      
+   


### PR DESCRIPTION
Straightforward test that checks to see if adding `requires unified_shared_memory` breaks the compiler. 

**gfortran 10.2.0 output**
20 | !$omp requires unified_shared_memory
      |       1
Error: Unclassifiable OpenMP directive at (1)

**xlf 16.1.1-8 output**
`line 20.7: 1515-019 (S) Syntax is incorrect.`



These results are similar to what we saw on .c version of test

**gcc 10.2.0 output**
sorry, unimplemented: 'unified_shared_memory' clause on 'requires' directive not supported yet
   16 | #pragma omp requires unified_shared_memory

**xlc 16.1.1-8 output**

error: expected an OpenMP directive
#pragma omp requires unified_shared_memory
            ^