### PR TITLE
Add 5.0 test of parallel master taskloop construct

### DIFF
--- a/tests/5.0/parallel_master_taskloop/test_parallel_master_taskloop.c
+++ b/tests/5.0/parallel_master_taskloop/test_parallel_master_taskloop.c
@@ -14,8 +14,8 @@
 
 #define N 1024
 
-int test_parallel_parallel_master_taskloop() {
-  OMPVV_INFOMSG("test_parallel_parallel_master_taskloop");
+int test_parallel_master_taskloop() {
+  OMPVV_INFOMSG("test_parallel_master_taskloop");
   int errors = 0;
   int num_threads = -1;
   int x[N];
@@ -50,7 +50,7 @@ int test_parallel_parallel_master_taskloop() {
 int main() {
   int errors = 0;
 
-  OMPVV_TEST_AND_SET_VERBOSE(errors, test_parallel_parallel_master_taskloop());
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_parallel_master_taskloop());
 
   OMPVV_REPORT_AND_RETURN(errors);
 }

--- a/tests/5.0/parallel_master_taskloop/test_parallel_master_taskloop.c
+++ b/tests/5.0/parallel_master_taskloop/test_parallel_master_taskloop.c
@@ -1,0 +1,56 @@
+//===--- test_parallel_parallel_master_taskloop.c -------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// This test checks the parallel master taskloop directive. The test performs
+// simple operations on an int array which are then checked for correctness.
+//
+////===----------------------------------------------------------------------===//
+#include <assert.h>
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+int test_parallel_parallel_master_taskloop() {
+  OMPVV_INFOMSG("test_parallel_parallel_master_taskloop");
+  int errors = 0;
+  int num_threads = -1;
+  int x[N];
+  int y[N];
+  int z[N];
+
+  for (int i = 0; i < N; i++) {
+    x[i] = 1;
+    y[i] = i + 1;
+    z[i] = 2*(i + 1);
+  }
+
+#pragma omp parallel master taskloop num_threads(OMPVV_NUM_THREADS_HOST) shared(x, y, z, num_threads)
+  for (int i = 0; i < N; i++) {
+    x[i] += y[i]*z[i];
+    if (omp_get_thread_num() == 0) {
+      num_threads = omp_get_num_threads();
+    }
+  }
+
+  for (int i = 0; i < N; i++) {
+    OMPVV_TEST_AND_SET_VERBOSE(errors, x[i] != 1 + (y[i]*z[i]));
+  }
+
+  OMPVV_WARNING_IF(num_threads == 1, "Test ran with one thread, so parallelism of taskloop can't be guaranteed.");
+  OMPVV_ERROR_IF(num_threads < 1, "Test returned an invalid number of threads.");
+
+  return errors;
+}
+
+
+int main() {
+  int errors = 0;
+
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_parallel_parallel_master_taskloop());
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.0/parallel_master_taskloop/test_parallel_master_taskloop.c
+++ b/tests/5.0/parallel_master_taskloop/test_parallel_master_taskloop.c
@@ -42,6 +42,7 @@ int test_parallel_master_taskloop() {
 
   OMPVV_WARNING_IF(num_threads == 1, "Test ran with one thread, so parallelism of taskloop can't be guaranteed.");
   OMPVV_ERROR_IF(num_threads < 1, "Test returned an invalid number of threads.");
+  OMPVV_TEST_AND_SET_VERBOSE(errors, num_threads < 1);
 
   return errors;
 }

--- a/tests/5.0/parallel_master_taskloop/test_parallel_master_taskloop.c
+++ b/tests/5.0/parallel_master_taskloop/test_parallel_master_taskloop.c
@@ -1,4 +1,4 @@
-//===--- test_parallel_parallel_master_taskloop.c -------------------------------===//
+//===--- test_parallel_master_taskloop.c -------------------------------===//
 //
 // OpenMP API Version 5.0 Nov 2018
 //

--- a/tests/5.0/parallel_master_taskloop/test_parallel_master_taskloop_device.c
+++ b/tests/5.0/parallel_master_taskloop/test_parallel_master_taskloop_device.c
@@ -46,6 +46,7 @@ int test_parallel_master_taskloop() {
 
   OMPVV_WARNING_IF(num_threads == 1, "Test ran with one thread, so parallelism of taskloop can't be guaranteed.");
   OMPVV_ERROR_IF(num_threads < 1, "Test returned an invalid number of threads.");
+  OMPVV_TEST_AND_SET_VERBOSE(errors, num_threads < 1);
 
   return errors;
 }

--- a/tests/5.0/parallel_master_taskloop/test_parallel_master_taskloop_device.c
+++ b/tests/5.0/parallel_master_taskloop/test_parallel_master_taskloop_device.c
@@ -1,0 +1,62 @@
+//===--- test_parallel_master_taskloop_device.c ------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// This test checks the parallel master taskloop directive. The test performs
+// simple operations on an int array which are then checked for correctness.
+// This test checks the construct in a target context.
+//
+////===----------------------------------------------------------------------===//
+#include <assert.h>
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+int test_parallel_master_taskloop() {
+  OMPVV_INFOMSG("test_parallel_master_taskloop");
+  int errors = 0;
+  int num_threads = -1;
+  int x[N];
+  int y[N];
+  int z[N];
+
+  for (int i = 0; i < N; i++) {
+    x[i] = 1;
+    y[i] = i + 1;
+    z[i] = 2*(i + 1);
+  }
+
+#pragma omp target map(tofrom: x, y, z, num_threads)
+  {
+#pragma omp parallel master taskloop num_threads(OMPVV_NUM_THREADS_HOST) shared(x, y, z, num_threads)
+    for (int i = 0; i < N; i++) {
+      x[i] += y[i]*z[i];
+      if (omp_get_thread_num() == 0) {
+        num_threads = omp_get_num_threads();
+      }
+    }
+  }
+
+  for (int i = 0; i < N; i++) {
+    OMPVV_TEST_AND_SET_VERBOSE(errors, x[i] != 1 + (y[i]*z[i]));
+  }
+
+  OMPVV_WARNING_IF(num_threads == 1, "Test ran with one thread, so parallelism of taskloop can't be guaranteed.");
+  OMPVV_ERROR_IF(num_threads < 1, "Test returned an invalid number of threads.");
+
+  return errors;
+}
+
+
+int main() {
+  OMPVV_TEST_OFFLOADING;
+
+  int errors = 0;
+
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_parallel_master_taskloop());
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}


### PR DESCRIPTION
This is a simple test of the parallel master taskloop construct for correctness of array math in a loop, with a check for number of threads.

It fails XL due to lack of support but passes GCC and Clang.