### PR TITLE
Add 5.0 test of parallel for construct with allocate clause

### DIFF
--- a/tests/5.0/parallel_for/test_parallel_for_allocate.c
+++ b/tests/5.0/parallel_for/test_parallel_for_allocate.c
@@ -1,0 +1,62 @@
+//===------ test_parallel_for_allocate.c ----------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// Tests the parallel for directive with allocator clause, based on the
+// OpenMP 5.0 example for allocators. The allocator testing first creates
+// an allocator, with 64-byte alignment and the default memory space,
+// then checks that 64-byte alignment is correct and that the memory can
+// be written to in the parallel for region in private arrays set to
+// allocate with the created allocator. The tests checks that the values
+// were written correctly, and then frees the memory and deletes the
+// allocator.
+//
+//===----------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+int test_parallel_for_allocate() {
+  int errors = 0;
+
+  int* x;
+  int result[N][N];
+  omp_memspace_handle_t x_memspace = omp_default_mem_space;
+  omp_alloctrait_t x_traits[1] = {omp_atk_alignment, 64};
+  omp_allocator_handle_t x_alloc = omp_init_allocator(x_memspace, 1, x_traits);
+
+#pragma omp parallel for allocate(x_alloc: x) private(x) shared(result) num_threads(OMPVV_NUM_THREADS_HOST)
+  for (int i = 0; i < N; i++) {
+    x = (int *) malloc(N*sizeof(int));
+#pragma omp simd simdlen(16) aligned(x: 64)
+    for (int j = 0; j < N; j++) {
+      x[j] = j*i;
+    }
+    for (int j = 0; j < N; j++) {
+      result[i][j] = x[j];
+    }
+    free(x);
+  }
+
+  for (int i = 0; i < N; i++) {
+    for (int j = 0; j < N; j++) {
+      OMPVV_TEST_AND_SET_VERBOSE(errors, result[i][j] != i*j);
+    }
+  }
+
+  omp_destroy_allocator(x_alloc);
+
+  return errors;
+}
+
+int main() {
+  int errors = 0;
+
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_parallel_for_allocate() != 0);
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.0/parallel_for/test_parallel_for_allocate.c
+++ b/tests/5.0/parallel_for/test_parallel_for_allocate.c
@@ -24,9 +24,17 @@ int test_parallel_for_allocate() {
   int errors = 0;
   int* x;
   int result[N][N];
+  int successful_alloc = 0;
+
   omp_memspace_handle_t x_memspace = omp_default_mem_space;
   omp_alloctrait_t x_traits[1] = {omp_atk_alignment, 64};
   omp_allocator_handle_t x_alloc = omp_init_allocator(x_memspace, 1, x_traits);
+
+  for (int i = 0; i < N; i++) {
+    for (int j = 0; j < N; j++) {
+      result[i][j] = -1;
+    }
+  }
 
 #pragma omp parallel for allocate(x_alloc: x) private(x) shared(result) num_threads(OMPVV_NUM_THREADS_HOST)
   for (int i = 0; i < N; i++) {
@@ -40,8 +48,12 @@ int test_parallel_for_allocate() {
         result[i][j] = x[j];
       }
       free(x);
+      successful_alloc++;
     }
   }
+
+  OMPVV_ERROR_IF(successful_alloc < 1, "Failed to allocate x");
+  OMPVV_TEST_AND_SET_VERBOSE(errors, successful_alloc < 1);
 
   for (int i = 0; i < N; i++) {
     for (int j = 0; j < N; j++) {

--- a/tests/5.0/parallel_for/test_parallel_for_allocate.c
+++ b/tests/5.0/parallel_for/test_parallel_for_allocate.c
@@ -1,4 +1,4 @@
-//===------ test_parallel_for_allocate.c ----------------------------------===//
+//===--- test_parallel_for_allocate.c -------------------------------------===//
 //
 // OpenMP API Version 5.0 Nov 2018
 //
@@ -22,7 +22,6 @@
 
 int test_parallel_for_allocate() {
   int errors = 0;
-
   int* x;
   int result[N][N];
   omp_memspace_handle_t x_memspace = omp_default_mem_space;
@@ -32,14 +31,16 @@ int test_parallel_for_allocate() {
 #pragma omp parallel for allocate(x_alloc: x) private(x) shared(result) num_threads(OMPVV_NUM_THREADS_HOST)
   for (int i = 0; i < N; i++) {
     x = (int *) malloc(N*sizeof(int));
+    if (x != NULL) {
 #pragma omp simd simdlen(16) aligned(x: 64)
-    for (int j = 0; j < N; j++) {
-      x[j] = j*i;
+      for (int j = 0; j < N; j++) {
+        x[j] = j*i;
+      }
+      for (int j = 0; j < N; j++) {
+        result[i][j] = x[j];
+      }
+      free(x);
     }
-    for (int j = 0; j < N; j++) {
-      result[i][j] = x[j];
-    }
-    free(x);
   }
 
   for (int i = 0; i < N; i++) {


### PR DESCRIPTION
This tests the allocate clause on a for (worksharing-loop) directive. 5.0 spec requires that any list item on an allocate clause must be privatized by a data-sharing clause on the same directive, so this test does so. A private array is created in the parallel for region using a 64-byte-aligned allocator and the array is written to in a SIMD region with the aligned(x: 64) clause. The values are saved to shared array and the values are checked for correctness.