### PR TITLE
Add 5.0 test of loop directive with lastprivate clause

### DIFF
--- a/tests/5.0/loop/test_loop_lastprivate.c
+++ b/tests/5.0/loop/test_loop_lastprivate.c
@@ -1,0 +1,98 @@
+//===--- test_loop_lastprivate.c ----------------------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// This test uses the lastprivate clause with a loop directive. According to
+// specification, the list items on a lastprivate clause in this context may
+// only contain loop iteration variables of loops associated with the loop
+// directive. This test checks that the loop iteration variables associated
+// with a loop directive and a loop directive with collapse(2) have valid
+// values after the parallel region containing the loop.
+//
+////===------------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define SIZE 1024
+
+int test_one_loop_level() {
+  int a[SIZE];
+  int b[SIZE];
+  int errors = 0;
+  int lp_errors = 0;
+  int x = 0;
+
+  for (x = 0; x < SIZE; ++x) {
+    a[x] = 1;
+    b[x] = x;
+  }
+
+#pragma omp parallel num_threads(OMPVV_NUM_THREADS_HOST)
+  {
+#pragma omp loop lastprivate(x)
+    for (x = 0; x < SIZE; ++x) {
+      a[x] += b[x];
+    }
+  }
+
+  OMPVV_TEST_AND_SET_VERBOSE(lp_errors, x >= SIZE || x < 0);
+  OMPVV_ERROR_IF(lp_errors, "Loop iteration variable in loop construct ended with invalid value.");
+
+  for (x = 0; x < SIZE; ++x) {
+    OMPVV_TEST_AND_SET_VERBOSE(errors, a[x] - b[x] != 1);
+  }
+
+  return errors + lp_errors;
+}
+
+int test_two_loop_levels() {
+  int a[SIZE][SIZE];
+  int b[SIZE][SIZE];
+  int errors = 0;
+  int lp_errors_x = 0;
+  int lp_errors_y = 0;
+  int x = 0;
+  int y = 0;
+
+  for (x = 0; x < SIZE; ++x) {
+    for (y = 0; y < SIZE; ++y) {
+      a[x][y] = 1;
+      b[x][y] = x + y;
+    }
+  }
+
+#pragma omp parallel num_threads(OMPVV_NUM_THREADS_HOST)
+  {
+#pragma omp loop lastprivate(x)
+    for (x = 0; x < SIZE; ++x) {
+      for (y = 0; y < SIZE; ++y) {
+        a[x][y] += b[x][y];
+      }
+    }
+  }
+
+  OMPVV_TEST_AND_SET_VERBOSE(lp_errors_x, x > SIZE || x < 0);
+  OMPVV_TEST_AND_SET_VERBOSE(lp_errors_y, y > SIZE || y < 0);
+  OMPVV_ERROR_IF(lp_errors_x, "Outer loop iteration variable in loop directive with collapse ended with invalid value.");
+  OMPVV_ERROR_IF(lp_errors_y, "Inner loop iteration variable in loop directive with collapse ended with invalid value.");
+
+  for (x = 0; x < SIZE; ++x) {
+    for (y = 0; y < SIZE; ++y) {
+      OMPVV_TEST_AND_SET_VERBOSE(errors, a[x][y] - b[x][y] != 1);
+    }
+  }
+
+  return errors + lp_errors_x + lp_errors_y;
+}
+
+int main() {
+  int errors = 0;
+
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_one_loop_level());
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_two_loop_levels());
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.0/loop/test_loop_lastprivate.c
+++ b/tests/5.0/loop/test_loop_lastprivate.c
@@ -66,7 +66,7 @@ int test_two_loop_levels() {
 
 #pragma omp parallel num_threads(OMPVV_NUM_THREADS_HOST)
   {
-#pragma omp loop lastprivate(x, y)
+#pragma omp loop lastprivate(x, y) collapse(2)
     for (x = 0; x < SIZE; ++x) {
       for (y = 0; y < SIZE; ++y) {
         a[x][y] += b[x][y];

--- a/tests/5.0/loop/test_loop_lastprivate.c
+++ b/tests/5.0/loop/test_loop_lastprivate.c
@@ -38,7 +38,7 @@ int test_one_loop_level() {
     }
   }
 
-  OMPVV_TEST_AND_SET_VERBOSE(lp_errors, x > SIZE || x < 0);
+  OMPVV_TEST_AND_SET_VERBOSE(lp_errors, x != SIZE);
   OMPVV_ERROR_IF(lp_errors, "Loop iteration variable in loop construct ended with invalid value.");
 
   for (x = 0; x < SIZE; ++x) {
@@ -66,7 +66,7 @@ int test_two_loop_levels() {
 
 #pragma omp parallel num_threads(OMPVV_NUM_THREADS_HOST)
   {
-#pragma omp loop lastprivate(x)
+#pragma omp loop lastprivate(x, y)
     for (x = 0; x < SIZE; ++x) {
       for (y = 0; y < SIZE; ++y) {
         a[x][y] += b[x][y];
@@ -74,8 +74,8 @@ int test_two_loop_levels() {
     }
   }
 
-  OMPVV_TEST_AND_SET_VERBOSE(lp_errors_x, x > SIZE || x < 0);
-  OMPVV_TEST_AND_SET_VERBOSE(lp_errors_y, y > SIZE || y < 0);
+  OMPVV_TEST_AND_SET_VERBOSE(lp_errors_x, x != SIZE);
+  OMPVV_TEST_AND_SET_VERBOSE(lp_errors_y, y != SIZE);
   OMPVV_ERROR_IF(lp_errors_x, "Outer loop iteration variable in loop directive with collapse ended with invalid value.");
   OMPVV_ERROR_IF(lp_errors_y, "Inner loop iteration variable in loop directive with collapse ended with invalid value.");
 

--- a/tests/5.0/loop/test_loop_lastprivate.c
+++ b/tests/5.0/loop/test_loop_lastprivate.c
@@ -38,7 +38,7 @@ int test_one_loop_level() {
     }
   }
 
-  OMPVV_TEST_AND_SET_VERBOSE(lp_errors, x >= SIZE || x < 0);
+  OMPVV_TEST_AND_SET_VERBOSE(lp_errors, x > SIZE || x < 0);
   OMPVV_ERROR_IF(lp_errors, "Loop iteration variable in loop construct ended with invalid value.");
 
   for (x = 0; x < SIZE; ++x) {


### PR DESCRIPTION
This test of the lastprivate clause, unlike other loop tests, is different from usual lastprivate testing for worksharing loop directives.

5.0 spec restricts the lastprivate clause to only be used on loop iteration variables when used with a loop directive. This test checks that the lastprivate'd loop iteration variables for a single-level loop and a two-level collapsed loop end with valid values after the end of the loop region.