### PR TITLE
New 5.0 tests of loop with reduction clause

### DIFF
--- a/tests/5.0/loop/test_loop_reduction_add.c
+++ b/tests/5.0/loop/test_loop_reduction_add.c
@@ -1,6 +1,6 @@
-//===--- test_target_teams_distribute_reduction_add.c-------------------------===//
+//===--- test_loop_reduction_add.c ------------------------------------------===//
 //
-// OpenMP API Version 4.5 Nov 2015
+// OpenMP API Version 5.0 Nov 2018
 //
 // This test uses the reduction clause on a loop directive, testing that the
 // variable in the reduction clause is properly reduced using the add
@@ -20,7 +20,7 @@ int test_add() {
   int a[N];
   int b[N];
   int total = 0;
-  int host_total = 0;
+  int expect_total = 0;
   int errors = 0;
   int num_threads[N];
 
@@ -36,26 +36,24 @@ int test_add() {
     for (int x = 0; x < N; ++x) {
       total += a[x] + b[x];
     }
-#pragma omp master
-    {
-      for (int x = 0; x < N; ++x) {
-        num_threads[x] = omp_get_num_threads();
-      }
+#pragma omp for
+    for (int x = 0; x < N; ++x) {
+      num_threads[x] = omp_get_num_threads();
     }
   }
 
   for (int x = 0; x < N; ++x) {
-    host_total += a[x] + b[x];
+    expect_total += a[x] + b[x];
   }
 
   for (int x = 1; x < N; ++x) {
-    OMPVV_WARNING_IF(num_threads[x - 1] != num_threads[x], "Kernel reported differing numbers of threads.  Validity of testing of reduction clause cannot be guaranteed.");
+    OMPVV_WARNING_IF(num_threads[x - 1] != num_threads[x], "Test reported differing numbers of threads.  Validity of testing of reduction clause cannot be guaranteed.");
   }
-  OMPVV_WARNING_IF(num_threads[0] == 1, "Test operated with one team.  Reduction clause cannot be tested.");
+  OMPVV_WARNING_IF(num_threads[0] == 1, "Test operated with one thread.  Reduction clause cannot be tested.");
   OMPVV_WARNING_IF(num_threads[0] <= 0, "Test reported invalid number of threads.  Validity of testing of reduction clause cannot be guaranteed.");
 
-  OMPVV_TEST_AND_SET_VERBOSE(errors, host_total != total);
-  OMPVV_ERROR_IF(host_total != total, "Total on device is %d but expected total from host is %d.", total, host_total);
+  OMPVV_TEST_AND_SET_VERBOSE(errors, expect_total != total);
+  OMPVV_ERROR_IF(expect_total != total, "Total from loop directive is %d but expected total is %d.", total, expect_total);
 
   return errors;
 }

--- a/tests/5.0/loop/test_loop_reduction_add.c
+++ b/tests/5.0/loop/test_loop_reduction_add.c
@@ -59,8 +59,6 @@ int test_add() {
 }
 
 int main() {
-  OMPVV_TEST_OFFLOADING;
-
   int total_errors = 0;
 
   OMPVV_TEST_AND_SET_VERBOSE(total_errors, test_add() != 0);

--- a/tests/5.0/loop/test_loop_reduction_add.c
+++ b/tests/5.0/loop/test_loop_reduction_add.c
@@ -1,0 +1,71 @@
+//===--- test_target_teams_distribute_reduction_add.c-------------------------===//
+//
+// OpenMP API Version 4.5 Nov 2015
+//
+// This test uses the reduction clause on a loop directive, testing that the
+// variable in the reduction clause is properly reduced using the add
+// operator.
+//
+////===----------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+#include <math.h>
+
+#define N 1024
+
+int test_add() {
+  int a[N];
+  int b[N];
+  int total = 0;
+  int host_total = 0;
+  int errors = 0;
+  int num_threads[N];
+
+  for (int x = 0; x < N; ++x) {
+    a[x] = 1;
+    b[x] = x;
+    num_threads[x] = -1;
+  }
+
+#pragma omp parallel num_threads(OMPVV_NUM_THREADS_HOST)
+  {
+#pragma omp loop reduction(+:total)
+    for (int x = 0; x < N; ++x) {
+      total += a[x] + b[x];
+    }
+#pragma omp master
+    {
+      for (int x = 0; x < N; ++x) {
+        num_threads[x] = omp_get_num_threads();
+      }
+    }
+  }
+
+  for (int x = 0; x < N; ++x) {
+    host_total += a[x] + b[x];
+  }
+
+  for (int x = 1; x < N; ++x) {
+    OMPVV_WARNING_IF(num_threads[x - 1] != num_threads[x], "Kernel reported differing numbers of threads.  Validity of testing of reduction clause cannot be guaranteed.");
+  }
+  OMPVV_WARNING_IF(num_threads[0] == 1, "Test operated with one team.  Reduction clause cannot be tested.");
+  OMPVV_WARNING_IF(num_threads[0] <= 0, "Test reported invalid number of threads.  Validity of testing of reduction clause cannot be guaranteed.");
+
+  OMPVV_TEST_AND_SET_VERBOSE(errors, host_total != total);
+  OMPVV_ERROR_IF(host_total != total, "Total on device is %d but expected total from host is %d.", total, host_total);
+
+  return errors;
+}
+
+int main() {
+  OMPVV_TEST_OFFLOADING;
+
+  int total_errors = 0;
+
+  OMPVV_TEST_AND_SET_VERBOSE(total_errors, test_add() != 0);
+
+  OMPVV_REPORT_AND_RETURN(total_errors);
+}

--- a/tests/5.0/loop/test_loop_reduction_and.c
+++ b/tests/5.0/loop/test_loop_reduction_and.c
@@ -1,0 +1,91 @@
+//===--- test_target_teams_distribute_reduction_and.c------------------------===//
+//
+// OpenMP API Version 4.5 Nov 2015
+//
+// This test uses the reduction clause on a target teams distribute directive,
+// testing that the variable in the reduction clause is properly reduced using
+// the and operator.
+//
+////===----------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+#include <math.h>
+
+#define N 1024
+#define THRESHOLD 512
+
+int test_and() {
+  char a[N];
+      // The below calculation is meant to ensure about half the arrays we will
+      // test will come out to true under the 'and' operator, and the rest false.
+      // For the and operator, a test array that comes out true requires every
+      // entry to be false, which is why this margin is so close to 100%.
+  double false_margin = pow(exp(1), log(.5)/N);
+  int errors = 0;
+  int num_teams[N];
+  int tested_true = 0;
+  int tested_false = 0;
+  int itr_count = 0;
+  srand(1);
+
+  while ((!tested_true || !tested_false) && (itr_count < THRESHOLD)) {
+    for (int x = 0; x < N; ++x) {
+      a[x] = (rand() / (double) (RAND_MAX) < false_margin);
+      num_teams[x] = -x;
+    }
+
+    char result = 1;
+    char host_result = 1;
+
+#pragma omp target teams distribute reduction(&&:result) defaultmap(tofrom:scalar)
+    for (int x = 0; x < N; ++x) {
+      num_teams[x] = omp_get_num_teams();
+      result = result && a[x];
+    }
+
+    for (int x = 0; x < N; ++x) {
+      host_result = host_result && a[x];
+    }
+
+    if (itr_count == 0) {
+      for (int x = 1; x < N; ++x) {
+        OMPVV_WARNING_IF(num_teams[x - 1] != num_teams[x], "Kernel reported differing numbers of teams.  Validity of testing of reduction clause cannot be guaranteed.");
+      }
+      OMPVV_WARNING_IF(num_teams[0] == 1, "Test operated with one team.  Reduction clause cannot be tested.");
+      OMPVV_WARNING_IF(num_teams[0] <= 0, "Test reported invalid number of teams.  Validity of testing of reduction clause cannot be guaranteed.");
+    }
+
+    OMPVV_TEST_AND_SET_VERBOSE(errors, host_result != result);
+    OMPVV_ERROR_IF(host_result != result, "Result on device is %d but expected result from host is %d.", result, host_result);
+
+    if (host_result) {
+      tested_true = 1;
+    } else {
+      tested_false = 1;
+    }
+
+    if (host_result != result) {
+      break;
+    }
+
+    itr_count++;
+  }
+
+  OMPVV_WARNING_IF(!tested_true, "Did not test a case in which final result was true.");
+  OMPVV_WARNING_IF(!tested_false, "Did not test a case in which final result was false.");
+
+  return errors;
+}
+
+int main() {
+  OMPVV_TEST_OFFLOADING;
+
+  int total_errors = 0;
+
+  OMPVV_TEST_AND_SET_VERBOSE(total_errors, test_and() != 0);
+
+  OMPVV_REPORT_AND_RETURN(total_errors);
+}

--- a/tests/5.0/loop/test_loop_reduction_and.c
+++ b/tests/5.0/loop/test_loop_reduction_and.c
@@ -87,8 +87,6 @@ int test_and() {
 }
 
 int main() {
-  OMPVV_TEST_OFFLOADING;
-
   int total_errors = 0;
 
   OMPVV_TEST_AND_SET_VERBOSE(total_errors, test_and() != 0);

--- a/tests/5.0/loop/test_loop_reduction_and.c
+++ b/tests/5.0/loop/test_loop_reduction_and.c
@@ -1,10 +1,10 @@
-//===--- test_target_teams_distribute_reduction_and.c------------------------===//
+//===--- test_loop_reduction_and.c ---------------------------------------------===//
 //
-// OpenMP API Version 4.5 Nov 2015
+// OpenMP API Version 5.0 Nov 2018
 //
-// This test uses the reduction clause on a target teams distribute directive,
-// testing that the variable in the reduction clause is properly reduced using
-// the and operator.
+// This test uses the reduction clause on a loop directive, testing that the
+// variable in the reduction clause is properly reduced using the and
+// operator.
 //
 ////===----------------------------------------------------------------------===//
 
@@ -25,7 +25,7 @@ int test_and() {
       // entry to be false, which is why this margin is so close to 100%.
   double false_margin = pow(exp(1), log(.5)/N);
   int errors = 0;
-  int num_teams[N];
+  int num_threads[N];
   int tested_true = 0;
   int tested_false = 0;
   int itr_count = 0;
@@ -34,16 +34,22 @@ int test_and() {
   while ((!tested_true || !tested_false) && (itr_count < THRESHOLD)) {
     for (int x = 0; x < N; ++x) {
       a[x] = (rand() / (double) (RAND_MAX) < false_margin);
-      num_teams[x] = -x;
+      num_threads[x] = -x;
     }
 
     char result = 1;
     char host_result = 1;
 
-#pragma omp target teams distribute reduction(&&:result) defaultmap(tofrom:scalar)
-    for (int x = 0; x < N; ++x) {
-      num_teams[x] = omp_get_num_teams();
-      result = result && a[x];
+#pragma omp parallel num_threads(OMPVV_NUM_THREADS_HOST)
+    {
+#pragma omp loop reduction(&&:result)
+      for (int x = 0; x < N; ++x) {
+        result = result && a[x];
+      }
+#pragma omp for
+      for (int x = 0; x < N; ++x) {
+        num_threads[x] = omp_get_num_threads();
+      }
     }
 
     for (int x = 0; x < N; ++x) {
@@ -52,10 +58,10 @@ int test_and() {
 
     if (itr_count == 0) {
       for (int x = 1; x < N; ++x) {
-        OMPVV_WARNING_IF(num_teams[x - 1] != num_teams[x], "Kernel reported differing numbers of teams.  Validity of testing of reduction clause cannot be guaranteed.");
+        OMPVV_WARNING_IF(num_threads[x - 1] != num_threads[x], "Kernel reported differing numbers of threads.  Validity of testing of reduction clause cannot be guaranteed.");
       }
-      OMPVV_WARNING_IF(num_teams[0] == 1, "Test operated with one team.  Reduction clause cannot be tested.");
-      OMPVV_WARNING_IF(num_teams[0] <= 0, "Test reported invalid number of teams.  Validity of testing of reduction clause cannot be guaranteed.");
+      OMPVV_WARNING_IF(num_threads[0] == 1, "Test operated with one thread.  Reduction clause cannot be tested.");
+      OMPVV_WARNING_IF(num_threads[0] <= 0, "Test reported invalid number of threads.  Validity of testing of reduction clause cannot be guaranteed.");
     }
 
     OMPVV_TEST_AND_SET_VERBOSE(errors, host_result != result);

--- a/tests/5.0/loop/test_loop_reduction_and.c
+++ b/tests/5.0/loop/test_loop_reduction_and.c
@@ -1,4 +1,4 @@
-//===--- test_loop_reduction_and.c ---------------------------------------------===//
+//===--- test_loop_reduction_and.c ------------------------------------------===//
 //
 // OpenMP API Version 5.0 Nov 2018
 //
@@ -58,14 +58,14 @@ int test_and() {
 
     if (itr_count == 0) {
       for (int x = 1; x < N; ++x) {
-        OMPVV_WARNING_IF(num_threads[x - 1] != num_threads[x], "Kernel reported differing numbers of threads.  Validity of testing of reduction clause cannot be guaranteed.");
+        OMPVV_WARNING_IF(num_threads[x - 1] != num_threads[x], "Test reported differing numbers of threads.  Validity of testing of reduction clause cannot be guaranteed.");
       }
       OMPVV_WARNING_IF(num_threads[0] == 1, "Test operated with one thread.  Reduction clause cannot be tested.");
       OMPVV_WARNING_IF(num_threads[0] <= 0, "Test reported invalid number of threads.  Validity of testing of reduction clause cannot be guaranteed.");
     }
 
     OMPVV_TEST_AND_SET_VERBOSE(errors, host_result != result);
-    OMPVV_ERROR_IF(host_result != result, "Result on device is %d but expected result from host is %d.", result, host_result);
+    OMPVV_ERROR_IF(host_result != result, "Actual result is %d but expected result is %d.", result, host_result);
 
     if (host_result) {
       tested_true = 1;

--- a/tests/5.0/loop/test_loop_reduction_bitand.c
+++ b/tests/5.0/loop/test_loop_reduction_bitand.c
@@ -1,0 +1,86 @@
+//===--- test_target_teams_distribute_reduction_bitand.c---------------------===//
+//
+// OpenMP API Version 4.5 Nov 2015
+//
+// This test uses the reduction clause on a target teams distribute directive,
+// testing that the variable in the reduction clause is properly reduced using
+// the bitand operator.
+//
+////===----------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+#include <math.h>
+
+#define N 1024
+#define THRESHOLD 512
+
+int test_bitand() {
+  unsigned int a[N];
+  double false_margin = pow(exp(1), log(.5)/N); // See the 'and' operator test for
+  int errors = 0;                               // an exaplantion of this math.
+  int num_teams[N];
+  int num_attempts = 0;
+  int have_true = 0, have_false = 0;
+  srand(1);
+
+  while ((!have_true || !have_false) && (num_attempts < THRESHOLD)) {
+    have_true = 0;
+    have_false = 0;
+    for (int x = 0; x < N; ++x) {
+      for (int y = 0; y < 16; ++y) {
+        if (rand() / (double) RAND_MAX < false_margin) {
+          a[x] += (1 << y);
+          have_true = 1;
+        } else {
+          have_false = 1;
+        }
+      }
+      num_teams[x] = -x;
+    }
+    num_attempts++;
+  }
+
+  OMPVV_WARNING_IF(!have_true, "No true bits were generated to test");
+  OMPVV_WARNING_IF(!have_false, "No false bits were generated to test");
+
+  unsigned int b = 0;
+  for (int x = 0; x < 16; ++x) {
+    b = b + (1 << x);
+  }
+
+#pragma omp target teams distribute reduction(&:b) defaultmap(tofrom:scalar)
+  for (int x = 0; x < N; ++x) {
+    num_teams[x] = omp_get_num_teams();
+    b = b & a[x];
+  }
+
+  unsigned int host_b = a[0];
+
+  for (int x = 0; x < N; ++x) {
+    host_b = host_b & a[x];
+  }
+
+  for (int x = 1; x < N; ++x) {
+    OMPVV_WARNING_IF(num_teams[x - 1] != num_teams[x], "Kernel reported differing numbers of teams.  Validity of testing of reduction clause cannot be guaranteed.");
+  }
+  OMPVV_WARNING_IF(num_teams[0] == 1, "Test operated with one team.  Reduction clause cannot be tested.");
+  OMPVV_WARNING_IF(num_teams[0] <= 0, "Test reported invalid number of teams.  Validity of testing of reduction clause cannot be guaranteed.");
+
+  OMPVV_TEST_AND_SET_VERBOSE(errors, b != host_b);
+  OMPVV_ERROR_IF(host_b != b, "Bit on device is %d but expected bit from host is %d.", b, host_b);
+
+  return errors;
+}
+
+int main() {
+  OMPVV_TEST_OFFLOADING;
+
+  int total_errors = 0;
+
+  OMPVV_TEST_AND_SET_VERBOSE(total_errors, test_bitand() != 0);
+
+  OMPVV_REPORT_AND_RETURN(total_errors);
+}

--- a/tests/5.0/loop/test_loop_reduction_bitand.c
+++ b/tests/5.0/loop/test_loop_reduction_bitand.c
@@ -70,13 +70,13 @@ int test_bitand() {
   }
 
   for (int x = 1; x < N; ++x) {
-    OMPVV_WARNING_IF(num_threads[x - 1] != num_threads[x], "Kernel reported differing numbers of threads.  Validity of testing of reduction clause cannot be guaranteed.");
+    OMPVV_WARNING_IF(num_threads[x - 1] != num_threads[x], "Test reported differing numbers of threads.  Validity of testing of reduction clause cannot be guaranteed.");
   }
   OMPVV_WARNING_IF(num_threads[0] == 1, "Test operated with one thread.  Reduction clause cannot be tested.");
   OMPVV_WARNING_IF(num_threads[0] <= 0, "Test reported invalid number of threads.  Validity of testing of reduction clause cannot be guaranteed.");
 
   OMPVV_TEST_AND_SET_VERBOSE(errors, b != host_b);
-  OMPVV_ERROR_IF(host_b != b, "Bit on device is %d but expected bit from host is %d.", b, host_b);
+  OMPVV_ERROR_IF(host_b != b, "Bit from loop directive is %d but expected bit is %d.", b, host_b);
 
   return errors;
 }

--- a/tests/5.0/loop/test_loop_reduction_bitand.c
+++ b/tests/5.0/loop/test_loop_reduction_bitand.c
@@ -1,10 +1,10 @@
-//===--- test_target_teams_distribute_reduction_bitand.c---------------------===//
+//===--- test_loop_reduction_bitand.c ---------------------------------------===//
 //
-// OpenMP API Version 4.5 Nov 2015
+// OpenMP API Version 5.0 Nov 2018
 //
-// This test uses the reduction clause on a target teams distribute directive,
-// testing that the variable in the reduction clause is properly reduced using
-// the bitand operator.
+// This test uses the reduction clause on a loop directive, testing that the
+// variable in the reduction clause is properly reduced using the bitand
+// operator.
 //
 ////===----------------------------------------------------------------------===//
 
@@ -21,7 +21,7 @@ int test_bitand() {
   unsigned int a[N];
   double false_margin = pow(exp(1), log(.5)/N); // See the 'and' operator test for
   int errors = 0;                               // an exaplantion of this math.
-  int num_teams[N];
+  int num_threads[N];
   int num_attempts = 0;
   int have_true = 0, have_false = 0;
   srand(1);
@@ -38,7 +38,7 @@ int test_bitand() {
           have_false = 1;
         }
       }
-      num_teams[x] = -x;
+      num_threads[x] = -x;
     }
     num_attempts++;
   }
@@ -51,10 +51,16 @@ int test_bitand() {
     b = b + (1 << x);
   }
 
-#pragma omp target teams distribute reduction(&:b) defaultmap(tofrom:scalar)
-  for (int x = 0; x < N; ++x) {
-    num_teams[x] = omp_get_num_teams();
-    b = b & a[x];
+#pragma omp parallel num_threads(OMPVV_NUM_THREADS_HOST)
+  {
+#pragma omp loop reduction(&:b)
+    for (int x = 0; x < N; ++x) {
+      b = b & a[x];
+    }
+#pragma omp for
+    for (int x = 0; x < N; ++x) {
+      num_threads[x] = omp_get_num_threads();
+    }
   }
 
   unsigned int host_b = a[0];
@@ -64,10 +70,10 @@ int test_bitand() {
   }
 
   for (int x = 1; x < N; ++x) {
-    OMPVV_WARNING_IF(num_teams[x - 1] != num_teams[x], "Kernel reported differing numbers of teams.  Validity of testing of reduction clause cannot be guaranteed.");
+    OMPVV_WARNING_IF(num_threads[x - 1] != num_threads[x], "Kernel reported differing numbers of threads.  Validity of testing of reduction clause cannot be guaranteed.");
   }
-  OMPVV_WARNING_IF(num_teams[0] == 1, "Test operated with one team.  Reduction clause cannot be tested.");
-  OMPVV_WARNING_IF(num_teams[0] <= 0, "Test reported invalid number of teams.  Validity of testing of reduction clause cannot be guaranteed.");
+  OMPVV_WARNING_IF(num_threads[0] == 1, "Test operated with one thread.  Reduction clause cannot be tested.");
+  OMPVV_WARNING_IF(num_threads[0] <= 0, "Test reported invalid number of threads.  Validity of testing of reduction clause cannot be guaranteed.");
 
   OMPVV_TEST_AND_SET_VERBOSE(errors, b != host_b);
   OMPVV_ERROR_IF(host_b != b, "Bit on device is %d but expected bit from host is %d.", b, host_b);

--- a/tests/5.0/loop/test_loop_reduction_bitand.c
+++ b/tests/5.0/loop/test_loop_reduction_bitand.c
@@ -82,8 +82,6 @@ int test_bitand() {
 }
 
 int main() {
-  OMPVV_TEST_OFFLOADING;
-
   int total_errors = 0;
 
   OMPVV_TEST_AND_SET_VERBOSE(total_errors, test_bitand() != 0);

--- a/tests/5.0/loop/test_loop_reduction_bitor.c
+++ b/tests/5.0/loop/test_loop_reduction_bitor.c
@@ -1,0 +1,84 @@
+//===--- test_target_teams_distribute_reduction_bitor.c----------------------===//
+//
+// OpenMP API Version 4.5 Nov 2015
+//
+// This test uses the reduction clause on a target teams distribute directive,
+// testing that the variable in the reduction clause is properly reduced using
+// the bitor operator.
+//
+////===----------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+#include <math.h>
+
+#define N 1024
+#define THRESHOLD 1024
+
+int test_bitor() {
+  int a[N];
+  // See the 'and' operator test for an exaplantion of this math.
+  double true_margin = pow(exp(1), log(.5)/N);
+  int errors = 0;
+  int num_teams[N];
+  int num_attempts = 0;
+  int have_true = 0, have_false = 0;
+  srand(1);
+
+  while ((!have_true || !have_false) && (num_attempts < THRESHOLD)) {
+    have_true = 0;
+    have_false = 0;
+    for (int x = 0; x < N; ++x) {
+      for (int y = 0; y < 16; ++y) {
+        if (rand() / (double) RAND_MAX > true_margin) {
+          a[x] += (1 << y);
+          have_true = 1;
+        } else {
+          have_false = 1;
+        }
+      }
+      num_teams[x] = -x;
+    }
+    num_attempts++;
+  }
+
+  OMPVV_WARNING_IF(!have_true, "No true bits were generated to test");
+  OMPVV_WARNING_IF(!have_false, "No false bits were generated to test");
+
+  unsigned int b = 0;
+
+#pragma omp target teams distribute reduction(|:b) defaultmap(tofrom:scalar)
+  for (int x = 0; x < N; ++x) {
+    num_teams[x] = omp_get_num_teams();
+    b = b | a[x];
+  }
+
+  unsigned int host_b = 0;
+
+  for (int x = 0; x < N; ++x) {
+    host_b = host_b | a[x];
+  }
+
+  for (int x = 1; x < N; ++x) {
+    OMPVV_WARNING_IF(num_teams[x - 1] != num_teams[x], "Kernel reported differing numbers of teams.  Validity of testing of reduction clause cannot be guaranteed.");
+  }
+  OMPVV_WARNING_IF(num_teams[0] == 1, "Test operated with one team.  Reduction clause cannot be tested.");
+  OMPVV_WARNING_IF(num_teams[0] <= 0, "Test reported invalid number of teams.  Validity of testing of reduction clause cannot be guaranteed.");
+
+  OMPVV_TEST_AND_SET_VERBOSE(errors, b != host_b);
+  OMPVV_ERROR_IF(host_b != b, "Bit on device is %d but expected bit from host is %d.", b, host_b);
+
+  return errors;
+}
+
+int main() {
+  OMPVV_TEST_OFFLOADING;
+
+  int total_errors = 0;
+
+  OMPVV_TEST_AND_SET_VERBOSE(total_errors, test_bitor() != 0);
+
+  OMPVV_REPORT_AND_RETURN(total_errors);
+}

--- a/tests/5.0/loop/test_loop_reduction_bitor.c
+++ b/tests/5.0/loop/test_loop_reduction_bitor.c
@@ -1,10 +1,10 @@
-//===--- test_target_teams_distribute_reduction_bitor.c----------------------===//
+//===--- test_loop_reduction_bitor.c ----------------------------------------===//
 //
-// OpenMP API Version 4.5 Nov 2015
+// OpenMP API Version 5.0 Nov 2018
 //
-// This test uses the reduction clause on a target teams distribute directive,
-// testing that the variable in the reduction clause is properly reduced using
-// the bitor operator.
+// This test uses the reduction clause on a loop directive, testing that the
+// variable in the reduction clause is properly reduced using the bitor
+// operator.
 //
 ////===----------------------------------------------------------------------===//
 
@@ -22,7 +22,7 @@ int test_bitor() {
   // See the 'and' operator test for an exaplantion of this math.
   double true_margin = pow(exp(1), log(.5)/N);
   int errors = 0;
-  int num_teams[N];
+  int num_threads[N];
   int num_attempts = 0;
   int have_true = 0, have_false = 0;
   srand(1);
@@ -39,7 +39,7 @@ int test_bitor() {
           have_false = 1;
         }
       }
-      num_teams[x] = -x;
+      num_threads[x] = -x;
     }
     num_attempts++;
   }
@@ -49,10 +49,16 @@ int test_bitor() {
 
   unsigned int b = 0;
 
-#pragma omp target teams distribute reduction(|:b) defaultmap(tofrom:scalar)
-  for (int x = 0; x < N; ++x) {
-    num_teams[x] = omp_get_num_teams();
-    b = b | a[x];
+#pragma omp parallel num_threads(OMPVV_NUM_THREADS_HOST)
+  {
+#pragma omp loop reduction(|:b)
+    for (int x = 0; x < N; ++x) {
+      b = b | a[x];
+    }
+#pragma omp for
+    for (int x = 0; x < N; ++x) {
+      num_threads[x] = omp_get_num_threads();
+    }
   }
 
   unsigned int host_b = 0;
@@ -62,10 +68,10 @@ int test_bitor() {
   }
 
   for (int x = 1; x < N; ++x) {
-    OMPVV_WARNING_IF(num_teams[x - 1] != num_teams[x], "Kernel reported differing numbers of teams.  Validity of testing of reduction clause cannot be guaranteed.");
+    OMPVV_WARNING_IF(num_threads[x - 1] != num_threads[x], "Kernel reported differing numbers of threads.  Validity of testing of reduction clause cannot be guaranteed.");
   }
-  OMPVV_WARNING_IF(num_teams[0] == 1, "Test operated with one team.  Reduction clause cannot be tested.");
-  OMPVV_WARNING_IF(num_teams[0] <= 0, "Test reported invalid number of teams.  Validity of testing of reduction clause cannot be guaranteed.");
+  OMPVV_WARNING_IF(num_threads[0] == 1, "Test operated with one thread.  Reduction clause cannot be tested.");
+  OMPVV_WARNING_IF(num_threads[0] <= 0, "Test reported invalid number of threads.  Validity of testing of reduction clause cannot be guaranteed.");
 
   OMPVV_TEST_AND_SET_VERBOSE(errors, b != host_b);
   OMPVV_ERROR_IF(host_b != b, "Bit on device is %d but expected bit from host is %d.", b, host_b);

--- a/tests/5.0/loop/test_loop_reduction_bitor.c
+++ b/tests/5.0/loop/test_loop_reduction_bitor.c
@@ -80,8 +80,6 @@ int test_bitor() {
 }
 
 int main() {
-  OMPVV_TEST_OFFLOADING;
-
   int total_errors = 0;
 
   OMPVV_TEST_AND_SET_VERBOSE(total_errors, test_bitor() != 0);

--- a/tests/5.0/loop/test_loop_reduction_bitor.c
+++ b/tests/5.0/loop/test_loop_reduction_bitor.c
@@ -68,13 +68,13 @@ int test_bitor() {
   }
 
   for (int x = 1; x < N; ++x) {
-    OMPVV_WARNING_IF(num_threads[x - 1] != num_threads[x], "Kernel reported differing numbers of threads.  Validity of testing of reduction clause cannot be guaranteed.");
+    OMPVV_WARNING_IF(num_threads[x - 1] != num_threads[x], "Test reported differing numbers of threads.  Validity of testing of reduction clause cannot be guaranteed.");
   }
   OMPVV_WARNING_IF(num_threads[0] == 1, "Test operated with one thread.  Reduction clause cannot be tested.");
   OMPVV_WARNING_IF(num_threads[0] <= 0, "Test reported invalid number of threads.  Validity of testing of reduction clause cannot be guaranteed.");
 
   OMPVV_TEST_AND_SET_VERBOSE(errors, b != host_b);
-  OMPVV_ERROR_IF(host_b != b, "Bit on device is %d but expected bit from host is %d.", b, host_b);
+  OMPVV_ERROR_IF(host_b != b, "Bit from loop directive is %d but expected bit is %d.", b, host_b);
 
   return errors;
 }

--- a/tests/5.0/loop/test_loop_reduction_bitxor.c
+++ b/tests/5.0/loop/test_loop_reduction_bitxor.c
@@ -1,0 +1,64 @@
+//===--- test_target_teams_distribute_reduction_bitxor.c----------------------------===//
+//
+// OpenMP API Version 4.5 Nov 2015
+//
+// This test uses the reduction clause on a target teams distribute directive,
+// testing that the variable in the reduction clause is properly reduced using
+// the bitxor operator.
+//
+////===----------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+#include <math.h>
+
+#define N 1024
+
+int test_bitxor() {
+  unsigned int a[N];
+  int errors = 0;
+  int num_teams[N];
+  srand(1);
+
+  for (int x = 0; x < N; ++x) {
+    a[x] = (unsigned int) rand() / (double) (RAND_MAX / 2);
+    num_teams[x] = -x;
+  }
+
+  unsigned int b = 0;
+
+#pragma omp target teams distribute reduction(^:b) defaultmap(tofrom:scalar)
+  for (int x = 0; x < N; ++x) {
+    num_teams[x] = omp_get_num_teams();
+    b = (b ^ a[x]);
+  }
+
+  unsigned int host_b = 0;
+
+  for (int x = 0; x < N; ++x) {
+    host_b = (host_b ^ a[x]);
+  }
+
+  for (int x = 1; x < N; ++x) {
+    OMPVV_WARNING_IF(num_teams[x - 1] != num_teams[x], "Kernel reported differing numbers of teams.  Validity of testing of reduction clause cannot be guaranteed.");
+  }
+  OMPVV_WARNING_IF(num_teams[0] == 1, "Test operated with one team.  Reduction clause cannot be tested.");
+  OMPVV_WARNING_IF(num_teams[0] <= 0, "Test reported invalid number of teams.  Validity of testing of reduction clause cannot be guaranteed.");
+
+  OMPVV_TEST_AND_SET_VERBOSE(errors, b != host_b);
+  OMPVV_ERROR_IF(host_b != b, "Bit on device is %d but expected bit from host is %d.", b, host_b);
+
+  return errors;
+}
+
+int main() {
+  OMPVV_TEST_OFFLOADING;
+
+  int total_errors = 0;
+
+  OMPVV_TEST_AND_SET_VERBOSE(total_errors, test_bitxor() != 0);
+
+  OMPVV_REPORT_AND_RETURN(total_errors);
+}

--- a/tests/5.0/loop/test_loop_reduction_bitxor.c
+++ b/tests/5.0/loop/test_loop_reduction_bitxor.c
@@ -60,8 +60,6 @@ int test_bitxor() {
 }
 
 int main() {
-  OMPVV_TEST_OFFLOADING;
-
   int total_errors = 0;
 
   OMPVV_TEST_AND_SET_VERBOSE(total_errors, test_bitxor() != 0);

--- a/tests/5.0/loop/test_loop_reduction_max.c
+++ b/tests/5.0/loop/test_loop_reduction_max.c
@@ -1,0 +1,66 @@
+//===--- test_target_teams_distribute_reduction_max.c------------------------===//
+//
+// OpenMP API Version 4.5 Nov 2015
+//
+// This test uses the reduction clause on a target teams distribute directive,
+// testing that the variable in the reduction clause is properly reduced using
+// the max operator.
+//
+////===----------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+#include <math.h>
+
+#define N 1024
+
+int test_max() {
+  int a[N];
+  int b[N];
+  int errors = 0;
+  int num_teams[N];
+  srand(1);
+
+  for (int x = 0; x < N; ++x) {
+    a[x] = (int) rand() / (double)(RAND_MAX / 100);
+    b[x] = (int) rand() / (double)(RAND_MAX / 100);
+    num_teams[x] = -x;
+  }
+
+  int result = 0;
+
+#pragma omp target teams distribute reduction(max:result) defaultmap(tofrom:scalar)
+  for (int x = 0; x < N; ++x) {
+    result = fmax(a[x] + b[x], result);
+    num_teams[x] = omp_get_num_teams();
+  }
+
+  int host_max = 0;
+
+  for (int x = 0; x < N; ++x) {
+    host_max = fmax(host_max, a[x] + b[x]);
+  }
+
+  for (int x = 1; x < N; ++x) {
+    OMPVV_WARNING_IF(num_teams[x - 1] != num_teams[x], "Kernel reported differing numbers of teams.  Validity of testing of reduction clause cannot be guaranteed.");
+  }
+  OMPVV_WARNING_IF(num_teams[0] == 1, "Test operated with one team.  Reduction clause cannot be tested.");
+  OMPVV_WARNING_IF(num_teams[0] <= 0, "Test reported invalid number of teams.  Validity of testing of reduction clause cannot be guaranteed.");
+
+  OMPVV_TEST_AND_SET_VERBOSE(errors, result != host_max);
+  OMPVV_ERROR_IF(host_max != result, "Max on device is %d but expected max from host is %d.", result, host_max);
+
+  return errors;
+}
+
+int main() {
+  OMPVV_TEST_OFFLOADING;
+
+  int total_errors = 0;
+
+  OMPVV_TEST_AND_SET_VERBOSE(total_errors, test_max() != 0);
+
+  OMPVV_REPORT_AND_RETURN(total_errors);
+}

--- a/tests/5.0/loop/test_loop_reduction_max.c
+++ b/tests/5.0/loop/test_loop_reduction_max.c
@@ -50,13 +50,13 @@ int test_max() {
   }
 
   for (int x = 1; x < N; ++x) {
-    OMPVV_WARNING_IF(num_threads[x - 1] != num_threads[x], "Kernel reported differing numbers of threads.  Validity of testing of reduction clause cannot be guaranteed.");
+    OMPVV_WARNING_IF(num_threads[x - 1] != num_threads[x], "Test reported differing numbers of threads.  Validity of testing of reduction clause cannot be guaranteed.");
   }
   OMPVV_WARNING_IF(num_threads[0] == 1, "Test operated with one thread.  Reduction clause cannot be tested.");
   OMPVV_WARNING_IF(num_threads[0] <= 0, "Test reported invalid number of threads.  Validity of testing of reduction clause cannot be guaranteed.");
 
   OMPVV_TEST_AND_SET_VERBOSE(errors, result != host_max);
-  OMPVV_ERROR_IF(host_max != result, "Max on device is %d but expected max from host is %d.", result, host_max);
+  OMPVV_ERROR_IF(host_max != result, "Max from loop directive is %d but expected max is %d.", result, host_max);
 
   return errors;
 }

--- a/tests/5.0/loop/test_loop_reduction_max.c
+++ b/tests/5.0/loop/test_loop_reduction_max.c
@@ -1,10 +1,10 @@
-//===--- test_target_teams_distribute_reduction_max.c------------------------===//
+//===--- test_loop_reduction_max.c ------------------------------------------===//
 //
-// OpenMP API Version 4.5 Nov 2015
+// OpenMP API Version 5.0 Nov 2018
 //
-// This test uses the reduction clause on a target teams distribute directive,
-// testing that the variable in the reduction clause is properly reduced using
-// the max operator.
+// This test uses the reduction clause on a loop directive, testing that the
+// variable in the reduction clause is properly reduced using the max
+// operator.
 //
 ////===----------------------------------------------------------------------===//
 
@@ -20,21 +20,27 @@ int test_max() {
   int a[N];
   int b[N];
   int errors = 0;
-  int num_teams[N];
+  int num_threads[N];
   srand(1);
 
   for (int x = 0; x < N; ++x) {
     a[x] = (int) rand() / (double)(RAND_MAX / 100);
     b[x] = (int) rand() / (double)(RAND_MAX / 100);
-    num_teams[x] = -x;
+    num_threads[x] = -x;
   }
 
   int result = 0;
 
-#pragma omp target teams distribute reduction(max:result) defaultmap(tofrom:scalar)
-  for (int x = 0; x < N; ++x) {
-    result = fmax(a[x] + b[x], result);
-    num_teams[x] = omp_get_num_teams();
+#pragma omp parallel num_threads(OMPVV_NUM_THREADS_HOST)
+  {
+#pragma omp loop reduction(max:result)
+    for (int x = 0; x < N; ++x) {
+      result = fmax(a[x] + b[x], result);
+    }
+#pragma omp for
+    for (int x = 0; x < N; ++x) {
+      num_threads[x] = omp_get_num_threads();
+    }
   }
 
   int host_max = 0;
@@ -44,10 +50,10 @@ int test_max() {
   }
 
   for (int x = 1; x < N; ++x) {
-    OMPVV_WARNING_IF(num_teams[x - 1] != num_teams[x], "Kernel reported differing numbers of teams.  Validity of testing of reduction clause cannot be guaranteed.");
+    OMPVV_WARNING_IF(num_threads[x - 1] != num_threads[x], "Kernel reported differing numbers of threads.  Validity of testing of reduction clause cannot be guaranteed.");
   }
-  OMPVV_WARNING_IF(num_teams[0] == 1, "Test operated with one team.  Reduction clause cannot be tested.");
-  OMPVV_WARNING_IF(num_teams[0] <= 0, "Test reported invalid number of teams.  Validity of testing of reduction clause cannot be guaranteed.");
+  OMPVV_WARNING_IF(num_threads[0] == 1, "Test operated with one thread.  Reduction clause cannot be tested.");
+  OMPVV_WARNING_IF(num_threads[0] <= 0, "Test reported invalid number of threads.  Validity of testing of reduction clause cannot be guaranteed.");
 
   OMPVV_TEST_AND_SET_VERBOSE(errors, result != host_max);
   OMPVV_ERROR_IF(host_max != result, "Max on device is %d but expected max from host is %d.", result, host_max);

--- a/tests/5.0/loop/test_loop_reduction_max.c
+++ b/tests/5.0/loop/test_loop_reduction_max.c
@@ -62,8 +62,6 @@ int test_max() {
 }
 
 int main() {
-  OMPVV_TEST_OFFLOADING;
-
   int total_errors = 0;
 
   OMPVV_TEST_AND_SET_VERBOSE(total_errors, test_max() != 0);

--- a/tests/5.0/loop/test_loop_reduction_min.c
+++ b/tests/5.0/loop/test_loop_reduction_min.c
@@ -1,0 +1,66 @@
+//===--- test_target_teams_distribute_reduction_min.c----------------------------===//
+//
+// OpenMP API Version 4.5 Nov 2015
+//
+// This test uses the reduction clause on a target teams distribute directive,
+// testing that the variable in the reduction clause is properly reduced using
+// the min operator.
+//
+////===----------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+#include <math.h>
+
+#define N 1024
+
+int test_min() {
+  int a[N];
+  int b[N];
+  int errors = 0;
+  int num_teams[N];
+  srand(1);
+
+  for (int x = 0; x < N; ++x) {
+    a[x] = (int) rand() / (double) (RAND_MAX / 100);
+    b[x] = (int) rand() / (double) (RAND_MAX / 100);
+    num_teams[x] = -x;
+  }
+
+  int result = a[0] + b[0];
+
+#pragma omp target teams distribute reduction(min:result) defaultmap(tofrom:scalar)
+  for (int x = 0; x < N; ++x) {
+    num_teams[x] = omp_get_num_teams();
+    result = fmin(result, a[x] + b[x]);
+  }
+
+  int host_min = a[0] + b[0];
+
+  for (int x = 0; x < N; ++x) {
+    host_min = fmin(host_min, a[x] + b[x]);
+  }
+
+  for (int x = 1; x < N; ++x) {
+    OMPVV_WARNING_IF(num_teams[x - 1] != num_teams[x], "Kernel reported differing numbers of teams.  Validity of testing of reduction clause cannot be guaranteed.");
+  }
+  OMPVV_WARNING_IF(num_teams[0] == 1, "Test operated with one team.  Reduction clause cannot be tested.");
+  OMPVV_WARNING_IF(num_teams[0] <= 0, "Test reported invalid number of teams.  Validity of testing of reduction clause cannot be guaranteed.");
+
+  OMPVV_TEST_AND_SET_VERBOSE(errors, host_min != result);
+  OMPVV_ERROR_IF(host_min != result, "Min on device is %d but expected min from host is %d.", result, host_min);
+
+  return errors;
+}
+
+int main() {
+  OMPVV_TEST_OFFLOADING;
+
+  int total_errors = 0;
+
+  OMPVV_TEST_AND_SET_VERBOSE(total_errors, test_min() != 0);
+
+  OMPVV_REPORT_AND_RETURN(total_errors);
+}

--- a/tests/5.0/loop/test_loop_reduction_min.c
+++ b/tests/5.0/loop/test_loop_reduction_min.c
@@ -1,12 +1,13 @@
-//===--- test_target_teams_distribute_reduction_min.c----------------------------===//
+//===--- test_loop_reduction_min.c ------------------------------------------===//
 //
-// OpenMP API Version 4.5 Nov 2015
+// OpenMP API Version 5.0 Nov 2018
 //
-// This test uses the reduction clause on a target teams distribute directive,
-// testing that the variable in the reduction clause is properly reduced using
-// the min operator.
+// This test uses the reduction clause on a loop directive, testing that the
+// variable in the reduction clause is properly reduced using the min
+// operator.
 //
 ////===----------------------------------------------------------------------===//
+
 
 #include <omp.h>
 #include <stdio.h>
@@ -20,21 +21,27 @@ int test_min() {
   int a[N];
   int b[N];
   int errors = 0;
-  int num_teams[N];
+  int num_threads[N];
   srand(1);
 
   for (int x = 0; x < N; ++x) {
     a[x] = (int) rand() / (double) (RAND_MAX / 100);
     b[x] = (int) rand() / (double) (RAND_MAX / 100);
-    num_teams[x] = -x;
+    num_threads[x] = -x;
   }
 
   int result = a[0] + b[0];
 
-#pragma omp target teams distribute reduction(min:result) defaultmap(tofrom:scalar)
-  for (int x = 0; x < N; ++x) {
-    num_teams[x] = omp_get_num_teams();
-    result = fmin(result, a[x] + b[x]);
+#pragma omp parallel num_threads(OMPVV_NUM_THREADS_HOST)
+  {
+#pragma omp loop reduction(min:result)
+    for (int x = 0; x < N; ++x) {
+      result = fmin(result, a[x] + b[x]);
+    }
+#pragma omp for
+    for (int x = 0; x < N; ++x) {
+      num_threads[x] = omp_get_num_threads();
+    }
   }
 
   int host_min = a[0] + b[0];
@@ -44,10 +51,10 @@ int test_min() {
   }
 
   for (int x = 1; x < N; ++x) {
-    OMPVV_WARNING_IF(num_teams[x - 1] != num_teams[x], "Kernel reported differing numbers of teams.  Validity of testing of reduction clause cannot be guaranteed.");
+    OMPVV_WARNING_IF(num_threads[x - 1] != num_threads[x], "Kernel reported differing numbers of threads.  Validity of testing of reduction clause cannot be guaranteed.");
   }
-  OMPVV_WARNING_IF(num_teams[0] == 1, "Test operated with one team.  Reduction clause cannot be tested.");
-  OMPVV_WARNING_IF(num_teams[0] <= 0, "Test reported invalid number of teams.  Validity of testing of reduction clause cannot be guaranteed.");
+  OMPVV_WARNING_IF(num_threads[0] == 1, "Test operated with one thread.  Reduction clause cannot be tested.");
+  OMPVV_WARNING_IF(num_threads[0] <= 0, "Test reported invalid number of threads.  Validity of testing of reduction clause cannot be guaranteed.");
 
   OMPVV_TEST_AND_SET_VERBOSE(errors, host_min != result);
   OMPVV_ERROR_IF(host_min != result, "Min on device is %d but expected min from host is %d.", result, host_min);

--- a/tests/5.0/loop/test_loop_reduction_min.c
+++ b/tests/5.0/loop/test_loop_reduction_min.c
@@ -63,8 +63,6 @@ int test_min() {
 }
 
 int main() {
-  OMPVV_TEST_OFFLOADING;
-
   int total_errors = 0;
 
   OMPVV_TEST_AND_SET_VERBOSE(total_errors, test_min() != 0);

--- a/tests/5.0/loop/test_loop_reduction_min.c
+++ b/tests/5.0/loop/test_loop_reduction_min.c
@@ -51,13 +51,13 @@ int test_min() {
   }
 
   for (int x = 1; x < N; ++x) {
-    OMPVV_WARNING_IF(num_threads[x - 1] != num_threads[x], "Kernel reported differing numbers of threads.  Validity of testing of reduction clause cannot be guaranteed.");
+    OMPVV_WARNING_IF(num_threads[x - 1] != num_threads[x], "Test reported differing numbers of threads.  Validity of testing of reduction clause cannot be guaranteed.");
   }
   OMPVV_WARNING_IF(num_threads[0] == 1, "Test operated with one thread.  Reduction clause cannot be tested.");
   OMPVV_WARNING_IF(num_threads[0] <= 0, "Test reported invalid number of threads.  Validity of testing of reduction clause cannot be guaranteed.");
 
   OMPVV_TEST_AND_SET_VERBOSE(errors, host_min != result);
-  OMPVV_ERROR_IF(host_min != result, "Min on device is %d but expected min from host is %d.", result, host_min);
+  OMPVV_ERROR_IF(host_min != result, "Min from loop directive is %d but expected min is %d.", result, host_min);
 
   return errors;
 }

--- a/tests/5.0/loop/test_loop_reduction_multiply.c
+++ b/tests/5.0/loop/test_loop_reduction_multiply.c
@@ -1,0 +1,65 @@
+//===--- test_target_teams_distribute_reduction_multiply.c-------------------===//
+//
+// OpenMP API Version 4.5 Nov 2015
+//
+// This test uses the reduction clause on a target teams distribute directive,
+// testing that the variable in the reduction clause is properly reduced using
+// the multiply operator.
+//
+////===----------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+#include <math.h>
+
+#define N 1024
+
+int test_multiply() {
+  int a[N];
+  int errors = 0;
+  int num_teams[N];
+  srand(1);
+
+  for (int x = 0; x < N; ++x) {
+    a[x] = 1 + (int) rand() / (double) RAND_MAX;
+    num_teams[x] = -x;
+  }
+
+  int result = 1;
+  int host_result;
+
+  for (int x = 0; x < N; x = x + 16) {
+    result = 1;
+#pragma omp target teams distribute reduction(*:result) defaultmap(tofrom:scalar)
+    for (int y = 0; y < 16; ++y) {
+      result *= a[x + y];
+      num_teams[x + y] = omp_get_num_teams();
+    }
+    host_result = 1;
+    for (int y = 0; y < 16; ++y) {
+      host_result *= a[x + y];
+    }
+    OMPVV_TEST_AND_SET_VERBOSE(errors, host_result != result);
+    OMPVV_INFOMSG_IF(host_result != result, "Device result is %d and host result is %d.", result, host_result);
+  }
+
+  for (int x = 1; x < N; ++x) {
+    OMPVV_WARNING_IF(num_teams[x - 1] != num_teams[x], "Kernel reported differing numbers of teams.  Validity of testing of reduction clause cannot be guaranteed.");
+  }
+  OMPVV_WARNING_IF(num_teams[0] == 1, "Test operated with one team.  Reduction clause cannot be tested.");
+  OMPVV_WARNING_IF(num_teams[0] <= 0, "Test reported invalid number of teams.  Validity of testing of reduction clause cannot be guaranteed.");
+
+  return errors;
+}
+
+int main() {
+  OMPVV_TEST_OFFLOADING;
+
+  int total_errors = 0;
+
+  OMPVV_TEST_AND_SET_VERBOSE(total_errors, test_multiply() != 0);
+
+  OMPVV_REPORT_AND_RETURN(total_errors);
+}

--- a/tests/5.0/loop/test_loop_reduction_multiply.c
+++ b/tests/5.0/loop/test_loop_reduction_multiply.c
@@ -61,8 +61,6 @@ int test_multiply() {
 }
 
 int main() {
-  OMPVV_TEST_OFFLOADING;
-
   int total_errors = 0;
 
   OMPVV_TEST_AND_SET_VERBOSE(total_errors, test_multiply() != 0);

--- a/tests/5.0/loop/test_loop_reduction_multiply.c
+++ b/tests/5.0/loop/test_loop_reduction_multiply.c
@@ -48,11 +48,11 @@ int test_multiply() {
       host_result *= a[x + y];
     }
     OMPVV_TEST_AND_SET_VERBOSE(errors, host_result != result);
-    OMPVV_INFOMSG_IF(host_result != result, "Device result is %d and host result is %d.", result, host_result);
+    OMPVV_INFOMSG_IF(host_result != result, "Loop directive result is %d and expected result is %d.", result, host_result);
   }
 
   for (int x = 1; x < N; ++x) {
-    OMPVV_WARNING_IF(num_threads[x - 1] != num_threads[x], "Kernel reported differing numbers of threads.  Validity of testing of reduction clause cannot be guaranteed.");
+    OMPVV_WARNING_IF(num_threads[x - 1] != num_threads[x], "Test reported differing numbers of threads.  Validity of testing of reduction clause cannot be guaranteed.");
   }
   OMPVV_WARNING_IF(num_threads[0] == 1, "Test operated with one thread.  Reduction clause cannot be tested.");
   OMPVV_WARNING_IF(num_threads[0] <= 0, "Test reported invalid number of threads.  Validity of testing of reduction clause cannot be guaranteed.");

--- a/tests/5.0/loop/test_loop_reduction_or.c
+++ b/tests/5.0/loop/test_loop_reduction_or.c
@@ -1,0 +1,87 @@
+//===--- test_target_teams_distribute_reduction_or.c-------------------------===//
+//
+// OpenMP API Version 4.5 Nov 2015
+//
+// This test uses the reduction clause on a target teams distribute directive,
+// testing that the variable in the reduction clause is properly reduced using
+// the or operator.
+//
+////===----------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+#include <math.h>
+
+#define N 1024
+#define THRESHOLD 512
+
+int test_or() {
+  char a[N];
+  double true_margin = pow(exp(1), log(.5)/N);   // See the 'and' operator test for
+  int errors = 0;                                // an explanation of this math.
+  int num_teams[N];
+  int tested_true = 0;
+  int tested_false = 0;
+  int itr_count = 0;
+  srand(1);
+
+  while ((!tested_true || !tested_false) && (itr_count < THRESHOLD)) {
+    for (int x = 0; x < N; ++x) {
+      a[x] = rand() / (double)(RAND_MAX) > true_margin;
+      num_teams[x] = -x;
+    }
+
+    char result = 0;
+    char host_result = 0;
+
+#pragma omp target teams distribute reduction(||:result) defaultmap(tofrom:scalar)
+    for (int x = 0; x < N; ++x) {
+      num_teams[x] = omp_get_num_teams();
+      result = result || a[x];
+    }
+
+    for (int x = 0; x < N; ++x) {
+      host_result = host_result || a[x];
+    }
+
+    if (itr_count == 0) {
+      for (int x = 1; x < N; ++x) {
+        OMPVV_WARNING_IF(num_teams[x - 1] != num_teams[x], "Kernel reported differing numbers of teams.  Validity of testing of reduction clause cannot be guaranteed.");
+      }
+      OMPVV_WARNING_IF(num_teams[0] == 1, "Test operated with one team.  Reduction clause cannot be tested.");
+      OMPVV_WARNING_IF(num_teams[0] <= 0, "Test reported invalid number of teams.  Validity of testing of reduction clause cannot be guaranteed.");
+    }
+
+    OMPVV_TEST_AND_SET_VERBOSE(errors, host_result != result);
+    OMPVV_ERROR_IF(host_result != result, "Result on device is %d but expected result from host is %d.", result, host_result);
+
+    if (host_result) {
+      tested_true = 1;
+    } else {
+      tested_false = 1;
+    }
+
+    if (host_result != result) {
+      break;
+    }
+
+    itr_count++;
+  }
+
+  OMPVV_WARNING_IF(!tested_true, "Did not test a case in which final result was true.");
+  OMPVV_WARNING_IF(!tested_false, "Did not test a case in which final result was false.");
+
+  return errors;
+}
+
+int main() {
+  OMPVV_TEST_OFFLOADING;
+
+  int total_errors = 0;
+
+  OMPVV_TEST_AND_SET_VERBOSE(total_errors, test_or() != 0);
+
+  OMPVV_REPORT_AND_RETURN(total_errors);
+}

--- a/tests/5.0/loop/test_loop_reduction_or.c
+++ b/tests/5.0/loop/test_loop_reduction_or.c
@@ -83,8 +83,6 @@ int test_or() {
 }
 
 int main() {
-  OMPVV_TEST_OFFLOADING;
-
   int total_errors = 0;
 
   OMPVV_TEST_AND_SET_VERBOSE(total_errors, test_or() != 0);

--- a/tests/5.0/loop/test_loop_reduction_or.c
+++ b/tests/5.0/loop/test_loop_reduction_or.c
@@ -54,14 +54,14 @@ int test_or() {
 
     if (itr_count == 0) {
       for (int x = 1; x < N; ++x) {
-        OMPVV_WARNING_IF(num_threads[x - 1] != num_threads[x], "Kernel reported differing numbers of threads.  Validity of testing of reduction clause cannot be guaranteed.");
+        OMPVV_WARNING_IF(num_threads[x - 1] != num_threads[x], "Test reported differing numbers of threads.  Validity of testing of reduction clause cannot be guaranteed.");
       }
       OMPVV_WARNING_IF(num_threads[0] == 1, "Test operated with one thread.  Reduction clause cannot be tested.");
       OMPVV_WARNING_IF(num_threads[0] <= 0, "Test reported invalid number of threads.  Validity of testing of reduction clause cannot be guaranteed.");
     }
 
     OMPVV_TEST_AND_SET_VERBOSE(errors, host_result != result);
-    OMPVV_ERROR_IF(host_result != result, "Result on device is %d but expected result from host is %d.", result, host_result);
+    OMPVV_ERROR_IF(host_result != result, "Result from loop directive is %d but expected result is %d.", result, host_result);
 
     if (host_result) {
       tested_true = 1;

--- a/tests/5.0/loop/test_loop_reduction_subtract.c
+++ b/tests/5.0/loop/test_loop_reduction_subtract.c
@@ -1,0 +1,63 @@
+//===--- test_target_teams_distribute_reduction_subtract.c----------------------------===//
+//
+// OpenMP API Version 4.5 Nov 2015
+//
+// This test uses the reduction clause on a target teams distribute directive,
+// testing that the variable in the reduction clause is properly reduced using
+// the subtract operator.
+//
+////===----------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+#include <math.h>
+
+#define N 1024
+
+int test_subtraction() {
+  int a[N];
+  int b[N];
+  int total = 0;
+  int host_total = 0;
+  int errors = 0;
+  int num_teams[N];
+
+  for (int x = 0; x < N; ++x) {
+    a[x] = 1;
+    b[x] = x;
+    num_teams[x] = -x;
+  }
+
+#pragma omp target teams distribute reduction(-:total) defaultmap(tofrom:scalar)
+  for (int x = 0; x < N; ++x) {
+    num_teams[x] = omp_get_num_teams();
+    total -= a[x] + b[x];
+  }
+
+  for (int x = 0; x < N; ++x) {
+    host_total -= a[x] + b[x];
+  }
+
+  for (int x = 1; x < N; ++x) {
+    OMPVV_WARNING_IF(num_teams[x - 1] != num_teams[x], "Kernel reported differing numbers of teams.  Validity of testing of reduction clause cannot be guaranteed.");
+  }
+  OMPVV_WARNING_IF(num_teams[0] == 1, "Test operated with one team.  Reduction clause cannot be tested.");
+  OMPVV_WARNING_IF(num_teams[0] <= 0, "Test reported invalid number of teams.  Validity of testing of reduction clause cannot be guaranteed.");
+
+  OMPVV_TEST_AND_SET_VERBOSE(errors, host_total != total);
+  OMPVV_ERROR_IF(host_total != total, "Total on device is %d but expected total from host is %d.", total, host_total);
+
+  return errors;
+}
+
+int main() {
+  OMPVV_TEST_OFFLOADING;
+
+  int total_errors = 0;
+
+  OMPVV_TEST_AND_SET_VERBOSE(total_errors, test_subtraction() != 0);
+
+  OMPVV_REPORT_AND_RETURN(total_errors);
+}

--- a/tests/5.0/loop/test_loop_reduction_subtract.c
+++ b/tests/5.0/loop/test_loop_reduction_subtract.c
@@ -59,8 +59,6 @@ int test_subtraction() {
 }
 
 int main() {
-  OMPVV_TEST_OFFLOADING;
-
   int total_errors = 0;
 
   OMPVV_TEST_AND_SET_VERBOSE(total_errors, test_subtraction() != 0);

--- a/tests/5.0/loop/test_loop_reduction_subtract.c
+++ b/tests/5.0/loop/test_loop_reduction_subtract.c
@@ -47,13 +47,13 @@ int test_subtraction() {
   }
 
   for (int x = 1; x < N; ++x) {
-    OMPVV_WARNING_IF(num_threads[x - 1] != num_threads[x], "Kernel reported differing numbers of threads.  Validity of testing of reduction clause cannot be guaranteed.");
+    OMPVV_WARNING_IF(num_threads[x - 1] != num_threads[x], "Test reported differing numbers of threads.  Validity of testing of reduction clause cannot be guaranteed.");
   }
   OMPVV_WARNING_IF(num_threads[0] == 1, "Test operated with one thread.  Reduction clause cannot be tested.");
   OMPVV_WARNING_IF(num_threads[0] <= 0, "Test reported invalid number of threads.  Validity of testing of reduction clause cannot be guaranteed.");
 
   OMPVV_TEST_AND_SET_VERBOSE(errors, host_total != total);
-  OMPVV_ERROR_IF(host_total != total, "Total on device is %d but expected total from host is %d.", total, host_total);
+  OMPVV_ERROR_IF(host_total != total, "Total from loop directive is %d but expected total is %d.", total, host_total);
 
   return errors;
 }


### PR DESCRIPTION
These tests check the loop construct with the reduction clause. All reduction types are checked. The method used is similar to reduction testing for target teams distribute.

Currently only GCC passes these tests on Summit.