### PR TITLE
Adding OpenMP kernels from GridMini

### DIFF
--- a/tests/4.5/application_kernels/gridmini_map_struct_float_mul.cpp
+++ b/tests/4.5/application_kernels/gridmini_map_struct_float_mul.cpp
@@ -57,8 +57,8 @@ int main(int argc, char* argv[]){
   if(errors)
     OMPVV_INFOMSG("Maping of entire struct is not supported by this OpenMP implementation.\n");	
 
-
-  OMPVV_REPORT_AND_RETURN(errors);
+  //No error will be reported even if it is recorded.
+  OMPVV_REPORT_AND_RETURN(0);
 
 }
 

--- a/tests/4.5/application_kernels/gridmini_map_struct_float_mul.cpp
+++ b/tests/4.5/application_kernels/gridmini_map_struct_float_mul.cpp
@@ -1,0 +1,64 @@
+//===-- gridmini_float_mul_offload.c ---------------------------------------===//
+//
+// OpenMP API Version 4.5 Nov 2015
+//
+// This test checks that the float multiplication of members of the struct 'vec'
+// in the offloaded region provides the same answer as calculated by host. 
+// Since support for struct on map is implementation specific in 4.5 the test does 
+// not have a fail condition. 
+//
+//===----------------------------------------------------------------------===//
+
+#include <cstdlib>
+#include <stdio.h>
+#include <iostream>
+#include "ompvv.h"
+#include "omp.h"
+
+using namespace std;
+struct vec {
+  float v1;
+  float v2;
+};
+
+inline  vec mult(vec x, vec y){
+  vec out;
+  out.v1 = x.v1*y.v1;
+  out.v2 = x.v2*y.v2;
+  return out;
+}
+
+int main(int argc, char* argv[]){
+  OMPVV_TEST_OFFLOADING;
+
+  int errors = 0;
+  int N = 10;
+  float x = (float)rand()/(float)(RAND_MAX/10.0);
+  float y = (float)rand()/(float)(RAND_MAX/5.0);
+  vec in1,in2;
+  in1.v1 = x;
+  in1.v2 = x;
+  in2.v1 = y;
+  in2.v2 = y;
+  vec out[N];
+
+  //calulate on host
+  vec expected = mult(in1,in2);
+
+#pragma omp target teams distribute parallel for map(to:in1,in2) map(from:out[0:N])
+    for(int n = 0; n < N; n++) {
+      out[n] = mult(in1,in2);
+    }
+    
+  for(int n = 0; n < N; n++) {
+    OMPVV_TEST_AND_SET(errors,out[n].v1 != expected.v1);
+    OMPVV_TEST_AND_SET(errors,out[n].v2 != expected.v2);
+  }
+  if(errors)
+    OMPVV_INFOMSG("Maping of entire struct is not supported by this OpenMP implementation.\n");	
+
+
+  OMPVV_REPORT_AND_RETURN(errors);
+
+}
+

--- a/tests/5.0/application_kernels/gridmini_map_class.cpp
+++ b/tests/5.0/application_kernels/gridmini_map_class.cpp
@@ -1,0 +1,61 @@
+//===-- gridmini_map_struct_array.cpp ---------------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// This test checks that support for mapping attributes of class object.  
+// This is verified by checking result of mult of array attribute in the 
+// offloaded region provides the same answer as calculated on host. 
+//
+//===----------------------------------------------------------------------===//
+
+#include <cstdlib>
+#include <stdio.h>
+#include <iostream>
+#include "ompvv.h"
+#include "omp.h"
+
+using namespace std;
+class vec {
+ public:
+  float v[2];
+};
+
+inline  vec mult(vec x, vec y){
+  vec out;
+  out.v[0] = x.v[0]*y.v[0];
+  out.v[1] = x.v[1]*y.v[1];
+  return out;
+}
+
+int main(int argc, char* argv[]){
+  OMPVV_TEST_OFFLOADING;
+
+  int errors = 0;
+  int N = 10;
+  float x = (float)rand()/(float)(RAND_MAX/10.0);
+  float y = (float)rand()/(float)(RAND_MAX/5.0);
+  vec in1,in2;
+  in1.v[0] = x;
+  in1.v[1] = x;
+  in2.v[0] = y;
+  in2.v[1] = y;
+  vec out[N];
+
+  //calulate on host
+  vec expected = mult(in1,in2);
+
+#pragma omp target teams distribute parallel for map(to:in1,in2) map(from:out[0:N])
+    for(int n = 0; n < N; n++) {
+      out[n] = mult(in1,in2);
+    }
+    
+  for(int n = 0; n < N; n++) {
+    OMPVV_TEST_AND_SET(errors,out[n].v[0] != expected.v[0]);
+    OMPVV_TEST_AND_SET(errors,out[n].v[0] != expected.v[1]);
+  }
+
+
+  OMPVV_REPORT_AND_RETURN(errors);
+
+}
+

--- a/tests/5.0/application_kernels/gridmini_map_struct_array.cpp
+++ b/tests/5.0/application_kernels/gridmini_map_struct_array.cpp
@@ -1,0 +1,62 @@
+//===-- gridmini_map_struct_array.cpp ---------------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// This test checks that the float multiplication of array elements which is a 
+// member of the struct 'vec'in the offloaded region provides the same answer 
+// as calculated by host. OpenMP 5.0 spec states that 'If a list item in a map 
+// clause is a variable of structure type then it is treated as if each structure 
+// element contained in the variable is a list item in the clause.'
+//
+//===----------------------------------------------------------------------===//
+
+#include <cstdlib>
+#include <stdio.h>
+#include <iostream>
+#include "ompvv.h"
+#include "omp.h"
+
+using namespace std;
+struct vec {
+  float v[2];
+};
+
+inline  vec mult(vec x, vec y){
+  vec out;
+  out.v[0] = x.v[0]*y.v[0];
+  out.v[1] = x.v[1]*y.v[1];
+  return out;
+}
+
+int main(int argc, char* argv[]){
+  OMPVV_TEST_OFFLOADING;
+
+  int errors = 0;
+  int N = 10;
+  float x = (float)rand()/(float)(RAND_MAX/10.0);
+  float y = (float)rand()/(float)(RAND_MAX/5.0);
+  vec in1,in2;
+  in1.v[0] = x;
+  in1.v[1] = x;
+  in2.v[0] = y;
+  in2.v[1] = y;
+  vec out[N];
+
+  //calulate on host
+  vec expected = mult(in1,in2);
+
+#pragma omp target teams distribute parallel for map(to:in1,in2) map(from:out[0:N])
+    for(int n = 0; n < N; n++) {
+      out[n] = mult(in1,in2);
+    }
+    
+  for(int n = 0; n < N; n++) {
+    OMPVV_TEST_AND_SET(errors,out[n].v[0] != expected.v[0]);
+    OMPVV_TEST_AND_SET(errors,out[n].v[0] != expected.v[1]);
+  }
+
+
+  OMPVV_REPORT_AND_RETURN(errors);
+
+}
+

--- a/tests/5.0/application_kernels/gridmini_map_struct_float_mul.cpp
+++ b/tests/5.0/application_kernels/gridmini_map_struct_float_mul.cpp
@@ -1,0 +1,63 @@
+//===-- gridmini_map_struct_float_mul.cpp ---------------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// This test checks that the float multiplication of members of the struct 'vec'
+// in the offloaded region provides the same answer as calculated by host. 
+// OpenMP 5.0 spec states that 'If a list item in a map clause is a variable of 
+// structure type then it is treated as if each structure element contained in the 
+// variable is a list item in the clause.'
+//
+//===----------------------------------------------------------------------===//
+
+#include <cstdlib>
+#include <stdio.h>
+#include <iostream>
+#include "ompvv.h"
+#include "omp.h"
+
+using namespace std;
+struct vec {
+  float v1;
+  float v2;
+};
+
+inline  vec mult(vec x, vec y){
+  vec out;
+  out.v1 = x.v1*y.v1;
+  out.v2 = x.v2*y.v2;
+  return out;
+}
+
+int main(int argc, char* argv[]){
+  OMPVV_TEST_OFFLOADING;
+
+  int errors = 0;
+  int N = 10;
+  float x = (float)rand()/(float)(RAND_MAX/10.0);
+  float y = (float)rand()/(float)(RAND_MAX/5.0);
+  vec in1,in2;
+  in1.v1 = x;
+  in1.v2 = x;
+  in2.v1 = y;
+  in2.v2 = y;
+  vec out[N];
+
+  //calulate on host
+  vec expected = mult(in1,in2);
+
+#pragma omp target teams distribute parallel for map(to:in1,in2) map(from:out[0:N])
+    for(int n = 0; n < N; n++) {
+      out[n] = mult(in1,in2);
+    }
+    
+  for(int n = 0; n < N; n++) {
+    OMPVV_TEST_AND_SET(errors,out[n].v1 != expected.v1);
+    OMPVV_TEST_AND_SET(errors,out[n].v2 != expected.v2);
+  }
+
+
+  OMPVV_REPORT_AND_RETURN(errors);
+
+}
+

--- a/tests/5.0/application_kernels/gridmini_map_template.cpp
+++ b/tests/5.0/application_kernels/gridmini_map_template.cpp
@@ -17,8 +17,8 @@
 using namespace std;
 template <typename T>
 struct vec {
-  float v1;
-  float v2;
+  T v1;
+  T v2;
 };
 
 template <typename T> vec<T> mult(vec<T> x, vec<T> y){

--- a/tests/5.0/application_kernels/gridmini_map_template.cpp
+++ b/tests/5.0/application_kernels/gridmini_map_template.cpp
@@ -1,0 +1,62 @@
+//===-- gridmini_map_template.cpp - ---------------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// This test checks for support for C++ template by verifying that the multiplication 
+// of members of the struct 'vec' in the offloaded region provides the same answer 
+// as calculated by host. 
+//
+//===----------------------------------------------------------------------===//
+
+#include <cstdlib>
+#include <stdio.h>
+#include <iostream>
+#include "ompvv.h"
+#include "omp.h"
+
+using namespace std;
+template <typename T>
+struct vec {
+  float v1;
+  float v2;
+};
+
+template <typename T> vec<T> mult(vec<T> x, vec<T> y){
+  vec<T> out;
+  out.v1 = x.v1*y.v1;
+  out.v2 = x.v2*y.v2;
+  return out;
+}
+
+int main(int argc, char* argv[]){
+  OMPVV_TEST_OFFLOADING;
+
+  int errors = 0;
+  int N = 10;
+  float x = (float)rand()/(float)(RAND_MAX/10.0);
+  float y = (float)rand()/(float)(RAND_MAX/5.0);
+  vec<float> in1,in2;
+  in1.v1 = x;
+  in1.v2 = x;
+  in2.v1 = y;
+  in2.v2 = y;
+  vec<float> out[N];
+
+  //calulate on host
+  vec<float> expected = mult(in1,in2);
+
+#pragma omp target teams distribute parallel for map(to:in1,in2) map(from:out[0:N])
+    for(int n = 0; n < N; n++) {
+      out[n] = mult(in1,in2);
+    }
+    
+  for(int n = 0; n < N; n++) {
+    OMPVV_TEST_AND_SET(errors,out[n].v1 != expected.v1);
+    OMPVV_TEST_AND_SET(errors,out[n].v2 != expected.v2);
+  }
+
+
+  OMPVV_REPORT_AND_RETURN(errors);
+
+}
+

--- a/tests/5.0/application_kernels/gridmini_map_template_array.cpp
+++ b/tests/5.0/application_kernels/gridmini_map_template_array.cpp
@@ -1,0 +1,61 @@
+//===-- gridmini_map_struct_array.cpp ---------------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// This test checks support for C++ template via mult on array elements. The
+// array is a member of the struct 'vec'in the offloaded region provides the same answer 
+// as calculated by host. 
+//
+//===----------------------------------------------------------------------===//
+
+#include <cstdlib>
+#include <stdio.h>
+#include <iostream>
+#include "ompvv.h"
+#include "omp.h"
+
+using namespace std;
+template <typename T>
+struct vec {
+  T v[2];
+};
+
+template <typename T> vec<T> mult(vec<T> x, vec<T> y){
+  vec<T> out;
+  out.v[0] = x.v[0]*y.v[0];
+  out.v[1] = x.v[1]*y.v[1];
+  return out;
+}
+
+int main(int argc, char* argv[]){
+  OMPVV_TEST_OFFLOADING;
+
+  int errors = 0;
+  int N = 10;
+  float x = (float)rand()/(float)(RAND_MAX/10.0);
+  float y = (float)rand()/(float)(RAND_MAX/5.0);
+  vec<float> in1,in2;
+  in1.v[0] = x;
+  in1.v[1] = x;
+  in2.v[0] = y;
+  in2.v[1] = y;
+  vec<float> out[N];
+
+  //calulate on host
+  vec<float> expected = mult(in1,in2);
+
+#pragma omp target teams distribute parallel for map(to:in1,in2) map(from:out[0:N])
+    for(int n = 0; n < N; n++) {
+      out[n] = mult(in1,in2);
+    }
+    
+  for(int n = 0; n < N; n++) {
+    OMPVV_TEST_AND_SET(errors,out[n].v[0] != expected.v[0]);
+    OMPVV_TEST_AND_SET(errors,out[n].v[0] != expected.v[1]);
+  }
+
+
+  OMPVV_REPORT_AND_RETURN(errors);
+
+}
+

--- a/tests/5.0/application_kernels/gridmini_ptr.cpp
+++ b/tests/5.0/application_kernels/gridmini_ptr.cpp
@@ -1,0 +1,59 @@
+//===-- gridmini_map_struct_array.cpp ---------------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// This test checks that the float multiplication of array elements which is a 
+// member of the struct 'vec'in the offloaded region provides the same answer 
+// as calculated by host. The test also checks for support for ptr notations.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cstdlib>
+#include <stdio.h>
+#include <iostream>
+#include "ompvv.h"
+#include "omp.h"
+
+using namespace std;
+struct vec {
+  float v[2];
+};
+
+inline  void mult(vec *out, vec x, vec y){
+  out->v[0] = x.v[0] * y.v[0];
+  out->v[1] = x.v[1] * y.v[1];
+}
+
+int main(int argc, char* argv[]){
+  OMPVV_TEST_OFFLOADING;
+
+  int errors = 0;
+  int N = 10;
+  float x = (float)rand()/(float)(RAND_MAX/10.0);
+  float y = (float)rand()/(float)(RAND_MAX/5.0);
+  vec in1,in2;
+  in1.v[0] = x;
+  in1.v[1] = x;
+  in2.v[0] = y;
+  in2.v[1] = y;
+  vec out[N];
+
+  //calulate on host
+  vec expected;
+  mult(&expected,in1,in2);
+
+#pragma omp target teams distribute parallel for map(to:in1,in2) map(from:out[0:N])
+    for(int n = 0; n < N; n++) {
+      mult(out+n, in1, in2);
+    }
+    
+  for(int n = 0; n < N; n++) {
+    OMPVV_TEST_AND_SET(errors,out[n].v[0] != expected.v[0]);
+    OMPVV_TEST_AND_SET(errors,out[n].v[0] != expected.v[1]);
+  }
+
+
+  OMPVV_REPORT_AND_RETURN(errors);
+
+}
+


### PR DESCRIPTION
These are OpenMP kernels from GridMini provided by Meifeng. Most work with xl but fail with gcc. This mostly has to do with OpenMP mapping of structs which was further clarified in OpenMP spec 5.0. 