### PR TITLE
Add 5.0 tests of parallel master directive

### DIFF
--- a/tests/5.0/parallel_master/test_parallel_master.c
+++ b/tests/5.0/parallel_master/test_parallel_master.c
@@ -34,9 +34,7 @@ int test_parallel_master() {
     for (int i = 0; i < N; i++) {
       x[i] += y[i]*z[i];
     }
-    if (omp_get_thread_num() == 0) {
-      num_threads = omp_get_num_threads();
-    }
+    num_threads = omp_get_num_threads();
   }
 
   for (int i = 0; i < N; i++) {

--- a/tests/5.0/parallel_master/test_parallel_master.c
+++ b/tests/5.0/parallel_master/test_parallel_master.c
@@ -1,0 +1,59 @@
+//===--- test_parallel_master.c ---------------------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// This test checks the parallel master directive. The test performs simple
+// operations on an int array which are then checked for correctness.
+//
+////===----------------------------------------------------------------------===//
+#include <assert.h>
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+int test_parallel_master() {
+  OMPVV_INFOMSG("test_parallel_master");
+  int errors = 0;
+  int num_threads = -1;
+  int x[N];
+  int y[N];
+  int z[N];
+
+  for (int i = 0; i < N; i++) {
+    x[i] = 1;
+    y[i] = i + 1;
+    z[i] = 2*(i + 1);
+  }
+
+#pragma omp parallel master num_threads(OMPVV_NUM_THREADS_HOST) shared(x, y, z, num_threads)
+  {
+#pragma omp taskloop
+    for (int i = 0; i < N; i++) {
+      x[i] += y[i]*z[i];
+      if (omp_get_thread_num() == 0) {
+        num_threads = omp_get_num_threads();
+      }
+    }
+  }
+
+  for (int i = 0; i < N; i++) {
+    OMPVV_TEST_AND_SET_VERBOSE(errors, x[i] != 1 + (y[i]*z[i]));
+  }
+
+  OMPVV_WARNING_IF(num_threads == 1, "Test ran with one thread, so parallelism of parallel master with taskloop can't be guaranteed.");
+  OMPVV_ERROR_IF(num_threads < 1, "Test returned an invalid number of threads.");
+
+  return errors;
+}
+
+
+int main() {
+  int errors = 0;
+
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_parallel_master());
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.0/parallel_master/test_parallel_master.c
+++ b/tests/5.0/parallel_master/test_parallel_master.c
@@ -33,9 +33,9 @@ int test_parallel_master() {
 #pragma omp taskloop
     for (int i = 0; i < N; i++) {
       x[i] += y[i]*z[i];
-      if (omp_get_thread_num() == 0) {
-        num_threads = omp_get_num_threads();
-      }
+    }
+    if (omp_get_thread_num() == 0) {
+      num_threads = omp_get_num_threads();
     }
   }
 

--- a/tests/5.0/parallel_master/test_parallel_master.c
+++ b/tests/5.0/parallel_master/test_parallel_master.c
@@ -45,6 +45,7 @@ int test_parallel_master() {
 
   OMPVV_WARNING_IF(num_threads == 1, "Test ran with one thread, so parallelism of parallel master with taskloop can't be guaranteed.");
   OMPVV_ERROR_IF(num_threads < 1, "Test returned an invalid number of threads.");
+  OMPVV_TEST_AND_SET_VERBOSE(errors, num_threads < 1);
 
   return errors;
 }

--- a/tests/5.0/parallel_master/test_parallel_master_device.c
+++ b/tests/5.0/parallel_master/test_parallel_master_device.c
@@ -49,6 +49,7 @@ int test_parallel_master_device() {
 
   OMPVV_WARNING_IF(num_threads == 1, "Test ran with one thread, so parallelism of parallel master with taskloop can't be guaranteed.");
   OMPVV_ERROR_IF(num_threads < 1, "Test returned an invalid number of threads.");
+  OMPVV_TEST_AND_SET_VERBOSE(errors, num_threads < 1);
 
   return errors;
 }

--- a/tests/5.0/parallel_master/test_parallel_master_device.c
+++ b/tests/5.0/parallel_master/test_parallel_master_device.c
@@ -1,0 +1,65 @@
+//===--- test_parallel_master_device.c --------------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// This test checks the parallel master directive in a target context. The
+// test performs simple operations on an int array which are then checked for
+// correctness.
+//
+////===----------------------------------------------------------------------===//
+#include <assert.h>
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+int test_parallel_master_device() {
+  OMPVV_INFOMSG("test_parallel_master_device");
+  int errors = 0;
+  int num_threads = -1;
+  int x[N];
+  int y[N];
+  int z[N];
+
+  for (int i = 0; i < N; i++) {
+    x[i] = 1;
+    y[i] = i + 1;
+    z[i] = 2*(i + 1);
+  }
+
+#pragma omp target map(tofrom: x, y, z, num_threads)
+  {
+#pragma omp parallel master num_threads(OMPVV_NUM_THREADS_HOST) shared(x, y, z, num_threads)
+    {
+#pragma omp taskloop
+      for (int i = 0; i < N; i++) {
+        x[i] += y[i]*z[i];
+        if (omp_get_thread_num() == 0) {
+          num_threads = omp_get_num_threads();
+        }
+      }
+    }
+  }
+
+  for (int i = 0; i < N; i++) {
+    OMPVV_TEST_AND_SET_VERBOSE(errors, x[i] != 1 + (y[i]*z[i]));
+  }
+
+  OMPVV_WARNING_IF(num_threads == 1, "Test ran with one thread, so parallelism of parallel master with taskloop can't be guaranteed.");
+  OMPVV_ERROR_IF(num_threads < 1, "Test returned an invalid number of threads.");
+
+  return errors;
+}
+
+
+int main() {
+  OMPVV_TEST_OFFLOADING;
+
+  int errors = 0;
+
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_parallel_master_device());
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.0/parallel_master/test_parallel_master_device.c
+++ b/tests/5.0/parallel_master/test_parallel_master_device.c
@@ -36,9 +36,9 @@ int test_parallel_master_device() {
 #pragma omp taskloop
       for (int i = 0; i < N; i++) {
         x[i] += y[i]*z[i];
-        if (omp_get_thread_num() == 0) {
-          num_threads = omp_get_num_threads();
-        }
+      }
+      if (omp_get_thread_num() == 0) {
+        num_threads = omp_get_num_threads();
       }
     }
   }

--- a/tests/5.0/parallel_master/test_parallel_master_device.c
+++ b/tests/5.0/parallel_master/test_parallel_master_device.c
@@ -29,7 +29,7 @@ int test_parallel_master_device() {
     z[i] = 2*(i + 1);
   }
 
-#pragma omp target map(tofrom: x, y, z, num_threads)
+#pragma omp target map(tofrom: x, num_threads) map(to: y, z)
   {
 #pragma omp parallel master num_threads(OMPVV_NUM_THREADS_DEVICE) shared(x, y, z, num_threads)
     {
@@ -37,9 +37,7 @@ int test_parallel_master_device() {
       for (int i = 0; i < N; i++) {
         x[i] += y[i]*z[i];
       }
-      if (omp_get_thread_num() == 0) {
-        num_threads = omp_get_num_threads();
-      }
+      num_threads = omp_get_num_threads();
     }
   }
 

--- a/tests/5.0/parallel_master/test_parallel_master_device.c
+++ b/tests/5.0/parallel_master/test_parallel_master_device.c
@@ -31,7 +31,7 @@ int test_parallel_master_device() {
 
 #pragma omp target map(tofrom: x, y, z, num_threads)
   {
-#pragma omp parallel master num_threads(OMPVV_NUM_THREADS_HOST) shared(x, y, z, num_threads)
+#pragma omp parallel master num_threads(OMPVV_NUM_THREADS_DEVICE) shared(x, y, z, num_threads)
     {
 #pragma omp taskloop
       for (int i = 0; i < N; i++) {


### PR DESCRIPTION
This PR adds tests of the parallel master directive, one on the host and the other in a target region. Currently this test passes Clang and fails GCC due to invalid number of teams returned. I believe this is the same bug identified in PR #269.