### PR TITLE
Update test_target_teams_distribute_depend_array_section.F90

### DIFF
--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_depend_array_section.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_depend_array_section.F90
@@ -49,7 +49,7 @@ CONTAINS
     DO x = 1, N
        d(x) = c(x) + b(x)
     END DO
-    !omp taskwait
+    !$omp taskwait
     !$omp end target data
 
     errors = 0


### PR DESCRIPTION
OpenMP directive was missing "$ sign" so it was treated as comment in Fortran.