### PR TITLE
5.0/program_control/test_omp_target_offload.c: Remove _OPENMP check

### DIFF
--- a/tests/5.0/program_control/test_omp_target_offload.c
+++ b/tests/5.0/program_control/test_omp_target_offload.c
@@ -54,10 +54,6 @@ int main() {
    OMPVV_TEST_AND_SET_OFFLOADING(isOffloading);
    offload_policy_t policy = get_offload_policy();
 
-   // check if OMP_TARGET_OFFLOAD is supported
-   OMPVV_ERROR_IF(_OPENMP< 201811,"ERROR: OMP_TARGET_OFFLOAD NOT supported by VER. %d",_OPENMP );
-   OMPVV_TEST_AND_SET_VERBOSE(errors, _OPENMP < 201811);
-
    // initialize values on the host
    scalar = 17;
    on_init_dev = 1;


### PR DESCRIPTION
Compilers might support this OpenMP 5.0 feature but not enough of 5.0
to have set _OPENMP to 5.0. Like other tests under 4.5 or 5.0, check
the feature without a version check.

Issue #259
* tests/5.0/program_control/test_omp_target_offload.c: Remove error if _OPENMP < 201811.