### PR TITLE
Adding new 5.0 test for simd with order(concurrent) clause

### DIFF
--- a/tests/5.0/simd/test_simd_order_concurrent.c
+++ b/tests/5.0/simd/test_simd_order_concurrent.c
@@ -1,0 +1,52 @@
+//===--- test_simd_order_concurrent.c ---------------------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// This test checks for support of the order(concurrent) clause on a simd construct.
+// When an order(concurrent) clause is present on a simd construct, all of the same 
+// restrictions from having a loop construct with an order(concurrent) also apply.
+//
+////===----------------------------------------------------------------------------===//
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <omp.h> 
+#include "ompvv.h" 
+#define N 1024
+
+int test_simd_order_concurrent () {
+   int errors = 0;
+   int i;
+   int b[N], c[N];
+
+   struct new_struct {
+      int a[N];
+   };
+
+   struct new_struct struct_t;
+   
+   for (i = 0; i < N; i++ ) {
+      struct_t.a[i] = i;
+      b[i] = i + 5;
+      c[i] = 0;
+   }
+
+   #pragma omp simd order(concurrent) 
+      for (i = 0; i < N; i++) {
+         c[i] = struct_t.a[i] * b[i];
+      }
+
+   for (i = 0; i < N; i++) {
+      OMPVV_TEST_AND_SET(errors, c[i] != (struct_t.a[i] * b[i]));
+   }
+
+   return errors;
+}
+
+
+int main () { 
+   int errors = 0;
+
+   OMPVV_TEST_AND_SET_VERBOSE(errors, test_simd_order_concurrent());
+   OMPVV_REPORT_AND_RETURN(errors);
+}


### PR DESCRIPTION
Test for simd order(concurrent). 5.0 Specification says that if an order(concurrent) is present, all restrictions from the loop construct with an order(concurrent) clause also apply. I am assuming this statement is included in those restrictions -> "If the order clause is not present, the behavior is as if the order(concurrent) clause appeared on the construct."

Passes on newest llvm trunk and gcc 10.2
