### PR TITLE
test_omp_get_supported_active_levels: Fix condition

### DIFF
--- a/tests/5.0/program_control/test_omp_get_supported_active_levels.c
+++ b/tests/5.0/program_control/test_omp_get_supported_active_levels.c
@@ -5,7 +5,8 @@
 // Test for support of the omp_get_supported_active_levels() routine. 
 // This routine returns the number of active levels of parallelism 
 // supported by the implementation. This returned value must be greater
-// than 0 and less than the value of the max_active_levels-var ICV.
+// than 0 and the max-active-levels-var ICV may not have a value that is greater
+// than this number.
 // 
 ///===-----------------------------------------------------------------------===//
 
@@ -19,16 +20,16 @@
 int main() {
 
    int errors;
-   int num_active_levels;
+   int num_supp_active_levels;
    int max_active_levels;
 
    errors = 0;
  
-   num_active_levels = omp_get_supported_active_levels();
+   num_supp_active_levels = omp_get_supported_active_levels();
    max_active_levels = omp_get_max_active_levels();
 
-   OMPVV_TEST_AND_SET_VERBOSE(errors, num_active_levels > max_active_levels);
-   OMPVV_TEST_AND_SET_VERBOSE(errors, num_active_levels <= 0);
+   OMPVV_TEST_AND_SET_VERBOSE(errors, max_active_levels > num_supp_active_levels);
+   OMPVV_TEST_AND_SET_VERBOSE(errors, num_supp_active_levels <= 0);
 
    OMPVV_REPORT_AND_RETURN(errors);
 


### PR DESCRIPTION
OpenMP 5.1:
"The omp_get_supported_active_levels routine returns the number of active levels
of parallelism supported by the implementation.  The max-active-levels-var ICV
may not have a value that is greater than this number."

* tests/5.0/program_control/test_omp_get_supported_active_levels.c: Update comment
  to match the spec.  Rename variable num_active_levels to num_supp_active_levels
  for clarity; fix condition to actually match the spec.

OpenMP 5.0 spec: https://www.openmp.org/spec-html/5.0/openmpsu124.html#x161-7240003.2.15
OpenMP 5.1 spec: https://www.openmp.org/spec-html/5.1/openmpsu133.html#x172-2050003.2.14

@spophale , @tmh97 please review. – Thanks by the way for your quick reviews!