### PR TITLE
New 5.0 test for target construct with device clause

### DIFF
--- a/tests/5.0/target/test_target_device.c
+++ b/tests/5.0/target/test_target_device.c
@@ -1,0 +1,81 @@
+//===--- test_target_device.c ----------------------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// This test checks the target construct with device clause where device-
+// modifier is either ancestor or device_num. If no device_modifier is 
+// present, the behavior is the same as if device_num were present.
+//
+////===---------------------------------------------------------------------===//
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <omp.h>
+#include "ompvv.h"
+
+#define N 1028
+
+int test_target_device_ancestor() {
+
+    int i, which_device;
+    int a[N];
+    int errors = 0; 
+
+    for (int i = 0; i < N; i++) {
+        a[i] = i;
+    }
+
+    #pragma omp target device(ancestor: 1) map(tofrom: a, which_device) 
+    {
+        for (int i = 0; i < N; i++) {
+            a[i] = a[i] + 2;
+        }
+ 
+        which_device = omp_is_initial_device();
+    }
+
+    OMPVV_TEST_AND_SET_VERBOSE(errors, which_device != 1);
+    OMPVV_WARNING_IF(which_device != 1, "Target region was executed on device. Due to ancestor device-modifier,"
+                                         "this region should execute on host");
+
+    return errors;
+
+}
+
+int test_target_device_device_num() {
+    
+    int i, which_device;
+    int b[N];
+    int errors = 0; 
+
+    for (int i = 0; i < N; i++) {
+        b[i] = i;
+    }
+
+    #pragma omp target device(device_num: 1) map(tofrom: b, which_device) 
+    {
+        for (int i = 0; i < N; i++) {
+            b[i] = b[i] + 2;
+        }
+ 
+        which_device = omp_is_initial_device();
+    }
+
+    OMPVV_TEST_AND_SET_VERBOSE(errors, which_device != 0);
+    OMPVV_WARNING_IF(which_device != 0, "Target region was executed on host. Due to device num device-modifier,"
+                                         "this region should execute on specified target device");    
+
+    return errors;
+
+}
+
+int main() {
+
+    int errors = 0;
+   
+    OMPVV_TEST_AND_SET_VERBOSE(errors, test_target_device_ancestor());
+    
+    OMPVV_TEST_AND_SET_VERBOSE(errors, test_target_device_device_num());
+
+    OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.0/target/test_target_device.c
+++ b/tests/5.0/target/test_target_device.c
@@ -26,8 +26,8 @@ int test_target_device_ancestor() {
     }
 
     OMPVV_TEST_AND_SET(errors, omp_get_num_devices() <= 0);
-    OMPVV_ERROR_IF(omp_get_num_devices() <= 0, "There are no target devices available, cannot properly "
-                                                 "test fallback to host");
+    OMPVV_ERROR_IF(omp_get_num_devices() <= 0, "Since no target devices were found, this test"
+                                                 "will be skipped.");
 
     if (omp_get_num_devices() > 0) {
 
@@ -63,8 +63,9 @@ int test_target_device_device_num() {
 
     
     OMPVV_TEST_AND_SET(errors, omp_get_num_devices() <= 0);
-    OMPVV_ERROR_IF(omp_get_num_devices() <= 0, "There are no target devices available, cannot properly test");         
-
+    OMPVV_ERROR_IF(omp_get_num_devices() <= 0, "Since no target devices were found, this test"
+                                                 "will be skipped");
+	
     if (omp_get_num_devices() > 0) {
          
         first_device_num = omp_get_num_devices() - 1;

--- a/tests/5.0/target/test_target_device.c
+++ b/tests/5.0/target/test_target_device.c
@@ -25,16 +25,23 @@ int test_target_device_ancestor() {
         a[i] = i;
     }
 
-    #pragma omp target device(ancestor: 1) map(tofrom: a, which_device) 
-    {
-        for (int i = 0; i < N; i++) {
-            a[i] = a[i] + 2;
-        }
- 
-        which_device = omp_is_initial_device();
+    OMPVV_TEST_AND_SET(errors, omp_get_num_devices() <= 0);
+    OMPVV_ERROR_IF(omp_get_num_devices() <= 0, "There are no target devices available, cannot properly "
+                                                 "test fallback to host");
+
+    if (omp_get_num_devices() > 0) {
+
+        #pragma omp target device(ancestor: 1) map(tofrom: a, which_device) 
+	{
+	    for (int i = 0; i < N; i++) {
+                a[i] = a[i] + 2;
+	    }
+	
+	    which_device = omp_is_initial_device();
+	}
     }
 
-    OMPVV_TEST_AND_SET_VERBOSE(errors, which_device != 1);
+    OMPVV_TEST_AND_SET(errors, which_device != 1);
     OMPVV_ERROR_IF(which_device != 1, "Target region was executed on device. Due to ancestor device-modifier,"
                                          "this region should execute on host");
 
@@ -44,7 +51,7 @@ int test_target_device_ancestor() {
 
 int test_target_device_device_num() {
     
-    int i, which_device, host_device_num, first_device_num;
+    int i, target_device_num, host_device_num, first_device_num;
     int b[N];
     int errors = 0; 
 
@@ -55,26 +62,25 @@ int test_target_device_device_num() {
     host_device_num = omp_get_device_num(); 
 
     
-    OMPVV_TEST_AND_SET_VERBOSE(errors, omp_get_num_devices <= 0);
-    OMPVV_ERROR_IF(omp_get_num_devices <= 0, "Test fails, there are no target devices available");         
+    OMPVV_TEST_AND_SET(errors, omp_get_num_devices() <= 0);
+    OMPVV_ERROR_IF(omp_get_num_devices() <= 0, "There are no target devices available, cannot properly test");         
 
     if (omp_get_num_devices() > 0) {
          
-        first_device_num = host_device_num + 1;
-   
-        #pragma omp target device(device_num: first_device_num) map(tofrom: b, which_device) 
+        first_device_num = omp_get_num_devices() - 1;
+        #pragma omp target device(device_num: first_device_num) map(tofrom: b, target_device_num) 
         {
             for (int i = 0; i < N; i++) {
                 b[i] = b[i] + 2;
             }
  
-            which_device = omp_is_initial_device();
+            target_device_num = omp_get_device_num();
         }
     }
 
-    OMPVV_TEST_AND_SET_VERBOSE(errors, which_device != 0);
-    OMPVV_ERROR_IF(which_device != 0, "Target region was executed on host. Due to device num device-modifier,"
-                                         "this region should execute on specified target device");   
+    OMPVV_TEST_AND_SET(errors, target_device_num == host_device_num);
+    OMPVV_ERROR_IF(target_device_num == host_device_num, "Target region was executed on host," 
+                   "this region should execute on specified target device number");   
 
     return errors;
 


### PR DESCRIPTION
Test passes on newest llvm release. GCC seems to be lacking support for device clause, specifically the device-modifier expressions.
