### PR TITLE
New 5.0 test for metadirective with when and default

### DIFF
--- a/tests/5.0/metadirective/test_metadirective_arch_is_nvidia.c
+++ b/tests/5.0/metadirective/test_metadirective_arch_is_nvidia.c
@@ -1,0 +1,58 @@
+//===---test_metadirective_is_nvidia.c -------------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+// 
+// Test for metadirectives based on OpenMP 5.0 examples metadirective.1-3.c
+//
+////===---------------------------------------------------------------------===//
+
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 100
+
+int metadirective1() {
+   
+   int v1[N], v2[N], v3[N];
+
+   int which_device;
+   int errors = 0;
+
+   for(int i=0; i<N; i++) { 
+      v1[i] = (i+1); 
+      v2[i] = -(i+1); 
+   }
+
+   #pragma omp target map(to:v1,v2) map(from:v3) device(0)
+   #pragma omp metadirective \
+                   when(   device={arch("nvptx")}: teams loop) \
+                   default(                     parallel loop)
+
+      which_device = omp_is_initial_device(); 
+
+      for (int i = 0; i < N; i++) {
+         v3[i] = v1[i] * v2[i];
+      }
+
+   OMPVV_WARNING_IF(which_device != 0, "NVIDIA architecture appears to be unavailable, metadirective ran with the variant specified in the default clause");
+
+   for (int i = 0; i < N; i++) {
+      OMPVV_TEST_AND_SET_VERBOSE(errors, v3[i] != v1[i] * v2[i]);
+   }
+
+   return errors;
+}
+
+int main () {
+   
+   int errors = 0;
+   OMPVV_TEST_OFFLOADING;
+ 
+   OMPVV_TEST_AND_SET_VERBOSE(errors, metadirective1());
+  
+   OMPVV_REPORT_AND_RETURN(errors);
+
+}

--- a/tests/5.0/metadirective/test_metadirective_arch_nvidia_or_amd.c
+++ b/tests/5.0/metadirective/test_metadirective_arch_nvidia_or_amd.c
@@ -15,8 +15,9 @@
 
 int metadirective2() {
 
-   int i, device_num, errors, which_device;
+   int i, device_num, which_device;
    int a[N], total[N];
+   int errors = 0;
  
    for (int i = 0; i < N; i++) {
       a[i] = 0;  
@@ -52,6 +53,7 @@ int metadirective2() {
 int main () {
 
    int errors = 0;
+   
    OMPVV_TEST_OFFLOADING;
 
    OMPVV_TEST_AND_SET_VERBOSE(errors, metadirective2());

--- a/tests/5.0/metadirective/test_metadirective_arch_nvidia_or_amd.c
+++ b/tests/5.0/metadirective/test_metadirective_arch_nvidia_or_amd.c
@@ -11,18 +11,19 @@
 #include <stdlib.h>
 #include "ompvv.h"
 
-#define N 100
+#define N 1024
+
+int errors = 0;
 
 int metadirective2() {
 
    int i, device_num, which_device;
    int a[N], total[N];
-   int errors = 0;
  
    for (int i = 0; i < N; i++) {
       a[i] = 0;  
    }
-
+   
    for (device_num = 0; device_num < omp_get_num_devices(); device_num++) {
       #pragma omp target device(device_num)
       #pragma omp metadirective \
@@ -37,10 +38,11 @@ int metadirective2() {
       #pragma omp distribute parallel for
          for (i = 0; i < N; i++) {
             a[i] = i;
+            printf("value of a[%d] is:  %d\n", i, a[i]);
          }
    }
 
-   OMPVV_TEST_AND_SET(errors, which device != 0);
+   OMPVV_TEST_AND_SET_VERBOSE(errors, which_device != 0);
    OMPVV_ERROR_IF(which_device != 0, "NVIDIA and AMD architecture not available, ran on host");
 
    for (i = 0; i < N; i++) {
@@ -53,8 +55,6 @@ int metadirective2() {
 
 int main () {
 
-   int errors = 0;
-   
    OMPVV_TEST_OFFLOADING;
 
    OMPVV_TEST_AND_SET_VERBOSE(errors, metadirective2());

--- a/tests/5.0/metadirective/test_metadirective_arch_nvidia_or_amd.c
+++ b/tests/5.0/metadirective/test_metadirective_arch_nvidia_or_amd.c
@@ -38,7 +38,6 @@ int metadirective2() {
       #pragma omp distribute parallel for
          for (i = 0; i < N; i++) {
             a[i] = i;
-            printf("value of a[%d] is:  %d\n", i, a[i]);
          }
    }
 

--- a/tests/5.0/metadirective/test_metadirective_arch_nvidia_or_amd.c
+++ b/tests/5.0/metadirective/test_metadirective_arch_nvidia_or_amd.c
@@ -40,7 +40,8 @@ int metadirective2() {
          }
    }
 
-   OMPVV_WARNING_IF(which_device != 0, "NVIDIA and AMD architecture not available, ran on host");
+   OMPVV_TEST_AND_SET(errors, which device != 0);
+   OMPVV_ERROR_IF(which_device != 0, "NVIDIA and AMD architecture not available, ran on host");
 
    for (i = 0; i < N; i++) {
       OMPVV_TEST_AND_SET_VERBOSE(errors, a[i] != i); 

--- a/tests/5.0/metadirective/test_metadirective_arch_nvidia_or_amd.c
+++ b/tests/5.0/metadirective/test_metadirective_arch_nvidia_or_amd.c
@@ -1,0 +1,62 @@
+//===---test_metadirective_arch_nvidia_or_amd.c ----------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+// 
+// Test for metadirectives based on OpenMP 5.0 examples metadirective.1-3.c
+//
+////===---------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 100
+
+int metadirective2() {
+
+   int i, device_num, errors, which_device;
+   int a[N], total[N];
+ 
+   for (int i = 0; i < N; i++) {
+      a[i] = 0;  
+   }
+
+   for (device_num = 0; device_num < omp_get_num_devices(); device_num++) {
+      #pragma omp target device(device_num)
+      #pragma omp metadirective \
+                  when( implementation=vendor(nvidia): \
+                        teams num_teams(512) thread_limit(32) ) \
+                  when( implementation=vendor(amd): \
+                        teams num_teams(512) thread_limit(64) ) \
+                  default (teams)
+
+      which_device = omp_is_initial_device();
+
+      #pragma omp distribute parallel for
+         for (i = 0; i < N; i++) {
+            a[i] = i;
+         }
+   }
+
+   OMPVV_WARNING_IF(which_device != 0, "NVIDIA and AMD architecture not available, ran on host");
+
+   for (i = 0; i < N; i++) {
+      OMPVV_TEST_AND_SET_VERBOSE(errors, a[i] != i); 
+   }        
+
+   return errors;
+
+}
+
+int main () {
+
+   int errors = 0;
+   OMPVV_TEST_OFFLOADING;
+
+   OMPVV_TEST_AND_SET_VERBOSE(errors, metadirective2());
+
+   OMPVV_REPORT_AND_RETURN(errors);
+
+}
+                   


### PR DESCRIPTION
First test fails due to no support for omp_get_device_num() in target region from gcc/10.2.0, passes if removed 
Second test passes on gcc/10.2.0
llvm does not support