### PR TITLE
Run test_omp_target_offload with multiple environment vars set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -309,9 +309,19 @@ $(CURDIR)/tests/4.5/application_kernels/qmcpack_target_static_lib.c.o: $(CURDIR)
 %.c.run: $(OBJS_C)
 	$(call log_section_header,"RUN",$(SYSTEM),$(@:.run=),$(LOG_NOTE),$(OMP_VERSION),$(notdir $(@:.run=.log)))
 	@echo -e $(TXTGRN)"\n\n" running: $@ $(TXTNOC) $(if $(LOG), ${RECORD}$(notdir $(@:.run=.log)))
-	-$(call loadModules,$(C_COMPILER_MODULE)) $(BSRUN)$(RUN_TEST) $(@:.run=.o) $(VERBOSE) $(if $(LOG),$(RECORD)$(notdir $(@:.run=.log))\
-		&& echo "PASS" > $(LOGTEMPFILE) \
-		|| echo "FAIL" > $(LOGTEMPFILE))
+# If .../test_<envname>_env_<value>...
+	$(if $(findstring _env_,$@), \
+	  -$(call loadModules,$(C_COMPILER_MODULE)) \
+		 $(BSRUN)$(RUN_TEST) --env \
+		   $(shell echo "$@" | sed -e 's@.*/@@' -e 's@test_\(.*\)_env_.*@\1@' | tr 'a-z' 'A-Z') \
+		   $(shell echo "$@" | sed -e 's@.*/@@' -e 's@.*_env_\([^.]*\).*@\1@') \
+		   $(@:.run=.o) $(VERBOSE) $(if $(LOG),$(RECORD)$(notdir $(@:.run=.log)) \
+		 && echo "PASS" > $(LOGTEMPFILE) \
+		 || echo "FAIL" > $(LOGTEMPFILE)), \
+	 -$(call loadModules,$(C_COMPILER_MODULE)) $(BSRUN)$(RUN_TEST) $(@:.run=.o) $(VERBOSE) $(if $(LOG),$(RECORD)$(notdir $(@:.run=.log))\
+		 && echo "PASS" > $(LOGTEMPFILE) \
+		 || echo "FAIL" > $(LOGTEMPFILE)) \
+	)
 	-$(call log_section_footer,"RUN",$(SYSTEM),$$(cat $(LOGTEMPFILE)),$(LOG_NOTE),$(notdir $(@:.run=.log)))
 	-@$(if $(LOG), rm $(LOGTEMPFILE))
 
@@ -324,7 +334,8 @@ $(CURDIR)/tests/4.5/application_kernels/qmcpack_target_static_lib.c.o: $(CURDIR)
 		|| echo "FAIL" > $(LOGTEMPFILE))
 	-$(call log_section_footer,"RUN",$(SYSTEM),$$(cat $(LOGTEMPFILE)),$(LOG_NOTE),$(notdir $(@:.run=.log)))
 	-@$(if $(LOG), rm $(LOGTEMPFILE))
-# run c app rule
+
+# run Fortran app rule
 %.FOR.run: $(OBJS_F)
 	$(call log_section_header,"RUN",$(SYSTEM),$(@:.FOR.run=),$(LOG_NOTE),$(OMP_VERSION),$(notdir $(@:.FOR.run=.log)))
 	@echo -e $(TXTGRN)"\n\n" running: $@ $(TXTNOC) $(if $(LOG), ${RECORD}$(notdir $(@:.FOR.run=.log)))
@@ -334,6 +345,7 @@ $(CURDIR)/tests/4.5/application_kernels/qmcpack_target_static_lib.c.o: $(CURDIR)
 	-$(call log_section_footer,"RUN",$(SYSTEM),$$(cat $(LOGTEMPFILE)),$(LOG_NOTE),$(notdir $(@:.FOR.run=.log)))
 	-@$(if $(LOG), rm $(LOGTEMPFILE))
 
+
 ##################################################
 # Running only no compile rules
 ##################################################
@@ -341,9 +353,19 @@ $(CURDIR)/tests/4.5/application_kernels/qmcpack_target_static_lib.c.o: $(CURDIR)
 %.c.runonly:
 	$(call log_section_header,"RUN",$(SYSTEM),$(@:.runonly=),$(LOG_NOTE),$(OMP_VERSION),$(notdir $(@:.runonly=.log)))
 	@echo -e $(TXTGRN)"\n\n" running previously compiled: $@ $(TXTNOC) $(if $(LOG), ${RECORD}$(notdir $(@:.runonly=.log)))
-	-$(call loadModules,$(C_COMPILER_MODULE)) $(BSRUN)$(RUN_TEST) $(@:.runonly=.o) $(VERBOSE) $(if $(LOG),$(RECORD)$(notdir $(@:.runonly=.log))\
-		&& echo "PASS" > $(LOGTEMPFILE) \
-		|| echo "FAIL" > $(LOGTEMPFILE))
+# If .../test_<envname>_env_<value>...
+	$(if $(findstring _env_,$@), \
+	  $(call loadModules,$(C_COMPILER_MODULE)) \
+		 $(BSRUN)$(RUN_TEST) --env \
+		   $(shell echo "$@" | sed -e 's@.*/@@' -e 's@test_\(.*\)_env_.*@\1@' | tr 'a-z' 'A-Z') \
+		   $(shell echo "$@" | sed -e 's@.*/@@' -e 's@.*_env_\([^.]*\).*@\1@') \
+		   $(@:.runonly=.o) $(VERBOSE) $(if $(LOG),$(RECORD)$(notdir $(@:.runonly=.log))\
+		 && echo "PASS" > $(LOGTEMPFILE) \
+		 || echo "FAIL" > $(LOGTEMPFILE)) \
+	  $(call loadModules,$(C_COMPILER_MODULE)) $(BSRUN)$(RUN_TEST) $(@:.runonly=.o) $(VERBOSE) $(if $(LOG),$(RECORD)$(notdir $(@:.runonly=.log))\
+		 && echo "PASS" > $(LOGTEMPFILE) \
+		 || echo "FAIL" > $(LOGTEMPFILE)) \
+	)
 	-$(call log_section_footer,"RUN",$(SYSTEM),$$(cat $(LOGTEMPFILE)),$(LOG_NOTE),$(notdir $(@:.runonly=.log)))
 	-@$(if $(LOG), rm $(LOGTEMPFILE))
 
@@ -356,7 +378,8 @@ $(CURDIR)/tests/4.5/application_kernels/qmcpack_target_static_lib.c.o: $(CURDIR)
 		|| echo "FAIL" > $(LOGTEMPFILE))
 	-$(call log_section_footer,"RUN",$(SYSTEM),$$(cat $(LOGTEMPFILE)),$(LOG_NOTE),$(notdir $(@:.runonly=.log)))
 	-@$(if $(LOG), rm $(LOGTEMPFILE))
-# run c app rule
+
+# run Fortran app rule
 %.FOR.runonly:
 	$(call log_section_header,"RUN",$(SYSTEM),$(@:.FOR.runonly=),$(LOG_NOTE),$(OMP_VERSION),$(notdir $(@:.FOR.runonly=.log)))
 	@echo -e $(TXTGRN)"\n\n" running previously compiled: $@ $(TXTNOC) $(if $(LOG), ${RECORD}$(notdir $(@:.FOR.runonly=.log)))

--- a/tests/5.0/program_control/test_omp_target_offload_env_DEFAULT.c
+++ b/tests/5.0/program_control/test_omp_target_offload_env_DEFAULT.c
@@ -53,7 +53,7 @@ offload_policy_t get_offload_policy() {
 
 int main() {
    int i, errors, isOffloading;
-   int device_num, on_init_dev;
+   int on_init_dev;
    int scalar;
    int x[N];
 
@@ -98,7 +98,7 @@ int main() {
  
    OMPVV_ERROR_IF(policy==NOTSET, "OMP_TARGET_OFFLOAD has not been set");
    OMPVV_ERROR_IF(policy==UNKNOWN,"OMP_TARGET_OFFLOAD has an unknown value '%s'", getenv("OMP_TARGET_OFFLOAD"));
-   OMPVV_ERROR_IF(policy!=NOTSET && policy!=EXPECTED_POLICY, "OMP_TARGET_OFFLOAD set to %s but expected %s", getenv("OMP_TARGET_OFFLOAD"), EXPECTED_POLICY);
+   OMPVV_ERROR_IF(policy!=NOTSET && policy!=EXPECTED_POLICY, "OMP_TARGET_OFFLOAD has unexpected value '%s'", getenv("OMP_TARGET_OFFLOAD"));
 
    OMPVV_REPORT_AND_RETURN(errors);
 }

--- a/tests/5.0/program_control/test_omp_target_offload_env_DEFAULT.c
+++ b/tests/5.0/program_control/test_omp_target_offload_env_DEFAULT.c
@@ -1,4 +1,4 @@
-//===--- test_omp_target_offload.c ----------------------------------------------------------------===//
+//===--- test_omp_target_offload_DEFAULT.c ---------------------------------------------------------===//
 //
 // OpenMP API Version 5.0 Nov 2018
 //
@@ -10,8 +10,15 @@
 // the program will terminate execution when a target construct is encountered and a target device
 // is not available or supported by the implementation. 
 // 
+// The actually checked variant is set by EXPECTED_POLICY; if not overridden DEFAULT is tested.
+// See also test_omp_target_offload_DISABLED.c and test_omp_target_offload_MANDATORY.c
+//
 // This test was adopted from OpenMP 5.0 Examples Doc -> target_offload_control.1.c 
 ////===--------------------------------------------------------------------------------------------===//
+
+#ifndef EXPECTED_POLICY
+#define EXPECTED_POLICY DEFAULT
+#endif
 
 #include <omp.h>
 #include <stdio.h>
@@ -89,8 +96,9 @@ int main() {
    OMPVV_ERROR_IF(policy==MANDATORY && isOffloading == 1 && on_init_dev != 0, "Did not follow MANDATORY, instead executed target region on host even though device was available");
    OMPVV_TEST_AND_SET(errors, policy==MANDATORY && isOffloading == 1 && on_init_dev != 0);
  
-   OMPVV_ERROR_IF(policy==UNKNOWN,"OMP_TARGET_OFFLOAD has an unknown value");
    OMPVV_ERROR_IF(policy==NOTSET, "OMP_TARGET_OFFLOAD has not been set");
+   OMPVV_ERROR_IF(policy==UNKNOWN,"OMP_TARGET_OFFLOAD has an unknown value '%s'", getenv("OMP_TARGET_OFFLOAD"));
+   OMPVV_ERROR_IF(policy!=NOTSET && policy!=EXPECTED_POLICY, "OMP_TARGET_OFFLOAD set to %s but expected %s", getenv("OMP_TARGET_OFFLOAD"), EXPECTED_POLICY);
 
    OMPVV_REPORT_AND_RETURN(errors);
 }

--- a/tests/5.0/program_control/test_omp_target_offload_env_DISABLED.c
+++ b/tests/5.0/program_control/test_omp_target_offload_env_DISABLED.c
@@ -1,0 +1,13 @@
+//===--- test_omp_target_offload_env_DISABLED.c ----------------------------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// This test checks for offloading behavior when OMP_TARGET_OFFLOAD is set to DISABLED.
+//
+// See test_omp_target_offload_env_DEFAULT.c for details.
+//
+////===--------------------------------------------------------------------------------------------===//
+
+#define EXPECTED_POLICY DISABLED
+
+#include "./test_omp_target_offload_env_DEFAULT.c"

--- a/tests/5.0/program_control/test_omp_target_offload_env_MANDATORY.c
+++ b/tests/5.0/program_control/test_omp_target_offload_env_MANDATORY.c
@@ -1,0 +1,13 @@
+//===--- test_omp_target_offload_env_MANDATORY.c --------------------------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// This test checks for offloading behavior when OMP_TARGET_OFFLOAD is set to MANDATORY.
+//
+// See test_omp_target_offload_env_DEFAULT.c for details.
+//
+////===--------------------------------------------------------------------------------------------===//
+
+#define EXPECTED_POLICY MANDATORY
+
+#include "test_omp_target_offload_env_DEFAULT.c"


### PR DESCRIPTION
Currently, 5.0/program_control/test_omp_target_offload.c is a bit pointless as it requires that OMP_TARGET_OFFLOAD is set, which is usually not the case.

As discussed in pull #240, it cannot be set after program start.

This patch runs the once-compiled program three times. It seems to work okay, but I am not sure whether it messes up any diagnostic postprocessing.

* sys/scripts/run_test.sh: Permit passing an environment variable.
* Makefile (test_omp_target_offload.c.run, test_omp_target_offload.c.runonly):
  Run trice with env OMP_TARGET_OFFLOAD set to DEFAULT, MANDATORY, DISABLED.