### PR TITLE
Update gitignore to correctly ignore recent report online tags, pycache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ ompvv/*.mod
 ompvv/*.a
 results.json
 results.csv
-recent_online_report_tags
+recent_REPORT_ONLINE_tags
+sys/scripts/API/__pycache__/
 *~


### PR DESCRIPTION
This is a simple correction to the gitignore to handle files generated by running `make report_online`.