### PR TITLE
5.0/loop/test_loop_order_concurrent*.F90: Fix random init

### DIFF
--- a/tests/5.0/loop/test_loop_order_concurrent.F90
+++ b/tests/5.0/loop/test_loop_order_concurrent.F90
@@ -47,7 +47,7 @@ CONTAINS
        c(x) = 2*(x + 1)
     END DO
 
-    CALL init_random_seed()
+    CALL RANDOM_SEED()
 
     DO x = 1, OMPVV_NUM_THREADS_HOST
        CALL RANDOM_NUMBER(curr_rand)

--- a/tests/5.0/loop/test_loop_order_concurrent_device.F90
+++ b/tests/5.0/loop/test_loop_order_concurrent_device.F90
@@ -47,7 +47,7 @@ CONTAINS
        c(x) = 2*(x + 1)
     END DO
 
-    CALL init_random_seed()
+    CALL RANDOM_SEED()
 
     DO x = 1, OMPVV_NUM_THREADS_DEVICE
        CALL RANDOM_NUMBER(curr_rand)


### PR DESCRIPTION
* tests/5.0/loop/test_loop_order_concurrent.F90: Call standard
  intrinsic subroutine RANDOM_SEED instead of nonexisting
  init_random_seed.
* tests/5.0/loop/test_loop_order_concurrent_device.F90: Likewise.

@spophale @jhdavis8 @tmh97  – please review. Thanks!