### PR TITLE
Update test_target_teams_distribute_device.c

### DIFF
--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_device.c
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_device.c
@@ -47,11 +47,11 @@ int main() {
   }
 
   for (int dev = 0; dev < num_devices; ++dev) {
-#pragma omp target enter data map(to: a[dev][0:ARRAY_SIZE], b[0:ARRAY_SIZE], num_teams[dev]) device(dev)
+#pragma omp target enter data map(to: a[dev][0:ARRAY_SIZE], b[0:ARRAY_SIZE], num_teams[dev:1]) device(dev)
   }
 
   for (int dev = 0; dev < num_devices; ++dev) {
-#pragma omp target teams distribute map(alloc: a[dev][0:ARRAY_SIZE], b[0:ARRAY_SIZE], num_teams[dev]) device(dev)
+#pragma omp target teams distribute map(alloc: a[dev][0:ARRAY_SIZE], b[0:ARRAY_SIZE], num_teams[dev:1]) device(dev)
     for (int x = 0; x < ARRAY_SIZE; ++x) {
       if (omp_get_team_num() == 0) {
         num_teams[dev] = omp_get_num_teams();
@@ -61,7 +61,7 @@ int main() {
   }
 
   for (int dev = 0; dev < num_devices; ++dev) {
-#pragma omp target exit data map(from: a[dev][0:ARRAY_SIZE], num_teams[dev]) map(delete: b[0:ARRAY_SIZE]) device(dev)
+#pragma omp target exit data map(from: a[dev][0:ARRAY_SIZE], num_teams[dev:1]) map(delete: b[0:ARRAY_SIZE]) device(dev)
     for (int x = 0; x < ARRAY_SIZE; ++x) {
       OMPVV_TEST_AND_SET_VERBOSE(errors[dev], a[dev][x] != 1 + dev + b[x]);
       if (a[dev][x] != 1 + dev + b[x]) {


### PR DESCRIPTION
Fix array section passed to map clause. The program uses `num_teams[dev]`, but according to spec that should be `num_teams[dev:1]`:

The syntax of array sections is mentioned in Section 2.1.5 of the OpenMP Spec 5.1:

```
To specify an array section in an OpenMP construct, array subscript expressions are extended with the following syntax:
[ lower-bound : length : stride] or
[ lower-bound : length : ] or
[ lower-bound : length ] or
[ lower-bound : : stride] or
[ lower-bound : : ] or
[ lower-bound : ] or
[ : length : stride] or
[ : length : ] or
[ : length ] or
[ : : stride]
[ : : ]
[ : ]
```

Thanks!