### PR TITLE
Add 5.0 test of scan directive and reduction(inscan..) on par for simd

### DIFF
--- a/tests/5.0/scan/test_scan.c
+++ b/tests/5.0/scan/test_scan.c
@@ -2,11 +2,11 @@
 //
 // OpenMP API Version 5.0 Nov 2018
 //
-// This test checks the parallel for directive with the order(concurrent)
-// The test performs simple operations on an int array which are then
-// checked for correctness. The specification indicates only that iterations
-// in the loop may be executed concurrently, so no particular order or lack
-// thereof can be required by this test.
+// This test checks the scan directive with both the inclusive and exclusive
+// clause, as well as the parallel for simd directive with the
+// reduction(inscan) clause. The test peforms the scan operation with the add
+// operator and then checks the results against an expected result from a
+// sequentially-computed prefix sum.
 //
 ////===----------------------------------------------------------------------===//
 #include <assert.h>

--- a/tests/5.0/scan/test_scan.c
+++ b/tests/5.0/scan/test_scan.c
@@ -1,0 +1,89 @@
+//===--- test_scan.c --------------------------------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// This test checks the parallel for directive with the order(concurrent)
+// The test performs simple operations on an int array which are then
+// checked for correctness. The specification indicates only that iterations
+// in the loop may be executed concurrently, so no particular order or lack
+// thereof can be required by this test.
+//
+////===----------------------------------------------------------------------===//
+#include <assert.h>
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+int test_scan_inclusive() {
+  OMPVV_INFOMSG("test_scan_inclusive");
+  int errors = 0;
+  int x = 0;
+  int expected_x = 0;
+  int a[N];
+  int b[N];
+
+  for (int i = 0; i < N; i++) {
+    a[i] = i;
+    b[i] = 0;
+  }
+
+#pragma omp parallel for simd reduction(inscan, +: x) num_threads(OMPVV_NUM_THREADS_HOST)
+  for (int i = 0; i < N; i++) {
+    x += a[i];
+#pragma omp scan inclusive(x)
+    b[i] = x;
+  }
+
+  for (int i = 0; i < N; i++) {
+    for (int j = 0; j <= i; j++) {
+      expected_x += a[j];
+    }
+    OMPVV_TEST_AND_SET_VERBOSE(errors, b[i] != expected_x);
+    expected_x = 0;
+  }
+
+  return errors;
+}
+
+int test_scan_exclusive() {
+  OMPVV_INFOMSG("test_scan_exclusive");
+  int errors = 0;
+  int x = 0;
+  int expected_x = 0;
+  int a[N];
+  int b[N];
+
+  for (int i = 0; i < N; i++) {
+    a[i] = i;
+    b[i] = 0;
+  }
+
+#pragma omp parallel for simd reduction(inscan, +: x) num_threads(OMPVV_NUM_THREADS_HOST)
+  for (int i = 0; i < N; i++) {
+    b[i] = x;
+#pragma omp scan exclusive(x)
+    x += a[i];
+  }
+
+  for (int i = 0; i < N; i++) {
+    for (int j = 0; j < i; j++) {
+      expected_x += a[j];
+    }
+    OMPVV_TEST_AND_SET_VERBOSE(errors, b[i] != expected_x);
+    expected_x = 0;
+  }
+
+  return errors;
+}
+
+int main() {
+  int errors = 0;
+
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_scan_inclusive());
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_scan_exclusive());
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}


### PR DESCRIPTION
This is a test of the new scan feature from OpenMP 5.0. The scan directive must appear with either an inclusive or exclusive clause, and the list item appearing in the inclusive/exclusive clause must also appear in a reduction(inscan...) clause on the for/simd construct that contains the scan directive. Thus, this test checks both scan and reduction(inscan...), by conducting both and inclusive and exclusive scan with a sum operator and checking the results against expected results from a sequential prefix sum.

Currently, this test passes GCC only on Summit. XL will not compile the test. It will compile with Clang, but the test reports incorrect values were returned (with 11.0.0-rc1 *and* 12.0.0-latest). This appears to be a compiler bug, so I will investigate further.