### PR TITLE
Add new 5.0 tests for requires with atomic_default_mem_order clause

### DIFF
--- a/tests/5.0/requires/test_requires_atomic_default_mem_order_acq_rel.c
+++ b/tests/5.0/requires/test_requires_atomic_default_mem_order_acq_rel.c
@@ -1,0 +1,57 @@
+//===---test_requires_atomic_default_mem_order_acq_rel.c---------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+// 
+// This test checks for support of the atomic_default_mem_order clause on the 
+// requires directive. This clause determines the default memory behavior for
+// atomic constructs. These behaviors are seq_cst, acq_rel, and relaxed.
+// This test checks the for acq_rel as the memory-order-clause.
+//
+////===----------------------------------------------------------------------===//
+
+#include <assert.h>
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+#pragma omp requires atomic_default_mem_order(acq_rel)
+
+int test_requires_atomic_acq_rel() {
+  OMPVV_INFOMSG("test_requires_atomic_acq_rel");
+
+  int x = 0, y = 0;
+  int errors = 0;
+
+#pragma omp parallel num_threads(2)
+   {
+      int thrd = omp_get_thread_num();
+       if (thrd == 0) {
+          x = 10;
+          #pragma omp atomic write 
+          y = 1;
+       } else {
+          int tmp = 0;
+          while (tmp == 0) {
+            #pragma omp atomic read 
+            tmp = y;
+          }
+          OMPVV_TEST_AND_SET(errors, x != 10);
+       }
+   }
+   return errors;
+}
+
+
+int main() {
+
+  int errors = 0;
+
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_requires_atomic_acq_rel());
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}
+
+

--- a/tests/5.0/requires/test_requires_atomic_default_mem_order_relaxed.c
+++ b/tests/5.0/requires/test_requires_atomic_default_mem_order_relaxed.c
@@ -1,0 +1,58 @@
+//===---test_requires_atomic_default_mem_order_relaxed.c---------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+// 
+// This test checks for support of the atomic_default_mem_order clause on the 
+// requires directive. This clause determines the default memory behavior for
+// atomic constructs. These behaviors are seq_cst, acq_rel, and relaxed.
+// This test checks for relaxed as the memory-order-clause.
+//
+// Adapted from 5.0 OpenMP example acquire_release.3.c
+////===----------------------------------------------------------------------===//
+
+#include <assert.h>
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+#pragma omp requires atomic_default_mem_order(acq_rel)
+
+int test_requires_atomic_relaxed() {
+  OMPVV_INFOMSG("test_requires_atomic_relaxed");
+
+  int x = 0, y = 0;
+  int errors = 0;
+
+#pragma omp parallel num_threads(2)
+   {
+      int thrd = omp_get_thread_num();
+       if (thrd == 0) {
+          x = 10;
+          #pragma omp flush
+          #pragma omp atomic write 
+          y = 1;
+       } else {
+          int tmp = 0;
+          while (tmp == 0) {
+            #pragma omp atomic read 
+            tmp = y;
+          }
+          #pragma omp flush
+          OMPVV_TEST_AND_SET_VERBOSE(errors, x != 10);
+       }
+   }
+   return errors;
+}
+
+
+int main() {
+
+  int errors = 0;
+
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_requires_atomic_relaxed());
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.0/requires/test_requires_atomic_default_mem_order_seq_cst.c
+++ b/tests/5.0/requires/test_requires_atomic_default_mem_order_seq_cst.c
@@ -1,0 +1,55 @@
+//===---test_requires_atomic_default_mem_order_seq_cst.c---------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// This test checks for support of the atomic_default_mem_order clause on the 
+// requires directive. This clause determines the default memory behavior for
+// atomic constructs. These behaviors are seq_cst, acq_rel, and relaxed.
+// This test checks the seq_cst behavior, which is also the default.
+//
+// Adapted from 5.0 OpenMP example acquire_release.2.c
+////===----------------------------------------------------------------------===//
+
+#include <assert.h>
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+#pragma omp requires atomic_default_mem_order(seq_cst)
+
+int test_atomic_seq_cst() {
+  OMPVV_INFOMSG("test_atomic_seq_cst");
+
+  int x = 0, y = 0;
+  int errors = 0;
+
+#pragma omp parallel num_threads(2)
+   {
+      int thrd = omp_get_thread_num();
+       if (thrd == 0) {
+          x = 10;
+          #pragma omp atomic write 
+          y = 1;
+       } else {
+          int tmp = 0;
+          while (tmp == 0) {
+            #pragma omp atomic read 
+            tmp = y;
+          }
+          OMPVV_TEST_AND_SET_VERBOSE(errors, x != 10);
+       }
+   }
+   return errors;
+}
+
+int main() {
+
+  int errors = 0;
+
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_atomic_seq_cst());
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}


### PR DESCRIPTION
Adding 3 different tests for each memory behavior that can be specified through the atomic_default_mem_order clause on a requires directive.

All tests pass gcc/10.20 and latest llvm trunk. 

Seq_cst and acq_rel are based on the same example, while relaxed behavior is based on a slightly different example.