### PR TITLE
Issue 296: Fix data-sharing use for test_taskloop_in_reduction

### DIFF
--- a/tests/5.0/taskloop/test_taskloop_in_reduction.c
+++ b/tests/5.0/taskloop/test_taskloop_in_reduction.c
@@ -29,7 +29,7 @@ int test_taskloop_in_reduction() {
     z[i] = 2*(i + 1);
   }
 
-#pragma omp parallel reduction(task, +: sum) num_threads(OMPVV_NUM_THREADS_HOST) shared(y, z, num_threads, sum)
+#pragma omp parallel reduction(task, +: sum) num_threads(OMPVV_NUM_THREADS_HOST) shared(y, z, num_threads)
   {
 #pragma omp master
     {

--- a/tests/5.0/taskloop/test_taskloop_in_reduction_device.c
+++ b/tests/5.0/taskloop/test_taskloop_in_reduction_device.c
@@ -30,7 +30,7 @@ int test_taskloop_in_reduction() {
     z[i] = 2*(i + 1);
   }
 
-#pragma omp target parallel reduction(task, +: sum) num_threads(OMPVV_NUM_THREADS_DEVICE) shared(y, z, num_threads, sum) defaultmap(tofrom)
+#pragma omp target parallel reduction(task, +: sum) num_threads(OMPVV_NUM_THREADS_DEVICE) shared(y, z, num_threads) defaultmap(tofrom)
   {
 #pragma omp master
     {


### PR DESCRIPTION
Issue #296
Pull Req. #297

* tests/5.0/taskloop/test_taskloop_in_reduction.c: Remove reduction
  variable from 'share' clause.
* tests/5.0/taskloop/test_taskloop_in_reduction.c: Likewise.

@spophale , @jhdavis8, @tmh97 - Please review.
Details are/reasoning is given in the Issue #296. 