### PR TITLE
Update test_target_enter_data_classes_inheritance.cpp

### DIFF
--- a/tests/4.5/target_enter_data/test_target_enter_data_classes_inheritance.cpp
+++ b/tests/4.5/target_enter_data/test_target_enter_data_classes_inheritance.cpp
@@ -70,7 +70,7 @@ private:
   double sumB; 
 
 public:
-  B(int n) : Mapper<B>(this), n(n) {
+  B(int nn) : Mapper<B>(this), n(nn) {
     x = new double[n];
     std::fill(x, x+n, 0);
     // This is a work around to avoid referring to 


### PR DESCRIPTION
I believe there is a bug in this code.

The code in question is:

```
...
class B : public Mapper<B> {
protected:
  int n;
private:
  double* x;
  double sumB;

public:
  B(int n) : Mapper<B>(this), n(n) {
    x = new double[n];
    std::fill(x, x+n, 0);
    double* solutionX = x;
    int &cpy_n = n;
#pragma omp target enter data map(to:solutionX[0:n], cpy_n)
  }
....
```

The problematic issue is `int &cpy_n = n`, with `enter map(to:cpy_n)`.
`cpy_n` is a reference to `n`.  But what is `n` here?  Is it the class member `n`?  is it the argument to the method `B`?  It appears to be the argument `n`.  If I rename the argument `n` to `nn`, change the `n(n)` to `n(nn)`, then the program works, inside the constructor method `B` here `n` refers unambiguously to the member `n`.

What do you think?

Thanks!