### PR TITLE
New 5.0 test, target version of simd nontemporal test

### DIFF
--- a/tests/5.0/simd/test_simd_nontemporal.c
+++ b/tests/5.0/simd/test_simd_nontemporal.c
@@ -15,6 +15,7 @@
 #include "ompvv.h"
 
 #define N 1028
+#define STRIDE_LEN 100
 
 int test_simd_nontemporal() {
    int errors = 0;
@@ -28,12 +29,12 @@ int test_simd_nontemporal() {
    }   
 
    #pragma simd nontemporal (a, b, c)
-      for (i = 0; i < N; i += 100) {
+      for (i = 0; i < N; i += STRIDE_LEN) {
          a[i] = b[i] * c[i];
       }   
 
    for (i = 0; i < N; i++) {
-      if (i % 100 == 0) { 
+      if (i % STRIDE_LEN == 0) { 
          OMPVV_TEST_AND_SET(errors, a[i] != (b[i] * c[i]));
       } else { 
 	 OMPVV_TEST_AND_SET(errors, a[i] != 10);

--- a/tests/5.0/target_simd/test_target_simd_nontemporal.c
+++ b/tests/5.0/target_simd/test_target_simd_nontemporal.c
@@ -33,7 +33,7 @@ int test_simd_nontemporal() {
       }   
 
    for (i = 0; i < N; i++) {
-      if (i % 100 == 0) { 
+      if (i % STRIDE_LEN == 0) { 
          OMPVV_TEST_AND_SET(errors, a[i] != (b[i] * c[i]));
       } else { 
 	 OMPVV_TEST_AND_SET(errors, a[i] != 10);

--- a/tests/5.0/target_simd/test_target_simd_nontemporal.c
+++ b/tests/5.0/target_simd/test_target_simd_nontemporal.c
@@ -15,7 +15,7 @@
 #include "ompvv.h"
 
 #define N 1028
-
+#define STRIDE_LEN 100
 int test_simd_nontemporal() {
    int errors = 0;
    int i;
@@ -28,7 +28,7 @@ int test_simd_nontemporal() {
    }   
 
    #pragma simd target nontemporal (a, b, c)
-      for (i = 0; i < N; i += 100) {
+      for (i = 0; i < N; i += STRIDE_LEN) {
          a[i] = b[i] * c[i];
       }   
 

--- a/tests/5.0/target_simd/test_target_simd_nontemporal.c
+++ b/tests/5.0/target_simd/test_target_simd_nontemporal.c
@@ -1,0 +1,52 @@
+//===--- test_target_simd_nontemporal.c -----------------------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//  
+// This test checks for support of the nontemporal clause on a target simd construct. 
+// The nontemporal clause indicates that accesses to the storage location of list items
+// have low temporal locality across the iterations in which those storage 
+// locations are accessed. 
+//  
+////===--------------------------------------------------------------------------------===/
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1028
+
+int test_simd_nontemporal() {
+   int errors = 0;
+   int i;
+   int a[N], b[N], c[N];
+
+   for (i = 0; i < N; i++) {
+      a[i] = 10; 
+      b[i] = i;
+      c[i] = 2 * i;
+   }   
+
+   #pragma simd target nontemporal (a, b, c)
+      for (i = 0; i < N; i += 100) {
+         a[i] = b[i] * c[i];
+      }   
+
+   for (i = 0; i < N; i++) {
+      if (i % 100 == 0) { 
+         OMPVV_TEST_AND_SET(errors, a[i] != (b[i] * c[i]));
+      } else { 
+	 OMPVV_TEST_AND_SET(errors, a[i] != 10);
+      }
+   }   
+
+   return errors;
+}
+
+int main () {
+   int errors = 0;
+
+   OMPVV_TEST_OFFLOADING;
+   OMPVV_TEST_AND_SET_VERBOSE(errors, test_simd_nontemporal())
+   OMPVV_REPORT_AND_RETURN(errors);
+}


### PR DESCRIPTION
Target version of simd test. Passes on newest llvm trunk and gcc 10.2.0