### PR TITLE
test_omp_target_offload_env_DEFAULT.c: Fix include file

### DIFF
--- a/tests/5.0/program_control/test_omp_target_offload_env_DEFAULT.c
+++ b/tests/5.0/program_control/test_omp_target_offload_env_DEFAULT.c
@@ -22,9 +22,9 @@
 
 #include <omp.h>
 #include <stdio.h>
-#include <ctype.h>
+#include <ctype.h>  // For isspace.
 #include <stdlib.h>
-#include <string.h>
+#include <strings.h>  // For strncasecmp.
 #include "ompvv.h"
 
 #define N 1028


### PR DESCRIPTION
* tests/5.0/program_control/test_omp_target_offload_env_DEFAULT.c:
  Use proper #include file for strncasecmp.

That function is in 'strings.h' not in 'string.h'. Hence, this patch silences an implicitly defined warning. 