### PR TITLE
Update test_target_teams_distribute_depend_disjoint_section.F90

### DIFF
--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_depend_disjoint_section.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_depend_disjoint_section.F90
@@ -55,7 +55,7 @@ CONTAINS
        !$omp atomic
        c(x) = c(x) + (2*(a(x) + b(x)) + d(x))
     END DO
-    !omp taskwait
+    !$omp taskwait
     !$omp end target data
 
     DO x = 1, N


### PR DESCRIPTION
OpenMP directive was missing "$ sign" so it was treated as comment in Fortran.