### PR TITLE
test_omp_get_supported_active_levels.c: Fix macro name typo

### DIFF
--- a/tests/5.0/program_control/test_omp_get_supported_active_levels.c
+++ b/tests/5.0/program_control/test_omp_get_supported_active_levels.c
@@ -28,7 +28,7 @@ int main() {
    max_active_levels = omp_get_max_active_levels();
 
    OMPVV_TEST_AND_SET_VERBOSE(errors, num_active_levels > max_active_levels);
-   OMPVV_TET_AND_SET_VERBOSE(errors, num_active_levels <= 0);
+   OMPVV_TEST_AND_SET_VERBOSE(errors, num_active_levels <= 0);
 
    OMPVV_REPORT_AND_RETURN(errors);
 


### PR DESCRIPTION
* tests/5.0/program_control/test_omp_get_supported_active_levels.c:
  Fix macro name typo.

In OMPVV_TE(S)T_AND_SET_VERBOSE