### PR TITLE
Add Fortran test of use_device_ptr on target data

### DIFF
--- a/tests/5.0/target_data/test_target_data_use_device_ptr.F90
+++ b/tests/5.0/target_data/test_target_data_use_device_ptr.F90
@@ -1,0 +1,62 @@
+!/===-- test_target_data_use_device_ptr.c ---------------------------------===//
+!
+! OpenMP API Version 5.0 Nov 2018
+!
+! This file is a test for the use_device_ptr when used with the map clause
+! with target data directive. This test uses arrays of size N whose values
+! are modified on the device and tested in the host. Once the array has
+! been mapped to the device, the use_device_ptr should be able to be used
+! with the ptr to the array and subsequently modify values on the device.
+! This test ensures address conversions of use_device_ptr clauses will
+! occur as if performed after all variables are mapped according to those
+! map clauses.
+!
+!/===----------------------------------------------------------------------===//
+#include "ompvv.F90"
+
+#define N 1024
+
+PROGRAM test_target_data_use_device_ptr
+  USE iso_fortran_env
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+  OMPVV_TEST_OFFLOADING
+
+  OMPVV_TEST_VERBOSE(use_device_ptr() .ne. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION use_device_ptr()
+    INTEGER :: errors, x
+    INTEGER,POINTER,DIMENSION(:) :: array_device, array_host
+
+    allocate(array_device(N))
+    allocate(array_host(N))
+
+    errors = 0
+
+    DO x = 1, N
+       array_device(x) = x
+       array_host(x) = 0
+    END DO
+
+    !$omp target data map(to: array_device(1:N)) use_device_ptr(array_device)
+    !$omp target is_device_ptr(array_device) map(tofrom: array_host(1:N))
+    DO x = 1, N
+       array_host(x) = array_host(x) + array_device(x)
+    END DO
+    !$omp end target
+    !$omp end target data
+
+    DO x = 1, N
+       OMPVV_TEST_AND_SET_VERBOSE(errors, array_host(x) .ne. x)
+    END DO
+
+    deallocate(array_device)
+    deallocate(array_host)
+
+    use_device_ptr = errors
+  END FUNCTION use_device_ptr
+END PROGRAM test_target_data_use_device_ptr

--- a/tests/5.0/target_data/test_target_data_use_device_ptr.F90
+++ b/tests/5.0/target_data/test_target_data_use_device_ptr.F90
@@ -40,16 +40,16 @@ CONTAINS
 
   END SUBROUTINE run_target_region
   INTEGER FUNCTION use_device_ptr()
-    INTEGER :: errors, x
+    INTEGER :: errors
     INTEGER :: scalar_device, scalar_host
 
     errors = 0
-    scalar_device = x
+    scalar_device = N
     scalar_host = 0
 
     call run_target_region(scalar_host, scalar_device)
 
-    OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_host .ne. x)
+    OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_host .ne. N)
 
     use_device_ptr = errors
   END FUNCTION use_device_ptr


### PR DESCRIPTION
I'm adding this test not necessarily because I think it is valid, but it order to discuss it at the next meeting. It appears the following restriction to the `is_device_ptr` clause for Fortran impairs our ability to test `use_device_ptr` in the same manner as we did for C:

```
A list item that appears in an is_device_ptr clause must be a dummy argument that does
4 not have the ALLOCATABLE, POINTER or VALUE attribute.
```

Any insight into how to work around this is appreciated. I am still thinking about how exactly it would be best to test this feature in Fortran. At the moment, Summit XLF and gfortran both will not compile this test due to it not meeting the aforementioned restriction.