### PR TITLE
Add 5.0 test of loop construct with order(concurrent)

### DIFF
--- a/tests/5.0/loop/test_loop_order_concurrent.c
+++ b/tests/5.0/loop/test_loop_order_concurrent.c
@@ -23,6 +23,7 @@
 int test_loop_order_concurrent() {
   OMPVV_INFOMSG("test_loop_order_concurrent");
   int errors = 0;
+  int total_wait_errors = 0;
   int x[N];
   int y[N];
   int z[N];
@@ -30,16 +31,24 @@ int test_loop_order_concurrent() {
 
   for (int i = 0; i < N; i++) {
     x[i] = 1;
-    y[i] = i;
-    z[i] = 2*i;
+    y[i] = i + 1;
+    z[i] = 2*(i + 1);
   }
 
-#pragma omp parallel num_threads(OMPVV_NUM_THREADS_HOST)
+#pragma omp parallel num_threads(OMPVV_NUM_THREADS_HOST) shared(total_wait_errors, x, y, z, num_threads)
   {
+    int wait_errors = 0;
 #pragma omp loop
     for (int i = 0; i < N; i++) {
       x[i] += y[i]*z[i];
     }
+    for (int i = 0; i < N; i++) {
+      if (x[i] == 1) {
+        wait_errors++;
+      }
+    }
+#pragma omp atomic update
+    total_wait_errors += wait_errors;
     if (omp_get_thread_num() == 0) {
       num_threads = omp_get_num_threads();
     }
@@ -52,8 +61,9 @@ int test_loop_order_concurrent() {
   OMPVV_WARNING_IF(num_threads == 1, "Test ran with one thread, so parallelism of loop construct can't be guaranteed.");
   OMPVV_TEST_AND_SET_VERBOSE(errors, num_threads < 1);
   OMPVV_ERROR_IF(num_threads < 1, "omp_get_num_threads() returned an invalid number of threads.");
+  OMPVV_ERROR_IF(total_wait_errors, "Threads in parallel region did not wait for loop region to finish before proceeding.");
 
-  return errors;
+  return errors + total_wait_errors;
 }
 
 

--- a/tests/5.0/loop/test_loop_order_concurrent.c
+++ b/tests/5.0/loop/test_loop_order_concurrent.c
@@ -40,7 +40,7 @@ int test_loop_order_concurrent() {
 #pragma omp parallel num_threads(OMPVV_NUM_THREADS_HOST) shared(total_wait_errors, x, y, z, num_threads)
   {
     int wait_errors = 0;
-#pragma omp loop
+#pragma omp loop order(concurrent)
     for (int i = 0; i < N; i++) {
       x[i] += y[i]*z[i];
     }

--- a/tests/5.0/loop/test_loop_order_concurrent.c
+++ b/tests/5.0/loop/test_loop_order_concurrent.c
@@ -6,8 +6,10 @@
 // order(concurrent) clause is assumed to be present if it is not present, so
 // this test covers the standalone loop directive as well. The test creates a
 // parallel region with a loop construct nested within, and performs simple
-// operations on an int array which are then checked for correctness. Note
-// that the number of
+// operations on an int array which are then checked for correctness. The
+// number of threads is checked in the parallel region but after the loop
+// construct because runtime API calls are not permitted in loop directive
+// regions.
 //
 ////===----------------------------------------------------------------------===//
 #include <assert.h>

--- a/tests/5.0/loop/test_loop_order_concurrent.c
+++ b/tests/5.0/loop/test_loop_order_concurrent.c
@@ -6,7 +6,9 @@
 // order(concurrent) clause is assumed to be present if it is not present, so
 // this test covers the standalone loop directive as well. The test creates a
 // parallel region with a loop construct nested within, and performs simple
-// operations on an int array which are then checked for correctness. The
+// operations on an int array which are then checked for correctness. 
+// Additionally, since loop binds to a parallel region the test checks that 
+// the threads all wait before proceeding out of the loop region. The
 // number of threads is checked in the parallel region but after the loop
 // construct because runtime API calls are not permitted in loop directive
 // regions.

--- a/tests/5.0/loop/test_loop_order_concurrent.c
+++ b/tests/5.0/loop/test_loop_order_concurrent.c
@@ -1,0 +1,64 @@
+//===--- test_loop_order_concurrent.c ---------------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// This test checks the loop directive with the order(concurrent) clause. The
+// order(concurrent) clause is assumed to be present if it is not present, so
+// this test covers the standalone loop directive as well. The test creates a
+// parallel region with a loop construct nested within, and performs simple
+// operations on an int array which are then checked for correctness. Note
+// that the number of
+//
+////===----------------------------------------------------------------------===//
+#include <assert.h>
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+int test_loop_order_concurrent() {
+  OMPVV_INFOMSG("test_loop_order_concurrent");
+  int errors = 0;
+  int x[N];
+  int y[N];
+  int z[N];
+  int num_threads = -1;
+
+  for (int i = 0; i < N; i++) {
+    x[i] = 1;
+    y[i] = i;
+    z[i] = 2*i;
+  }
+
+#pragma omp parallel num_threads(OMPVV_NUM_THREADS_HOST)
+  {
+#pragma omp loop
+    for (int i = 0; i < N; i++) {
+      x[i] += y[i]*z[i];
+    }
+    if (omp_get_thread_num() == 0) {
+      num_threads = omp_get_num_threads();
+    }
+  }
+
+  for (int i = 0; i < N; i++) {
+    OMPVV_TEST_AND_SET_VERBOSE(errors, x[i] != 1 + (y[i]*z[i]));
+  }
+
+  OMPVV_WARNING_IF(num_threads == 1, "Test ran with one thread, so parallelism of loop construct can't be guaranteed.");
+  OMPVV_TEST_AND_SET_VERBOSE(errors, num_threads < 1);
+  OMPVV_ERROR_IF(num_threads < 1, "omp_get_num_threads() returned an invalid number of threads.");
+
+  return errors;
+}
+
+
+int main() {
+  int errors = 0;
+
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_loop_order_concurrent());
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}


### PR DESCRIPTION
This test checks the loop directive with the order(concurrent) clause. According to 5.0 spec, the order(concurrent) clause is assumed to be present even when it is not, so this test also effectively checks the standalone loop directive. The test uses a similar approach to other worksharing loop directive tests we created for 4.5.

Right now on Summit, GCC passes this test while Clang and XL fail due to lack of implementation.