### PR TITLE
Fix header spec version in Fortran 4.5 reduction tests

### DIFF
--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_add.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_add.F90
@@ -1,6 +1,6 @@
 !===--- test_target_teams_distribute_reduction_add.F90----------------------===//
 !
-! OpenMP API Version 5.0 Nov 2018
+! OpenMP API Version 4.5 Nov 2015
 !
 ! This test uses the reduction clause on a target teams distribute
 ! directive, testing, for the add operator, that the variable in the

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_and.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_and.F90
@@ -1,6 +1,6 @@
 !===--- test_target_teams_distribute_reduction_and.F90----------------------===//
 !
-! OpenMP API Version 5.0 Nov 2018
+! OpenMP API Version 4.5 Nov 2015
 !
 ! This test uses the reduction clause on a target teams distribute
 ! directive, testing, for the and operator, that the variable in the
@@ -60,8 +60,8 @@ CONTAINS
        END DO
 
        !$omp target teams distribute map(to: a(1:N)) &
-       !$omp& reduction(.and.: result) map(tofrom: &
-       !$omp& result)
+       !$omp& reduction(.and.: result) defaultmap( &
+       !$omp& tofrom: scalar)
        DO x = 1, N
           result = a(x) .AND. result
        END DO

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_bitand.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_bitand.F90
@@ -1,6 +1,6 @@
 !===--- test_target_teams_distribute_reduction_bitand.F90-------------------===//
 !
-! OpenMP API Version 5.0 Nov 2018
+! OpenMP API Version 4.5 Nov 2015
 !
 ! This test uses the reduction clause on a target teams distribute
 ! directive, testing, for the bitand operator, that the variable in the

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_bitor.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_bitor.F90
@@ -1,6 +1,6 @@
 !===--- test_target_teams_distribute_reduction_bitor.F90--------------------===//
 !
-! OpenMP API Version 5.0 Nov 2018
+! OpenMP API Version 4.5 Nov 2015
 !
 ! This test uses the reduction clause on a target teams distribute
 ! directive, testing, for the bitor operator, that the variable in the

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_bitxor.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_bitxor.F90
@@ -1,6 +1,6 @@
 !===--- test_target_teams_distribute_reduction_bitxor.F90-------------------===//
 !
-! OpenMP API Version 5.0 Nov 2018
+! OpenMP API Version 4.5 Nov 2015
 !
 ! This test uses the reduction clause on a target teams distribute
 ! directive, testing, for the bitxor operator, that the variable in the

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_eqv.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_eqv.F90
@@ -1,6 +1,6 @@
 !===--- test_target_teams_distribute_reduction_eqv.F90----------------------===//
 !
-! OpenMP API Version 5.0 Nov 2018
+! OpenMP API Version 4.5 Nov 2015
 !
 ! This test uses the reduction clause on a target teams distribute
 ! directive, testing, for the eqv operator, that the variable in the

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_max.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_max.F90
@@ -1,6 +1,6 @@
 !===--- test_target_teams_distribute_reduction_max.F90----------------------===//
 !
-! OpenMP API Version 5.0 Nov 2018
+! OpenMP API Version 4.5 Nov 2015
 !
 ! This test uses the reduction clause on a target teams distribute
 ! directive, testing, for the max operator, that the variable in the

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_min.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_min.F90
@@ -1,6 +1,6 @@
 !===--- test_target_teams_distribute_reduction_min.F90----------------------===//
 !
-! OpenMP API Version 5.0 Nov 2018
+! OpenMP API Version 4.5 Nov 2015
 !
 ! This test uses the reduction clause on a target teams distribute
 ! directive, testing, for the min operator, that the variable in the

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_multiply.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_multiply.F90
@@ -1,6 +1,6 @@
 !===--- test_target_teams_distribute_reduction_multiply.F90-----------------===//
 !
-! OpenMP API Version 5.0 Nov 2018
+! OpenMP API Version 4.5 Nov 2015
 !
 ! This test uses the reduction clause on a target teams distribute
 ! directive, testing, for the multiply operator, that the variable in the

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_neqv.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_neqv.F90
@@ -1,6 +1,6 @@
 !===--- test_target_teams_distribute_reduction_neqv.F90---------------------===//
 !
-! OpenMP API Version 5.0 Nov 2018
+! OpenMP API Version 4.5 Nov 2015
 !
 ! This test uses the reduction clause on a target teams distribute
 ! directive, testing, for the neqv operator, that the variable in the

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_or.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_reduction_or.F90
@@ -1,6 +1,6 @@
 !===--- test_target_teams_distribute_reduction_or.F90-----------------------===//
 !
-! OpenMP API Version 5.0 Nov 2018
+! OpenMP API Version 4.5 Nov 2015
 !
 ! This test uses the reduction clause on a target teams distribute
 ! directive, testing, for the or operator, that the variable in the


### PR DESCRIPTION
All tests passing gfortran on Summit as usual.