### PR TITLE
Add 5.0 tests of parallel master taskloop simd directive

### DIFF
--- a/tests/5.0/parallel_master_taskloop_simd/test_parallel_master_taskloop_simd.c
+++ b/tests/5.0/parallel_master_taskloop_simd/test_parallel_master_taskloop_simd.c
@@ -1,0 +1,58 @@
+//===--- test_parallel_master_taskloop_simd.c --------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// This test checks the parallel master taskloop simd directive. The
+// test performs simple operations on an int array which are then
+// checked for correctness.
+//
+////===----------------------------------------------------------------------===//
+#include <assert.h>
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+int test_parallel_master_taskloop() {
+  OMPVV_INFOMSG("test_parallel_master_taskloop");
+  int errors = 0;
+  int num_threads = -1;
+  int x[N];
+  int y[N];
+  int z[N];
+
+  for (int i = 0; i < N; i++) {
+    x[i] = 1;
+    y[i] = i + 1;
+    z[i] = 2*(i + 1);
+  }
+
+#pragma omp parallel master taskloop simd num_threads(OMPVV_NUM_THREADS_HOST) shared(x, y, z, num_threads)
+  for (int i = 0; i < N; i++) {
+    x[i] += y[i]*z[i];
+    if (omp_get_thread_num() == 0) {
+      num_threads = omp_get_num_threads();
+    }
+  }
+
+  for (int i = 0; i < N; i++) {
+    OMPVV_TEST_AND_SET_VERBOSE(errors, x[i] != 1 + (y[i]*z[i]));
+  }
+
+  OMPVV_WARNING_IF(num_threads == 1, "Test ran with one thread, so parallelism of taskloop can't be guaranteed.");
+  OMPVV_ERROR_IF(num_threads < 1, "Test returned an invalid number of threads.");
+  OMPVV_TEST_AND_SET_VERBOSE(errors, num_threads < 1);
+
+  return errors;
+}
+
+
+int main() {
+  int errors = 0;
+
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_parallel_master_taskloop());
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.0/parallel_master_taskloop_simd/test_parallel_master_taskloop_simd.c
+++ b/tests/5.0/parallel_master_taskloop_simd/test_parallel_master_taskloop_simd.c
@@ -18,7 +18,6 @@
 int test_parallel_master_taskloop() {
   OMPVV_INFOMSG("test_parallel_master_taskloop");
   int errors = 0;
-  int num_threads = -1;
   int x[N];
   int y[N];
   int z[N];
@@ -29,21 +28,16 @@ int test_parallel_master_taskloop() {
     z[i] = 2*(i + 1);
   }
 
-#pragma omp parallel master taskloop simd num_threads(OMPVV_NUM_THREADS_HOST) shared(x, y, z, num_threads)
+#pragma omp parallel master taskloop simd num_threads(OMPVV_NUM_THREADS_HOST) shared(x, y, z)
   for (int i = 0; i < N; i++) {
     x[i] += y[i]*z[i];
-    if (omp_get_thread_num() == 0) {
-      num_threads = omp_get_num_threads();
-    }
   }
 
   for (int i = 0; i < N; i++) {
     OMPVV_TEST_AND_SET_VERBOSE(errors, x[i] != 1 + (y[i]*z[i]));
   }
 
-  OMPVV_WARNING_IF(num_threads == 1, "Test ran with one thread, so parallelism of taskloop can't be guaranteed.");
-  OMPVV_ERROR_IF(num_threads < 1, "Test returned an invalid number of threads.");
-  OMPVV_TEST_AND_SET_VERBOSE(errors, num_threads < 1);
+  OMPVV_INFOMSG("This test does not guarantee parallelism of the tested clause.");
 
   return errors;
 }

--- a/tests/5.0/parallel_master_taskloop_simd/test_parallel_master_taskloop_simd.c
+++ b/tests/5.0/parallel_master_taskloop_simd/test_parallel_master_taskloop_simd.c
@@ -37,7 +37,7 @@ int test_parallel_master_taskloop() {
     OMPVV_TEST_AND_SET_VERBOSE(errors, x[i] != 1 + (y[i]*z[i]));
   }
 
-  OMPVV_INFOMSG("This test does not guarantee parallelism of the tested clause.");
+  OMPVV_INFOMSG("This test does not guarantee thread parallelism of the clause.");
 
   return errors;
 }

--- a/tests/5.0/parallel_master_taskloop_simd/test_parallel_master_taskloop_simd_device.c
+++ b/tests/5.0/parallel_master_taskloop_simd/test_parallel_master_taskloop_simd_device.c
@@ -28,7 +28,7 @@ int test_parallel_master_taskloop() {
     z[i] = 2*(i + 1);
   }
 
-#pragma omp target map(tofrom: x, y, z)
+#pragma omp target map(tofrom: x) map(to: y, z)
   {
 #pragma omp parallel master taskloop simd num_threads(OMPVV_NUM_THREADS_DEVICE) shared(x, y, z)
     for (int i = 0; i < N; i++) {
@@ -40,7 +40,7 @@ int test_parallel_master_taskloop() {
     OMPVV_TEST_AND_SET_VERBOSE(errors, x[i] != 1 + (y[i]*z[i]));
   }
 
-  OMPVV_INFOMSG("This test does not guarantee parallelism of the tested clause.");
+  OMPVV_INFOMSG("This test does not guarantee thread parallelism of the clause.");
 
   return errors;
 }

--- a/tests/5.0/parallel_master_taskloop_simd/test_parallel_master_taskloop_simd_device.c
+++ b/tests/5.0/parallel_master_taskloop_simd/test_parallel_master_taskloop_simd_device.c
@@ -31,7 +31,7 @@ int test_parallel_master_taskloop() {
 
 #pragma omp target map(tofrom: x, y, z, num_threads)
   {
-#pragma omp parallel master taskloop simd num_threads(OMPVV_NUM_THREADS_HOST) shared(x, y, z, num_threads)
+#pragma omp parallel master taskloop simd num_threads(OMPVV_NUM_THREADS_DEVICE) shared(x, y, z, num_threads)
     for (int i = 0; i < N; i++) {
       x[i] += y[i]*z[i];
       if (omp_get_thread_num() == 0) {

--- a/tests/5.0/parallel_master_taskloop_simd/test_parallel_master_taskloop_simd_device.c
+++ b/tests/5.0/parallel_master_taskloop_simd/test_parallel_master_taskloop_simd_device.c
@@ -18,7 +18,6 @@
 int test_parallel_master_taskloop() {
   OMPVV_INFOMSG("test_parallel_master_taskloop");
   int errors = 0;
-  int num_threads = -1;
   int x[N];
   int y[N];
   int z[N];
@@ -29,14 +28,11 @@ int test_parallel_master_taskloop() {
     z[i] = 2*(i + 1);
   }
 
-#pragma omp target map(tofrom: x, y, z, num_threads)
+#pragma omp target map(tofrom: x, y, z)
   {
-#pragma omp parallel master taskloop simd num_threads(OMPVV_NUM_THREADS_DEVICE) shared(x, y, z, num_threads)
+#pragma omp parallel master taskloop simd num_threads(OMPVV_NUM_THREADS_DEVICE) shared(x, y, z)
     for (int i = 0; i < N; i++) {
       x[i] += y[i]*z[i];
-      if (omp_get_thread_num() == 0) {
-        num_threads = omp_get_num_threads();
-      }
     }
   }
 
@@ -44,9 +40,7 @@ int test_parallel_master_taskloop() {
     OMPVV_TEST_AND_SET_VERBOSE(errors, x[i] != 1 + (y[i]*z[i]));
   }
 
-  OMPVV_WARNING_IF(num_threads == 1, "Test ran with one thread, so parallelism of taskloop can't be guaranteed.");
-  OMPVV_ERROR_IF(num_threads < 1, "Test returned an invalid number of threads.");
-  OMPVV_TEST_AND_SET_VERBOSE(errors, num_threads < 1);
+  OMPVV_INFOMSG("This test does not guarantee parallelism of the tested clause.");
 
   return errors;
 }

--- a/tests/5.0/parallel_master_taskloop_simd/test_parallel_master_taskloop_simd_device.c
+++ b/tests/5.0/parallel_master_taskloop_simd/test_parallel_master_taskloop_simd_device.c
@@ -1,0 +1,63 @@
+//===--- test_parallel_master_taskloop_simd_device.c ------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// This test checks the parallel master taskloop simd directive. The test
+// performs simple operations on an int array which are then checked for
+// correctness. This test checks the construct in a target context.
+//
+////===----------------------------------------------------------------------===//
+#include <assert.h>
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+int test_parallel_master_taskloop() {
+  OMPVV_INFOMSG("test_parallel_master_taskloop");
+  int errors = 0;
+  int num_threads = -1;
+  int x[N];
+  int y[N];
+  int z[N];
+
+  for (int i = 0; i < N; i++) {
+    x[i] = 1;
+    y[i] = i + 1;
+    z[i] = 2*(i + 1);
+  }
+
+#pragma omp target map(tofrom: x, y, z, num_threads)
+  {
+#pragma omp parallel master taskloop simd num_threads(OMPVV_NUM_THREADS_HOST) shared(x, y, z, num_threads)
+    for (int i = 0; i < N; i++) {
+      x[i] += y[i]*z[i];
+      if (omp_get_thread_num() == 0) {
+        num_threads = omp_get_num_threads();
+      }
+    }
+  }
+
+  for (int i = 0; i < N; i++) {
+    OMPVV_TEST_AND_SET_VERBOSE(errors, x[i] != 1 + (y[i]*z[i]));
+  }
+
+  OMPVV_WARNING_IF(num_threads == 1, "Test ran with one thread, so parallelism of taskloop can't be guaranteed.");
+  OMPVV_ERROR_IF(num_threads < 1, "Test returned an invalid number of threads.");
+  OMPVV_TEST_AND_SET_VERBOSE(errors, num_threads < 1);
+
+  return errors;
+}
+
+
+int main() {
+  OMPVV_TEST_OFFLOADING;
+
+  int errors = 0;
+
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_parallel_master_taskloop());
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}


### PR DESCRIPTION
These tests check the combined parallel master taskloop simd directive on the device and on the host. The behavior is similar to that of other combined taskloop clauses. GCC fails the host version of the test due to invalid reported number of teams (same bug seen in #269), but in this case, passes the device test. Clang passes both tests but issues a compile time warning indicated the loops were not vectorized.