### PR TITLE
Target version of 5.0 omp_get_supported_active_levels test

### DIFF
--- a/tests/5.0/program_control/test_omp_get_supported_active_levels.c
+++ b/tests/5.0/program_control/test_omp_get_supported_active_levels.c
@@ -23,8 +23,8 @@ int main() {
    int num_supp_active_levels;
    int max_active_levels;
 
-   errors = 0;
- 
+   errors = 0; 
+   
    num_supp_active_levels = omp_get_supported_active_levels();
    max_active_levels = omp_get_max_active_levels();
 

--- a/tests/5.0/program_control/test_target_omp_get_supported_active_levels.c
+++ b/tests/5.0/program_control/test_target_omp_get_supported_active_levels.c
@@ -1,0 +1,41 @@
+//===--- test_target_omp_get_supported_active_levels.c ----------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// Test for support of the omp_get_supported_active_levels() routine within
+// a target region. This routine returns the number of active levels of 
+// parallelism supported by the implementation. This returned value must be greater
+// than 0 and the max-active-levels-var ICV may not have a value that is greater
+// than this number.
+// 
+//===------------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1028
+
+int main() {
+
+   int errors;
+   int num_supp_active_levels;
+   int max_active_levels;
+
+   OMPVV_TEST_OFFLOADING;
+
+   errors = 0;
+
+   #pragma omp target map(from: num_supp_active_levels, max_active_levels)
+   {
+      num_supp_active_levels = omp_get_supported_active_levels();
+      max_active_levels = omp_get_max_active_levels();
+   }
+
+   OMPVV_TEST_AND_SET_VERBOSE(errors, max_active_levels > num_supp_active_levels);
+   OMPVV_TEST_AND_SET_VERBOSE(errors, num_supp_active_levels <= 0);
+
+   OMPVV_REPORT_AND_RETURN(errors);
+
+}


### PR DESCRIPTION
Target version of https://github.com/SOLLVE/sollve_vv/blob/master/tests/5.0/program_control/test_omp_get_supported_active_levels.c.

- GCC and LLVM issue compile-time errors for `omp_get_supported_active_levels()` within a target region. 

- The 5.0 specification states "The omp_get_supported_active_levels routine returns the number of active levels of
parallelism supported by the implementation."

- For omp_get_max_levels, the specification states "The omp_get_max_active_levels routine returns the value of the max-active-levels-varICV, which determines the maximum number of nested active parallel regions on the device."

It seems reasonable to infer that `omp_get_supported_active_levels` should only be called from the sequential portion of the code, if so I can place that routine outside the target region (tested and works fine).

