### PR TITLE
Update test_parallel_master_taskloop.c

### DIFF
--- a/tests/5.0/parallel_master_taskloop/test_parallel_master_taskloop.c
+++ b/tests/5.0/parallel_master_taskloop/test_parallel_master_taskloop.c
@@ -31,7 +31,7 @@ int test_parallel_master_taskloop() {
 #pragma omp parallel master taskloop num_threads(OMPVV_NUM_THREADS_HOST) shared(x, y, z, num_threads)
   for (int i = 0; i < N; i++) {
     x[i] += y[i]*z[i];
-    if (omp_get_thread_num() == 0) {
+    if (i == 0) {
       num_threads = omp_get_num_threads();
     }
   }


### PR DESCRIPTION
Corrects implicit assumption that the master will be involved in executing the taskloop.

closes #324