### PR TITLE
Add Fortran version of 5.0 map order test

### DIFF
--- a/tests/5.0/target/test_target_mapping_before_alloc.F90
+++ b/tests/5.0/target/test_target_mapping_before_alloc.F90
@@ -49,10 +49,8 @@ CONTAINS
 
     !$omp target map(alloc: scalar, a, test_struct) map(to: scalar, a, &
     !$omp& test_struct) map(tofrom: errors)
-    IF (scalar .ne. 80 .OR. a(2) .ne. 2 .OR. test_struct%var .ne. 1 &
-         & .OR. test_struct%b(2) .ne. 2) THEN
-       errors = errors + 1
-    END IF
+    OMPVV_TEST_AND_SET_VERBOSE(errors, scalar .ne. 80 .OR. a(2) .ne. 2 .OR. test_struct%var .ne. 1 &
+         & .OR. test_struct%b(2) .ne. 2)
     !$omp end target
 
     to_before_alloc = errors

--- a/tests/5.0/target/test_target_mapping_before_alloc.F90
+++ b/tests/5.0/target/test_target_mapping_before_alloc.F90
@@ -1,0 +1,60 @@
+!===--- test_target_mapping_before_alloc.F90 -------------------------------===//
+!
+! OpenMP API Version 5.0 Nov 2018
+!
+! The description of the map clause was modified to clarify the mapping
+! order when multiple map-types are specified for a variable or structure
+! members of a variable on the same construct.
+!
+! For a given construct, the effect of a map clause with the to, from, or
+! tofrom map-type is ordered before the effect of a map clause with the
+! alloc map-type.
+!
+!//===----------------------------------------------------------------------===//
+#include "ompvv.F90"
+
+#define N 1024
+
+PROGRAM test_target_mapping_before_alloc
+  USE iso_fortran_env
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+  OMPVV_TEST_OFFLOADING
+
+  OMPVV_TEST_VERBOSE(to_before_alloc() .ne. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION to_before_alloc()
+    INTEGER :: errors, x, scalar
+    INTEGER,DIMENSION(N) :: a
+
+    TYPE structure
+       INTEGER :: var
+       INTEGER,DIMENSION(N) :: b
+    END TYPE structure
+
+    TYPE(structure) :: test_struct
+    test_struct%var = 1
+
+    DO x = 1, N
+       a(x) = x
+       test_struct%b(x) = x
+    END DO
+
+    scalar = 80
+    errors = 0
+
+    !$omp target map(alloc: scalar, a, test_struct) map(to: scalar, a, &
+    !$omp& test_struct) map(tofrom: errors)
+    IF (scalar .ne. 80 .OR. a(2) .ne. 2 .OR. test_struct%var .ne. 1 &
+         & .OR. test_struct%b(2) .ne. 2) THEN
+       errors = errors + 1
+    END IF
+    !$omp end target
+
+    to_before_alloc = errors
+  END FUNCTION to_before_alloc
+END PROGRAM test_target_mapping_before_alloc

--- a/tests/5.0/target/test_target_mapping_before_alloc.c
+++ b/tests/5.0/target/test_target_mapping_before_alloc.c
@@ -28,32 +28,27 @@ int to_before_alloc() {
   struct {
   int var;
   int b[N];
-  } member; 
+  } member;
 
   member.var = 1;
-  
-  for (i = 0; i < N; i++) { 
+
+  for (i = 0; i < N; i++) {
     a[i] = i;
     member.b[i] = i;
   }
 
-#pragma omp target  map (alloc: scalar, a, member) map(to: scalar, a, member) 
+#pragma omp target  map (alloc: scalar, a, member) map(to: scalar, a, member)
   {
-    if (scalar != 80 || a[1] != 2 || member.var != 1 || member.b[1] != 2) {
-      errors++;
-    }
-  }	 
-  return errors; 
+    OMPVV_TEST_AND_SET_VERBOSE(errors, scalar != 80 || a[1] != 2 || member.var != 1 || member.b[1] != 2)
+  }
+  return errors;
 }
 
 int main () {
-  
+
   int errors = 0;
-  
+
   OMPVV_TEST_OFFLOADING;
   OMPVV_TEST_AND_SET_VERBOSE(errors, to_before_alloc());
   OMPVV_REPORT_AND_RETURN(errors);
 }
-
-
-


### PR DESCRIPTION
Currently this test fails GCC and XLF. The GCC fail seems to be a bug.

GCC:
```
during GIMPLE pass: omplower
/autofs/nccs-svm1_home1/jhdavis/sollve-project/sollve_vv/tests/5.0/target/test_target_mapping_before_alloc.F90:51:0:

   51 |     !$omp& test_struct) map(tofrom: errors)
      | 
internal compiler error: in install_var_field, at omp-low.c:756
0x10837d47 install_var_field
        /tmp/belhorn/gcc-build-10.2.0/gcc-10.2.0/gcc/omp-low.c:756
0x1083bc97 scan_sharing_clauses
        /tmp/belhorn/gcc-build-10.2.0/gcc-10.2.0/gcc/omp-low.c:1423
0x1083f4cb scan_omp_target
        /tmp/belhorn/gcc-build-10.2.0/gcc-10.2.0/gcc/omp-low.c:2741
0x1084033b scan_omp_1_stmt
        /tmp/belhorn/gcc-build-10.2.0/gcc-10.2.0/gcc/omp-low.c:3801
0x1065744f walk_gimple_stmt(gimple_stmt_iterator*, tree_node* (*)(gimple_stmt_iterator*, bool*, walk_stmt_info*), tree_node* (*)(tree_node**, int*, void*), walk_stmt_info*)
        /tmp/belhorn/gcc-build-10.2.0/gcc-10.2.0/gcc/gimple-walk.c:578
0x10657847 walk_gimple_seq_mod(gimple**, tree_node* (*)(gimple_stmt_iterator*, bool*, walk_stmt_info*), tree_node* (*)(tree_node**, int*, void*), walk_stmt_info*)
        /tmp/belhorn/gcc-build-10.2.0/gcc-10.2.0/gcc/gimple-walk.c:51
0x10657663 walk_gimple_stmt(gimple_stmt_iterator*, tree_node* (*)(gimple_stmt_iterator*, bool*, walk_stmt_info*), tree_node* (*)(tree_node**, int*, void*), walk_stmt_info*)
        /tmp/belhorn/gcc-build-10.2.0/gcc-10.2.0/gcc/gimple-walk.c:641
0x10657847 walk_gimple_seq_mod(gimple**, tree_node* (*)(gimple_stmt_iterator*, bool*, walk_stmt_info*), tree_node* (*)(tree_node**, int*, void*), walk_stmt_info*)
        /tmp/belhorn/gcc-build-10.2.0/gcc-10.2.0/gcc/gimple-walk.c:51
0x10657783 walk_gimple_stmt(gimple_stmt_iterator*, tree_node* (*)(gimple_stmt_iterator*, bool*, walk_stmt_info*), tree_node* (*)(tree_node**, int*, void*), walk_stmt_info*)
        /tmp/belhorn/gcc-build-10.2.0/gcc-10.2.0/gcc/gimple-walk.c:605
0x10657847 walk_gimple_seq_mod(gimple**, tree_node* (*)(gimple_stmt_iterator*, bool*, walk_stmt_info*), tree_node* (*)(tree_node**, int*, void*), walk_stmt_info*)
        /tmp/belhorn/gcc-build-10.2.0/gcc-10.2.0/gcc/gimple-walk.c:51
0x1084936f scan_omp
        /tmp/belhorn/gcc-build-10.2.0/gcc-10.2.0/gcc/omp-low.c:3855
0x1084936f execute_lower_omp
        /tmp/belhorn/gcc-build-10.2.0/gcc-10.2.0/gcc/omp-low.c:13048
0x1084936f execute
        /tmp/belhorn/gcc-build-10.2.0/gcc-10.2.0/gcc/omp-low.c:13106
Please submit a full bug report,
with preprocessed source if appropriate.
Please include the complete backtrace with any bug report.
See <https://gcc.gnu.org/bugs/> for instructions.
```

XLF:
```
** ompvv_lib   === End of Compilation 1 ===
"/autofs/nccs-svm1_home1/jhdavis/sollve-project/sollve_vv/tests/5.0/target/test_target_mapping_before_alloc.F90", line 50.61: 1516-411 (S) List item scalar specified in the MAP clause must not share storage with l
ist item scalar in the same construct.
"/autofs/nccs-svm1_home1/jhdavis/sollve-project/sollve_vv/tests/5.0/target/test_target_mapping_before_alloc.F90", line 50.69: 1516-411 (S) List item a specified in the MAP clause must not share storage with list i
tem a in the same construct.
"/autofs/nccs-svm1_home1/jhdavis/sollve-project/sollve_vv/tests/5.0/target/test_target_mapping_before_alloc.F90", line 51.12: 1516-411 (S) List item test_struct specified in the MAP clause must not share storage w
ith list item test_struct in the same construct.
** test_target_mapping_before_alloc   === End of Compilation 2 ===
1501-511  Compilation failed for file test_target_mapping_before_alloc.F90.
```