### PR TITLE
Add Fortran version of requires dynamic_allocators test

### DIFF
--- a/sys/make/make.def
+++ b/sys/make/make.def
@@ -115,7 +115,7 @@ endif
 
 # Clang compiler
 ifeq ($(CC), clang)
-  COFFLOADING = -fopenmp-targets=nvptx64-nvidia-cuda
+  COFFLOADING = -fopenmp-targets=nvptx64-nvidia-cuda -Xopenmp-target -march=sm_70
   C_NO_OFFLOADING =
   CFLAGS += -lm -O3 -fopenmp $(COFFLOADING)
   #Adding this to fix problem with math.h
@@ -214,7 +214,7 @@ endif
 
 # Clang compiler
 ifeq ($(CXX), clang++)
-  CXXOFFLOADING = -fopenmp-targets=nvptx64-nvidia-cuda
+  CXXOFFLOADING = -fopenmp-targets=nvptx64-nvidia-cuda -Xopenmp-target -march=sm_70
   CXX_NO_OFFLOADING =
   CXXFLAGS += -std=c++11 -lm -O3 -fopenmp $(CXXOFFLOADING)
   #Adding this to fix problem with math.h

--- a/sys/systems/summit.def
+++ b/sys/systems/summit.def
@@ -29,6 +29,7 @@ endif
 # Clang compiler
 # ifeq ($(CC), clang)
 #   C_COMPILER_MODULE = llvm/1.0-20190225
+#   C_COMPILER_MODULE = cuda/10.1.243; module use /sw/summit/modulefiles/ums/stf010/Core; module load llvm/12.0.0-latest
 #   C_VERSION = clang -v 2>&1 | grep -oh "clang version [0-9.]*"| grep -oh "version .*" | sed "s/.*/& CORAL/"
 # endif
 

--- a/sys/systems/summit.def
+++ b/sys/systems/summit.def
@@ -29,13 +29,14 @@ endif
 # Clang compiler
 # ifeq ($(CC), clang)
 #   C_COMPILER_MODULE = llvm/1.0-20190225
-#   C_COMPILER_MODULE = cuda/10.1.243; module use /sw/summit/modulefiles/ums/stf010/Core; module load llvm/12.0.0-latest
+#   C_COMPILER_MODULE = cuda/10.1.243; module use /sw/summit/modulefiles/ums/stf010/Core; module load llvm/13.0.0-latest
+#   C_COMPILER_MODULE = llvm/11.0.0-rc1; module load cuda/10.1.243
 #   C_VERSION = clang -v 2>&1 | grep -oh "clang version [0-9.]*"| grep -oh "version .*" | sed "s/.*/& CORAL/"
 # endif
 
 # Clang compiler
 ifeq ($(CC), clang)
-  C_COMPILER_MODULE = llvm/11.0.0-rc1; module load cuda/10.1.243
+  C_COMPILER_MODULE = cuda/10.1.243; module use /sw/summit/modulefiles/ums/stf010/Core; module load llvm/13.0.0-latest
   C_VERSION = clang -v 2>&1 | grep -oh "clang version [0-9.]*" | grep -oh "version .*"
 endif
 
@@ -65,7 +66,7 @@ endif
 
 # Clang compiler
 ifeq ($(CXX), clang++)
-  CXX_COMPILER_MODULE = llvm/11.0.0-rc1; module load cuda/10.1.243
+  CXX_COMPILER_MODULE = cuda/10.1.243; module use /sw/summit/modulefiles/ums/stf010/Core; module load llvm/13.0.0-latest
   CXX_VERSION = clang++ -v 2>&1 | grep -oh "clang version [0-9.]*" | grep -oh "version .*"
 endif
 

--- a/tests/5.0/requires/test_requires_dynamic_allocators.F90
+++ b/tests/5.0/requires/test_requires_dynamic_allocators.F90
@@ -34,10 +34,10 @@ PROGRAM test_requires_dynamic_allocators
 CONTAINS
   INTEGER FUNCTION test_dynamic_allocators()
     INTEGER:: errors = 0
-    INTEGER,ALLOCATABLE:: x
+    INTEGER,ALLOCATABLE:: x(:)
     INTEGER:: i
     INTEGER(omp_memspace_handle_kind):: x_memspace = omp_default_mem_space
-    type(omp_alloctrait):: x_traits(1) = &[omp_alloctrait(omp_atk_alignment,64)]
+    type(omp_alloctrait):: x_traits(1) = omp_alloctrait(omp_atk_alignment,64)
     INTEGER(omp_allocator_handle_kind):: x_alloc
 
     !$omp target defaultmap(tofrom)

--- a/tests/5.0/requires/test_requires_dynamic_allocators.F90
+++ b/tests/5.0/requires/test_requires_dynamic_allocators.F90
@@ -1,0 +1,67 @@
+!//===------ test_requires_dynamic_allocators.F90 --------------------------===//
+!
+! OpenMP API Version 5.0 Nov 2018
+!
+! Tests the requires dynamic allocators clause by working with an OMP
+! allocator inside a target region. Allocators testing is based on the
+! OpenMP 5.0 example for allocators. The allocator testing first creates
+! an allocator, with 64-byte alignment and the default memory space,
+! then checks that 64-byte alignment is correct and that the memory can
+! be written to in the target region. The tests checks that the values
+! were written correctly, and then frees the memory and deletes the
+! allocator.
+!
+!//===----------------------------------------------------------------------===//
+
+#include "ompvv.F90"
+
+#define N 1024
+
+PROGRAM test_requires_dynamic_allocators
+  USE iso_fortran_env
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+
+  !$omp requires dynamic_allocators
+
+  OMPVV_TEST_OFFLOADING
+
+  OMPVV_TEST_VERBOSE(test_dynamic_allocators() .ne. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION test_dynamic_allocators()
+    INTEGER:: errors = 0
+    INTEGER,ALLOCATABLE:: x
+    INTEGER:: i
+    INTEGER(omp_memspace_handle_kind):: x_memspace = omp_default_mem_space
+    type(omp_alloctrait):: x_traits(1) = &[omp_alloctrait(omp_atk_alignment,64)]
+    INTEGER(omp_allocator_handle_kind):: x_alloc
+
+    !$omp target defaultmap(tofrom)
+    x_alloc = omp_init_allocator(x_memspace, 1, x_traits)
+
+    !$omp allocate(x) allocator(x_alloc)
+    allocate(x(N))
+
+    !$omp parallel
+    !$omp do simd simdlen(16) aligned(x: 64)
+    DO i = 1, N
+       x(i) = i
+    END DO
+    !$omp end parallel
+
+    DO i = 1, N
+       OMPVV_TEST_AND_SET_VERBOSE(errors, x(i) .ne. i)
+    END DO
+
+    !$omp end target
+
+    deallocate(x)
+    call omp_destroy_allocator(x_alloc)
+
+    test_dynamic_allocators = errors
+  END FUNCTION test_dynamic_allocators
+END PROGRAM test_requires_dynamic_allocators

--- a/tests/5.0/requires/test_requires_dynamic_allocators.F90
+++ b/tests/5.0/requires/test_requires_dynamic_allocators.F90
@@ -37,7 +37,7 @@ CONTAINS
     INTEGER,ALLOCATABLE:: x(:)
     INTEGER:: i
     INTEGER(omp_memspace_handle_kind):: x_memspace = omp_default_mem_space
-    type(omp_alloctrait):: x_traits(1) = omp_alloctrait(omp_atk_alignment,64)
+    type(omp_alloctrait):: x_traits(1) = [omp_alloctrait(omp_atk_alignment,64)]
     INTEGER(omp_allocator_handle_kind):: x_alloc
 
     !$omp target defaultmap(tofrom)


### PR DESCRIPTION
Currently will not compile with any available compiler on Summit, there is some difficulty in detecting issues with the test.