### PR TITLE
Adding uses_allocator tests for target.

### DIFF
--- a/tests/5.0/target/test_target_uses_allocators_cgroup.c
+++ b/tests/5.0/target/test_target_uses_allocators_cgroup.c
@@ -1,0 +1,54 @@
+//===--- test_target_uses_allocators_cgroup.c -----------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// The tests checks the uses_allocators clause with omp_cgroup_mem_alloc. 
+// The variable allaocated in the target is modified and used to compute result on 
+// device. Result is copied back to the host and checked with computed value on host.
+//
+//===----------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+int test_uses_allocators_cgroup() {
+  int errors = 0;
+  int x = 0;
+  int device_result = 0;
+  int result = 0;
+
+  for (int i = 0; i < N; i++) {
+    for (int j = 0; j < N; j++) {
+      result += j + i ;
+    }
+  }
+
+#pragma omp target uses_allocators(omp_cgroup_mem_alloc) allocate(omp_cgroup_mem_alloc: x) firstprivate(x) map(from: device_result)
+{
+  for (int i = 0; i < N; i++) {
+    for (int j = 0; j < N; j++) {
+      x += j + i;
+    }
+  }
+  device_result = x;
+}
+  OMPVV_TEST_AND_SET_VERBOSE(errors, result != device_result);
+
+  return errors;
+}
+
+int main() {
+
+  OMPVV_TEST_OFFLOADING;
+
+  int errors = 0;
+  
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_uses_allocators_cgroup() != 0);
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}
+

--- a/tests/5.0/target/test_target_uses_allocators_const.c
+++ b/tests/5.0/target/test_target_uses_allocators_const.c
@@ -1,0 +1,57 @@
+//===--- test_target_uses_allocators_const.c -------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// The tests checks the uses_allocators clause with omp_const_mem_alloc. 
+// The variable allaocated in the target region and and is used to 
+// modify result on device. Result is copied back to the host and checked 
+// with computed value on host.
+//
+//===----------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+int test_uses_allocators_const() {
+  int errors = 0;
+  int x = 0;
+  int device_result = 0;
+  int result = 0;
+
+
+  for (int i = 0; i < N; i++) {
+    for (int j = 0; j < N; j++) {
+      result += j + i ;
+    }
+  }
+
+#pragma omp target uses_allocators(omp_const_mem_alloc) allocate(omp_const_mem_alloc: x) firstprivate(x) map(from: device_result)
+{
+  for (int i = 0; i < N; i++) {
+    for (int j = 0; j < N; j++) {
+      x += j + i;
+    }
+  }
+  device_result = x;
+}
+
+  OMPVV_TEST_AND_SET_VERBOSE(errors, result != device_result);
+
+  return errors;
+}
+
+int main() {
+
+  OMPVV_TEST_OFFLOADING;
+
+  int errors = 0;
+  
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_uses_allocators_const() != 0);
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}
+

--- a/tests/5.0/target/test_target_uses_allocators_default.c
+++ b/tests/5.0/target/test_target_uses_allocators_default.c
@@ -1,0 +1,56 @@
+//===--- test_target_uses_allocators_default.c ----------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// The tests checks the uses_allocators clause with omp_default_mem_alloc. 
+// The variable allaocated in the target is modified. Result is copied back to
+// the host and checked with computed value on host.
+//
+//===----------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+int test_uses_allocators_default() {
+  int errors = 0;
+  int x = 0;
+  int device_result = 0;
+  int result = 0;
+
+
+  for (int i = 0; i < N; i++) {
+    for (int j = 0; j < N; j++) {
+      result += j + i ;
+    }
+  }
+
+#pragma omp target uses_allocators(omp_default_mem_alloc) allocate(omp_default_mem_alloc: x) firstprivate(x) map(from: device_result)
+{
+  for (int i = 0; i < N; i++) {
+    for (int j = 0; j < N; j++) {
+      x += j + i;
+    }
+  }
+  device_result = x;
+}
+
+  OMPVV_TEST_AND_SET_VERBOSE(errors, result != device_result);
+
+  return errors;
+}
+
+int main() {
+
+  OMPVV_TEST_OFFLOADING;
+
+  int errors = 0;
+  
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_uses_allocators_default() != 0);
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}
+

--- a/tests/5.0/target/test_target_uses_allocators_high_bw.c
+++ b/tests/5.0/target/test_target_uses_allocators_high_bw.c
@@ -1,0 +1,55 @@
+//===--- test_target_uses_allocators_high_bw.c -------------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// The tests checks the uses_allocators clause with omp_high_bw_mem_alloc. 
+// The variable allaocated in the target is modified and used to compute result 
+// on device. Result is copied back to the host  and checked with computed value on host.
+//
+//===----------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+int test_uses_allocators_high_bw() {
+  int errors = 0;
+  int x = 0;
+  int device_result = 0;
+  int result = 0;
+
+  for (int i = 0; i < N; i++) {
+    for (int j = 0; j < N; j++) {
+      result += j + i ;
+    }
+  }
+
+#pragma omp target uses_allocators(omp_high_bw_mem_alloc) allocate(omp_high_bw_mem_alloc: x) firstprivate(x) map(from: device_result)
+{
+    for (int i = 0; i < N; i++) {
+      for (int j = 0; j < N; j++) {
+        x += j + i;
+      }
+    }
+    device_result = x;
+}
+
+  OMPVV_TEST_AND_SET_VERBOSE(errors, result != device_result);
+
+  return errors;
+}
+
+int main() {
+
+  OMPVV_TEST_OFFLOADING;
+
+  int errors = 0;
+  
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_uses_allocators_high_bw() != 0);
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}
+

--- a/tests/5.0/target/test_target_uses_allocators_large_cap.c
+++ b/tests/5.0/target/test_target_uses_allocators_large_cap.c
@@ -1,0 +1,56 @@
+//===--- test_target_uses_allocators_large_cap.c ---------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// The tests checks the uses_allocators clause with omp_large_cap_mem_alloc. 
+// The variable allaocated in the target region is modified and used to compute 
+// result on device. Result is copied back to the host and checked with computed 
+// value on host.
+//
+//===----------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+int test_uses_allocators_large_cap() {
+  int errors = 0;
+  int x = 0;
+  int device_result = 0;
+  int result = 0;
+
+  for (int i = 0; i < N; i++) {
+    for (int j = 0; j < N; j++) {
+      result += j + i ;
+    }
+  }
+
+#pragma omp target uses_allocators(omp_large_cap_mem_alloc) allocate(omp_large_cap_mem_alloc: x) firstprivate(x) map(from: device_result)
+{
+  for (int i = 0; i < N; i++) {
+    for (int j = 0; j < N; j++) {
+      x += j + i;
+    }
+  }
+    device_result = x;
+}
+
+  OMPVV_TEST_AND_SET_VERBOSE(errors, result != device_result);
+
+  return errors;
+}
+
+int main() {
+
+  OMPVV_TEST_OFFLOADING;
+
+  int errors = 0;
+  
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_uses_allocators_large_cap() != 0);
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}
+

--- a/tests/5.0/target/test_target_uses_allocators_low_lat.c
+++ b/tests/5.0/target/test_target_uses_allocators_low_lat.c
@@ -1,0 +1,54 @@
+//===--- test_target_uses_allocators_low_lat.c ----------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// The tests checks the uses_allocators clause with omp_low_lat_mem_alloc. 
+// The variable allaocated in the target is modified. Result is copied back to
+// the host and checked with computed value on host.
+//
+//===----------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+int test_uses_allocators_low_lat() {
+  int errors = 0;
+  int x = 0;
+  int device_result = 0;
+  int result = 0;
+
+  for (int i = 0; i < N; i++) {
+    for (int j = 0; j < N; j++) {
+      result += j + i ;
+    }
+  }
+
+#pragma omp target uses_allocators(omp_low_lat_mem_alloc) allocate(omp_low_lat_mem_alloc: x) firstprivate(x) map(from: device_result)
+{
+  for (int i = 0; i < N; i++) {
+    for (int j = 0; j < N; j++) {
+      x += j + i;
+    }
+  }
+  device_result = x;
+}
+  OMPVV_TEST_AND_SET_VERBOSE(errors, result != device_result);
+
+  return errors;
+}
+
+int main() {
+
+  OMPVV_TEST_OFFLOADING;
+
+  int errors = 0;
+  
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_uses_allocators_low_lat() != 0);
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}
+

--- a/tests/5.0/target/test_target_uses_allocators_pteam.c
+++ b/tests/5.0/target/test_target_uses_allocators_pteam.c
@@ -1,0 +1,53 @@
+//===--- test_target_uses_allocators_pteam.c ------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// The tests checks the uses_allocators clause with omp_pteam_mem_alloc. 
+// The variable allaocated in the target region is modified and used to compute 
+// result in device envioronment. Result is copied back to the host and checked 
+// with computed value on host.
+//
+//===----------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 8
+
+int test_uses_allocators_pteam() {
+  int errors = 0;
+  int x = 0;
+  int device_result[N] = {0};
+  int result[N] = {0};
+
+  for (int i = 0; i < N; i++) {
+    result[i] = 3 * i ;
+  }
+
+#pragma omp target teams distribute uses_allocators(omp_pteam_mem_alloc) allocate(omp_pteam_mem_alloc: x) private(x) map(from: device_result)
+{
+  for (int i = 0; i < N; i++) {
+    x = 2 * i;
+    device_result[i] = i + x;
+  }
+}
+  for (int i = 0; i < N; i++) {
+    OMPVV_TEST_AND_SET_VERBOSE(errors, result[i] != device_result[i]);
+  }
+
+  return errors;
+}
+
+int main() {
+
+  OMPVV_TEST_OFFLOADING;
+
+  int errors = 0;
+  
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_uses_allocators_pteam() != 0);
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}
+

--- a/tests/5.0/target/test_target_uses_allocators_thread.c
+++ b/tests/5.0/target/test_target_uses_allocators_thread.c
@@ -1,0 +1,52 @@
+//===--- test_target_uses_allocators_thread.c -----------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// The tests checks the uses_allocators clause with omp_thread_mem_alloc. 
+// The variable allaocated in the target region is modified and used to compute 
+// result. Result is copied back to the host and checked with computed value on host.
+//
+//===----------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 8
+
+int test_uses_allocators_thread() {
+  int errors = 0;
+  int x = 0;
+  int device_result[N] = {0};
+  int result[N] = {0};
+
+  for (int i = 0; i < N; i++) {
+    result[i] = 3 * i ;
+  }
+
+#pragma omp target parallel uses_allocators(omp_thread_mem_alloc) allocate(omp_thread_mem_alloc: x) private(x) map(from: device_result)
+{
+  for (int i = 0; i < N; i++) {
+    x = 2 * i;
+    device_result[i] = i + x;
+  }
+}
+  for (int i = 0; i < N; i++) {
+    OMPVV_TEST_AND_SET_VERBOSE(errors, result[i] != device_result[i]);
+  }
+
+  return errors;
+}
+
+int main() {
+
+  OMPVV_TEST_OFFLOADING;
+
+  int errors = 0;
+  
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_uses_allocators_thread() != 0);
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}
+


### PR DESCRIPTION
All tested with LLVM trunk on Summit. 
