### PR TITLE
5.0 test of loop construct with bind clause

### DIFF
--- a/tests/5.0/loop/test_loop_bind.c
+++ b/tests/5.0/loop/test_loop_bind.c
@@ -16,10 +16,46 @@
 #include <stdlib.h>
 #include "ompvv.h"
 
-#define N 1024
+#define N 32
 
-int test_loop_bind() {
-  OMPVV_INFOMSG("test_loop_bind");
+int test_loop_bind_teams() {
+  OMPVV_INFOMSG("test_loop_bind_teams");
+  int errors = 0;
+  int x[N];
+  int y[N];
+  int z[N];
+  int num_teams = -1;
+
+  for (int i = 0; i < N; i++) {
+    x[i] = 1;
+    y[i] = i;
+    z[i] = 2*i;
+  }
+
+#pragma omp teams num_teams(OMPVV_NUM_TEAMS_DEVICE) thread_limit(OMPVV_NUM_THREADS_HOST)
+  {
+#pragma omp loop bind(teams)
+    for (int i = 0; i < N; i++) {
+      x[i] += y[i]*z[i];
+    }
+    if (omp_get_team_num() == 0) {
+      num_teams = omp_get_num_teams();
+    }
+  }
+
+  for (int i = 0; i < N; i++) {
+    OMPVV_TEST_AND_SET_VERBOSE(errors, x[i] != 1 + (y[i]*z[i]));
+  }
+
+  OMPVV_WARNING_IF(num_teams == 1, "Test ran with one team, so parallelism of loop construct with bind(teams) can't be guaranteed.");
+  OMPVV_TEST_AND_SET_VERBOSE(errors, num_teams < 1);
+  OMPVV_ERROR_IF(num_teams < 1, "omp_get_num_teams() returned an invalid value.");
+
+  return errors;
+}
+
+int test_loop_bind_parallel() {
+  OMPVV_INFOMSG("test_loop_bind_parallel");
   int errors = 0;
   int x[N][N];
   int y[N];
@@ -27,7 +63,9 @@ int test_loop_bind() {
   int num_threads = -1;
 
   for (int i = 0; i < N; i++) {
-    x[i] = 1;
+    for (int j = 0; j < N; j++) {
+      x[i][j] = 1;
+    }
     y[i] = i;
     z[i] = 2*i;
   }
@@ -36,18 +74,20 @@ int test_loop_bind() {
   for (int i = 0; i < N; i++) {
 #pragma omp parallel num_threads(OMPVV_NUM_THREADS_HOST)
     {
-#pragma omp loop binding(teams)
+#pragma omp loop bind(parallel)
       for (int j = 0; j < N; j++) {
         x[i][j] += y[i]*z[i];
       }
-      if (omp_get_thread_num() == 0) {
+      if (omp_get_thread_num() == 0 && omp_get_team_num() == 0) {
         num_threads = omp_get_num_threads();
       }
     }
   }
 
   for (int i = 0; i < N; i++) {
-    OMPVV_TEST_AND_SET_VERBOSE(errors, x[i] != 1 + (y[i]*z[i]));
+    for (int j = 0; j < N; j++) {
+      OMPVV_TEST_AND_SET_VERBOSE(errors, x[i][j] != 1 + (y[i]*z[i]));
+    }
   }
 
   OMPVV_WARNING_IF(num_threads == 1, "Test ran with one thread, so parallelism of loop construct can't be guaranteed.");
@@ -57,11 +97,55 @@ int test_loop_bind() {
   return errors;
 }
 
+int test_loop_bind_thread() {
+  OMPVV_INFOMSG("test_loop_bind_thread");
+  int errors = 0;
+  int x[N][N];
+  int y[N];
+  int z[N];
+  int num_threads = -1;
+
+  for (int i = 0; i < N; i++) {
+    for (int j = 0; j < N; j++) {
+      x[i][j] = 1;
+    }
+    y[i] = i;
+    z[i] = 2*i;
+  }
+
+#pragma omp teams distribute num_teams(OMPVV_NUM_TEAMS_DEVICE) thread_limit(OMPVV_NUM_THREADS_HOST)
+  for (int i = 0; i < N; i++) {
+#pragma omp parallel num_threads(OMPVV_NUM_THREADS_HOST)
+    {
+#pragma omp loop bind(thread)
+      for (int j = 0; j < N; j++) {
+        x[i][j] += y[i]*z[i];
+      }
+      if (omp_get_thread_num() == 0 && omp_get_team_num() == 0) {
+        num_threads = omp_get_num_threads();
+      }
+    }
+  }
+
+  for (int i = 0; i < N; i++) {
+    for (int j = 0; j < N; j++) {
+      OMPVV_TEST_AND_SET_VERBOSE(errors, x[i][j] != (1 + num_threads*(y[i]*z[i])));
+    }
+  }
+
+  OMPVV_WARNING_IF(num_threads == 1, "Test ran with one thread, so parallelism of loop construct can't be guaranteed.");
+  OMPVV_TEST_AND_SET_VERBOSE(errors, num_threads < 1);
+  OMPVV_ERROR_IF(num_threads < 1, "omp_get_num_threads() returned an invalid number of threads.");
+
+  return errors;
+}
 
 int main() {
   int errors = 0;
 
-  OMPVV_TEST_AND_SET_VERBOSE(errors, test_loop_bind());
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_loop_bind_teams());
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_loop_bind_parallel());
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_loop_bind_thread());
 
   OMPVV_REPORT_AND_RETURN(errors);
 }

--- a/tests/5.0/loop/test_loop_bind.c
+++ b/tests/5.0/loop/test_loop_bind.c
@@ -1,0 +1,67 @@
+//===--- test_loop_bind.c ---------------------------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// This test checks the loop directive with the order(concurrent) clause. The
+// order(concurrent) clause is assumed to be present if it is not present, so
+// this test covers the standalone loop directive as well. The test creates a
+// parallel region with a loop construct nested within, and performs simple
+// operations on an int array which are then checked for correctness. Note
+// that the number of
+//
+////===----------------------------------------------------------------------===//
+#include <assert.h>
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+int test_loop_bind() {
+  OMPVV_INFOMSG("test_loop_bind");
+  int errors = 0;
+  int x[N][N];
+  int y[N];
+  int z[N];
+  int num_threads = -1;
+
+  for (int i = 0; i < N; i++) {
+    x[i] = 1;
+    y[i] = i;
+    z[i] = 2*i;
+  }
+
+#pragma omp teams distribute num_teams(OMPVV_NUM_TEAMS_DEVICE) thread_limit(OMPVV_NUM_THREADS_HOST)
+  for (int i = 0; i < N; i++) {
+#pragma omp parallel num_threads(OMPVV_NUM_THREADS_HOST)
+    {
+#pragma omp loop binding(teams)
+      for (int j = 0; j < N; j++) {
+        x[i][j] += y[i]*z[i];
+      }
+      if (omp_get_thread_num() == 0) {
+        num_threads = omp_get_num_threads();
+      }
+    }
+  }
+
+  for (int i = 0; i < N; i++) {
+    OMPVV_TEST_AND_SET_VERBOSE(errors, x[i] != 1 + (y[i]*z[i]));
+  }
+
+  OMPVV_WARNING_IF(num_threads == 1, "Test ran with one thread, so parallelism of loop construct can't be guaranteed.");
+  OMPVV_TEST_AND_SET_VERBOSE(errors, num_threads < 1);
+  OMPVV_ERROR_IF(num_threads < 1, "omp_get_num_threads() returned an invalid number of threads.");
+
+  return errors;
+}
+
+
+int main() {
+  int errors = 0;
+
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_loop_bind());
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.0/loop/test_loop_bind.c
+++ b/tests/5.0/loop/test_loop_bind.c
@@ -2,12 +2,11 @@
 //
 // OpenMP API Version 5.0 Nov 2018
 //
-// This test checks the loop directive with the order(concurrent) clause. The
-// order(concurrent) clause is assumed to be present if it is not present, so
-// this test covers the standalone loop directive as well. The test creates a
-// parallel region with a loop construct nested within, and performs simple
-// operations on an int array which are then checked for correctness. Note
-// that the number of
+// This test checks the loop directive with the bind(binding) clause. The bind
+// clause indicates that the loop construct should apply in the context of the
+// given binding, one of teams, parallel, or thread. Each of these bindings
+// is tested in an appropriate context and the correctness of results of
+// array operations in the nested loop is checked.
 //
 ////===----------------------------------------------------------------------===//
 #include <assert.h>
@@ -21,13 +20,15 @@
 int test_loop_bind_teams() {
   OMPVV_INFOMSG("test_loop_bind_teams");
   int errors = 0;
-  int x[N];
+  int x[N][N];
   int y[N];
   int z[N];
   int num_teams = -1;
 
   for (int i = 0; i < N; i++) {
-    x[i] = 1;
+    for (int j = 0; j < N; j++) {
+      x[i][j] = 1;
+    }
     y[i] = i;
     z[i] = 2*i;
   }
@@ -36,16 +37,21 @@ int test_loop_bind_teams() {
   {
 #pragma omp loop bind(teams)
     for (int i = 0; i < N; i++) {
-      x[i] += y[i]*z[i];
+      for (int j = 0; j < N; j++) {
+        x[i][j] += y[i]*z[i];
+      }
     }
-    if (omp_get_team_num() == 0) {
+    if (omp_get_thread_num() == 0 && omp_get_team_num() == 0) {
       num_teams = omp_get_num_teams();
     }
   }
 
   for (int i = 0; i < N; i++) {
-    OMPVV_TEST_AND_SET_VERBOSE(errors, x[i] != 1 + (y[i]*z[i]));
+    for (int j = 0; j < N; j++) {
+      OMPVV_TEST_AND_SET_VERBOSE(errors, x[i][j] != 1 + (y[i]*z[i]));
+    }
   }
+
 
   OMPVV_WARNING_IF(num_teams == 1, "Test ran with one team, so parallelism of loop construct with bind(teams) can't be guaranteed.");
   OMPVV_TEST_AND_SET_VERBOSE(errors, num_teams < 1);
@@ -70,17 +76,16 @@ int test_loop_bind_parallel() {
     z[i] = 2*i;
   }
 
-#pragma omp teams distribute num_teams(OMPVV_NUM_TEAMS_DEVICE) thread_limit(OMPVV_NUM_THREADS_HOST)
-  for (int i = 0; i < N; i++) {
 #pragma omp parallel num_threads(OMPVV_NUM_THREADS_HOST)
-    {
+  {
 #pragma omp loop bind(parallel)
+    for (int i = 0; i < N; i++) {
       for (int j = 0; j < N; j++) {
         x[i][j] += y[i]*z[i];
       }
-      if (omp_get_thread_num() == 0 && omp_get_team_num() == 0) {
-        num_threads = omp_get_num_threads();
-      }
+    }
+    if (omp_get_thread_num() == 0 && omp_get_team_num() == 0) {
+      num_threads = omp_get_num_threads();
     }
   }
 
@@ -97,8 +102,50 @@ int test_loop_bind_parallel() {
   return errors;
 }
 
-int test_loop_bind_thread() {
-  OMPVV_INFOMSG("test_loop_bind_thread");
+int test_loop_bind_thread_teams() {
+  OMPVV_INFOMSG("test_loop_bind_thread_teams");
+  int errors = 0;
+  int x[N][N];
+  int y[N];
+  int z[N];
+  int num_teams = -1;
+
+  for (int i = 0; i < N; i++) {
+    for (int j = 0; j < N; j++) {
+      x[i][j] = 1;
+    }
+    y[i] = i;
+    z[i] = 2*i;
+  }
+
+#pragma omp teams num_teams(OMPVV_NUM_TEAMS_DEVICE) thread_limit(OMPVV_NUM_THREADS_HOST)
+  {
+#pragma omp loop bind(thread)
+    for (int i = 0; i < N; i++) {
+      for (int j = 0; j < N; j++) {
+        x[i][j] += y[i]*z[i];
+      }
+    }
+    if (omp_get_thread_num() == 0 && omp_get_team_num() == 0) {
+      num_teams = omp_get_num_teams();
+    }
+  }
+
+  for (int i = 0; i < N; i++) {
+    for (int j = 0; j < N; j++) {
+      OMPVV_TEST_AND_SET_VERBOSE(errors, x[i][j] != (1 + num_teams*(y[i]*z[i])));
+    }
+  }
+
+  OMPVV_WARNING_IF(num_teams == 1, "Test ran with one team, so parallelism of loop construct can't be guaranteed.");
+  OMPVV_TEST_AND_SET_VERBOSE(errors, num_teams < 1);
+  OMPVV_ERROR_IF(num_teams < 1, "omp_get_num_teams() returned an invalid number of teams.");
+
+  return errors;
+}
+
+int test_loop_bind_thread_parallel() {
+  OMPVV_INFOMSG("test_loop_bind_thread_parallel");
   int errors = 0;
   int x[N][N];
   int y[N];
@@ -113,17 +160,16 @@ int test_loop_bind_thread() {
     z[i] = 2*i;
   }
 
-#pragma omp teams distribute num_teams(OMPVV_NUM_TEAMS_DEVICE) thread_limit(OMPVV_NUM_THREADS_HOST)
-  for (int i = 0; i < N; i++) {
 #pragma omp parallel num_threads(OMPVV_NUM_THREADS_HOST)
-    {
+  {
 #pragma omp loop bind(thread)
+    for (int i = 0; i < N; i++) {
       for (int j = 0; j < N; j++) {
         x[i][j] += y[i]*z[i];
       }
-      if (omp_get_thread_num() == 0 && omp_get_team_num() == 0) {
-        num_threads = omp_get_num_threads();
-      }
+    }
+    if (omp_get_thread_num() == 0 && omp_get_team_num() == 0) {
+      num_threads = omp_get_num_threads();
     }
   }
 
@@ -145,7 +191,8 @@ int main() {
 
   OMPVV_TEST_AND_SET_VERBOSE(errors, test_loop_bind_teams());
   OMPVV_TEST_AND_SET_VERBOSE(errors, test_loop_bind_parallel());
-  OMPVV_TEST_AND_SET_VERBOSE(errors, test_loop_bind_thread());
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_loop_bind_thread_teams());
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_loop_bind_thread_parallel());
 
   OMPVV_REPORT_AND_RETURN(errors);
 }

--- a/tests/5.0/loop/test_loop_nested.c
+++ b/tests/5.0/loop/test_loop_nested.c
@@ -1,0 +1,112 @@
+//===--- test_loop_nested.c -------------------------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// This test checks the loop directive without any clauses with nested loops.
+// The construct is applied in a teams and a parallel construct and the
+// correctness of array operations in the nested loops in the loop construct
+// is checked. Compare with test_loop_bind.c, which performs the same
+// operations in a nested loop with a bind clause.
+//
+////===----------------------------------------------------------------------===//
+#include <assert.h>
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 32
+
+int test_loop_nested_teams() {
+  OMPVV_INFOMSG("test_loop_nested_teams");
+  int errors = 0;
+  int x[N][N];
+  int y[N];
+  int z[N];
+  int num_teams = -1;
+
+  for (int i = 0; i < N; i++) {
+    for (int j = 0; j < N; j++) {
+      x[i][j] = 1;
+    }
+    y[i] = i;
+    z[i] = 2*i;
+  }
+
+#pragma omp teams num_teams(OMPVV_NUM_TEAMS_DEVICE) thread_limit(OMPVV_NUM_THREADS_HOST)
+  {
+#pragma omp loop
+    for (int i = 0; i < N; i++) {
+      for (int j = 0; j < N; j++) {
+        x[i][j] += y[i]*z[i];
+      }
+    }
+    if (omp_get_thread_num() == 0 && omp_get_team_num() == 0) {
+      num_teams = omp_get_num_teams();
+    }
+  }
+
+  for (int i = 0; i < N; i++) {
+    for (int j = 0; j < N; j++) {
+      OMPVV_TEST_AND_SET_VERBOSE(errors, x[i][j] != 1 + (y[i]*z[i]));
+    }
+  }
+
+
+  OMPVV_WARNING_IF(num_teams == 1, "Test ran with one team, so parallelism of loop construct can't be guaranteed.");
+  OMPVV_TEST_AND_SET_VERBOSE(errors, num_teams < 1);
+  OMPVV_ERROR_IF(num_teams < 1, "omp_get_num_teams() returned an invalid value.");
+
+  return errors;
+}
+
+int test_loop_nested_parallel() {
+  OMPVV_INFOMSG("test_loop_nested_parallel");
+  int errors = 0;
+  int x[N][N];
+  int y[N];
+  int z[N];
+  int num_threads = -1;
+
+  for (int i = 0; i < N; i++) {
+    for (int j = 0; j < N; j++) {
+      x[i][j] = 1;
+    }
+    y[i] = i;
+    z[i] = 2*i;
+  }
+
+#pragma omp parallel num_threads(OMPVV_NUM_THREADS_HOST)
+  {
+#pragma omp loop
+    for (int i = 0; i < N; i++) {
+      for (int j = 0; j < N; j++) {
+        x[i][j] += y[i]*z[i];
+      }
+    }
+    if (omp_get_thread_num() == 0 && omp_get_team_num() == 0) {
+      num_threads = omp_get_num_threads();
+    }
+  }
+
+  for (int i = 0; i < N; i++) {
+    for (int j = 0; j < N; j++) {
+      OMPVV_TEST_AND_SET_VERBOSE(errors, x[i][j] != 1 + (y[i]*z[i]));
+    }
+  }
+
+  OMPVV_WARNING_IF(num_threads == 1, "Test ran with one thread, so parallelism of loop construct can't be guaranteed.");
+  OMPVV_TEST_AND_SET_VERBOSE(errors, num_threads < 1);
+  OMPVV_ERROR_IF(num_threads < 1, "omp_get_num_threads() returned an invalid number of threads.");
+
+  return errors;
+}
+
+int main() {
+  int errors = 0;
+
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_loop_nested_teams());
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_loop_nested_parallel());
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}


### PR DESCRIPTION
This tests the loop construct with the bind clause with each of its three possible bindings, team, parallel and thread. This test uses a similar array computation and value check to the previous loop construct test. Right now, gcc usually passes this test but will sometimes fail due to a data race on the array in the `bind(thread)` test. I am not sure if this is a compiler issue or a spec interpretation issue, so I made this PR to get feedback on the test.

Also, 5.0 states that when `bind(teams)` is used, threads can continue execution after executing the loop region, while they must wait for other threads when `bind(thread)` or `bind(parallel)` is used. I am thinking about adding a check that the threads wait for other threads before continuing in the `bind(thread)` and `bind(parallel)` tests.