### PR TITLE
Add Fortran versions of uses_allocators tests

### DIFF
--- a/tests/5.0/target/test_target_uses_allocators_cgroup.F90
+++ b/tests/5.0/target/test_target_uses_allocators_cgroup.F90
@@ -1,4 +1,4 @@
-!/===--- test_target_uses_allocators_cgroup.c -----------------------------===//
+!/===--- test_target_uses_allocators_cgroup.F90 ---------------------------===//
 !
 ! OpenMP API Version 5.0 Nov 2018
 !

--- a/tests/5.0/target/test_target_uses_allocators_cgroup.F90
+++ b/tests/5.0/target/test_target_uses_allocators_cgroup.F90
@@ -1,0 +1,53 @@
+!/===--- test_target_uses_allocators_cgroup.c -----------------------------===//
+!
+! OpenMP API Version 5.0 Nov 2018
+!
+! The tests checks the uses_allocators clause with omp_cgroup_mem_alloc.
+! The variable allaocated in the target is modified. Result is copied back to
+! the host and checked with computed value on host.
+!
+!/===----------------------------------------------------------------------===//
+
+#include "ompvv.F90"
+
+#define N 1024
+
+PROGRAM test_uses_allocators_cgroup
+
+  USE iso_fortran_env
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+
+  OMPVV_TEST_VERBOSE(test_target() .ne. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION test_target()
+    INTEGER:: x, errors, device_result, host_result, i, j
+    errors = 0
+    x = 0
+    device_result = 0
+    host_result = 0
+
+    DO i = 1, N
+       DO j = 1, N
+          host_result = host_result + j + i
+       END DO
+    END DO
+
+    !$omp target uses_allocators(omp_cgroup_mem_alloc) allocate(omp_cgroup_mem_alloc: x) firstprivate(x) map(from: device_result)
+    DO i = 1, N
+       DO j = 1, N
+          x = x + j + i
+       END DO
+    END DO
+    device_result = x
+    !$omp end target
+
+    OMPVV_TEST_AND_SET_VERBOSE(errors, host_result .ne. device_result)
+
+    test_target = errors
+  END FUNCTION test_target
+END PROGRAM test_uses_allocators_cgroup

--- a/tests/5.0/target/test_target_uses_allocators_const.F90
+++ b/tests/5.0/target/test_target_uses_allocators_const.F90
@@ -1,4 +1,4 @@
-!/===--- test_target_uses_allocators_const.c --------------------------===//
+!/===--- test_target_uses_allocators_const.F90 ----------------------------===//
 !
 ! OpenMP API Version 5.0 Nov 2018
 !

--- a/tests/5.0/target/test_target_uses_allocators_const.F90
+++ b/tests/5.0/target/test_target_uses_allocators_const.F90
@@ -1,0 +1,53 @@
+!/===--- test_target_uses_allocators_const.c --------------------------===//
+!
+! OpenMP API Version 5.0 Nov 2018
+!
+! The tests checks the uses_allocators clause with omp_const_mem_alloc.
+! The variable allaocated in the target is modified. Result is copied back to
+! the host and checked with computed value on host.
+!
+!/===----------------------------------------------------------------------===//
+
+#include "ompvv.F90"
+
+#define N 1024
+
+PROGRAM test_uses_allocators_const
+
+  USE iso_fortran_env
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+
+  OMPVV_TEST_VERBOSE(test_target() .ne. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION test_target()
+    INTEGER:: x, errors, device_result, host_result, i, j
+    errors = 0
+    x = 0
+    device_result = 0
+    host_result = 0
+
+    DO i = 1, N
+       DO j = 1, N
+          host_result = host_result + j + i
+       END DO
+    END DO
+
+    !$omp target uses_allocators(omp_const_mem_alloc) allocate(omp_const_mem_alloc: x) firstprivate(x) map(from: device_result)
+    DO i = 1, N
+       DO j = 1, N
+          x = x + j + i
+       END DO
+    END DO
+    device_result = x
+    !$omp end target
+
+    OMPVV_TEST_AND_SET_VERBOSE(errors, host_result .ne. device_result)
+
+    test_target = errors
+  END FUNCTION test_target
+END PROGRAM test_uses_allocators_const

--- a/tests/5.0/target/test_target_uses_allocators_default.F90
+++ b/tests/5.0/target/test_target_uses_allocators_default.F90
@@ -1,0 +1,53 @@
+!/===--- test_target_uses_allocators_default.c ----------------------------===//
+!
+! OpenMP API Version 5.0 Nov 2018
+!
+! The tests checks the uses_allocators clause with omp_default_mem_alloc.
+! The variable allaocated in the target is modified. Result is copied back to
+! the host and checked with computed value on host.
+!
+!/===----------------------------------------------------------------------===//
+
+#include "ompvv.F90"
+
+#define N 1024
+
+PROGRAM test_uses_allocators_default
+
+  USE iso_fortran_env
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+
+  OMPVV_TEST_VERBOSE(test_target() .ne. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION test_target()
+    INTEGER:: x, errors, device_result, host_result, i, j
+    errors = 0
+    x = 0
+    device_result = 0
+    host_result = 0
+
+    DO i = 1, N
+       DO j = 1, N
+          host_result = host_result + j + i
+       END DO
+    END DO
+
+    !$omp target uses_allocators(omp_default_mem_alloc) allocate(omp_default_mem_alloc: x) firstprivate(x) map(from: device_result)
+    DO i = 1, N
+       DO j = 1, N
+          x = x + j + i
+       END DO
+    END DO
+    device_result = x
+    !$omp end target
+
+    OMPVV_TEST_AND_SET_VERBOSE(errors, host_result .ne. device_result)
+
+    test_target = errors
+  END FUNCTION test_target
+END PROGRAM test_uses_allocators_default

--- a/tests/5.0/target/test_target_uses_allocators_default.F90
+++ b/tests/5.0/target/test_target_uses_allocators_default.F90
@@ -1,4 +1,4 @@
-!/===--- test_target_uses_allocators_default.c ----------------------------===//
+!/===--- test_target_uses_allocators_default.F90 --------------------------===//
 !
 ! OpenMP API Version 5.0 Nov 2018
 !

--- a/tests/5.0/target/test_target_uses_allocators_default.c
+++ b/tests/5.0/target/test_target_uses_allocators_default.c
@@ -2,7 +2,7 @@
 //
 // OpenMP API Version 5.0 Nov 2018
 //
-// The tests checks the uses_allocators clause with omp_default_mem_alloc. 
+// The tests checks the uses_allocators clause with omp_default_mem_alloc.
 // The variable allaocated in the target is modified. Result is copied back to
 // the host and checked with computed value on host.
 //

--- a/tests/5.0/target/test_target_uses_allocators_high_bw.F90
+++ b/tests/5.0/target/test_target_uses_allocators_high_bw.F90
@@ -1,0 +1,53 @@
+!/===--- test_target_uses_allocators_high_bw.c ----------------------------===//
+!
+! OpenMP API Version 5.0 Nov 2018
+!
+! The tests checks the uses_allocators clause with omp_high_bw_mem_alloc.
+! The variable allaocated in the target is modified. Result is copied back
+! to the host and checked with computed value on host.
+!
+!/===----------------------------------------------------------------------===//
+
+#include "ompvv.F90"
+
+#define N 1024
+
+PROGRAM test_uses_allocators_high_bw
+
+  USE iso_fortran_env
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+
+  OMPVV_TEST_VERBOSE(test_target() .ne. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION test_target()
+    INTEGER:: x, errors, device_result, host_result, i, j
+    errors = 0
+    x = 0
+    device_result = 0
+    host_result = 0
+
+    DO i = 1, N
+       DO j = 1, N
+          host_result = host_result + j + i
+       END DO
+    END DO
+
+    !$omp target uses_allocators(omp_high_bw_mem_alloc) allocate(omp_high_bw_mem_alloc: x) firstprivate(x) map(from: device_result)
+    DO i = 1, N
+       DO j = 1, N
+          x = x + j + i
+       END DO
+    END DO
+    device_result = x
+    !$omp end target
+
+    OMPVV_TEST_AND_SET_VERBOSE(errors, host_result .ne. device_result)
+
+    test_target = errors
+  END FUNCTION test_target
+END PROGRAM test_uses_allocators_high_bw

--- a/tests/5.0/target/test_target_uses_allocators_high_bw.F90
+++ b/tests/5.0/target/test_target_uses_allocators_high_bw.F90
@@ -1,4 +1,4 @@
-!/===--- test_target_uses_allocators_high_bw.c ----------------------------===//
+!/===--- test_target_uses_allocators_high_bw.F90 --------------------------===//
 !
 ! OpenMP API Version 5.0 Nov 2018
 !

--- a/tests/5.0/target/test_target_uses_allocators_high_bw.c
+++ b/tests/5.0/target/test_target_uses_allocators_high_bw.c
@@ -1,12 +1,13 @@
-//===--- test_target_uses_allocators_high_bw.c -------------------------------------===//
+//===--- test_target_uses_allocators_high_bw.c ---------------------------------===//
 //
 // OpenMP API Version 5.0 Nov 2018
 //
-// The tests checks the uses_allocators clause with omp_high_bw_mem_alloc. 
-// The variable allaocated in the target is modified and used to compute result 
-// on device. Result is copied back to the host  and checked with computed value on host.
+// The tests checks the uses_allocators clause with omp_high_bw_mem_alloc.
+// The variable allaocated in the target is modified and used to compute result
+// on device. Result is copied back to the host  and checked with computed value
+// on host.
 //
-//===----------------------------------------------------------------------===//
+//===---------------------------------------------------------------------------===//
 
 #include <omp.h>
 #include <stdio.h>

--- a/tests/5.0/target/test_target_uses_allocators_large_cap.F90
+++ b/tests/5.0/target/test_target_uses_allocators_large_cap.F90
@@ -1,4 +1,4 @@
-!/===--- test_target_uses_allocators_large_cap.c --------------------------===//
+!/===--- test_target_uses_allocators_large_cap.F90 ------------------------===//
 !
 ! OpenMP API Version 5.0 Nov 2018
 !

--- a/tests/5.0/target/test_target_uses_allocators_large_cap.F90
+++ b/tests/5.0/target/test_target_uses_allocators_large_cap.F90
@@ -1,0 +1,53 @@
+!/===--- test_target_uses_allocators_large_cap.c --------------------------===//
+!
+! OpenMP API Version 5.0 Nov 2018
+!
+! The tests checks the uses_allocators clause with omp_large_cap_mem_alloc.
+! The variable allaocated in the target is modified. Result is copied back to
+! the host and checked with computed value on host.
+!
+!/===----------------------------------------------------------------------===//
+
+#include "ompvv.F90"
+
+#define N 1024
+
+PROGRAM test_uses_allocators_large_cap
+
+  USE iso_fortran_env
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+
+  OMPVV_TEST_VERBOSE(test_target() .ne. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION test_target()
+    INTEGER:: x, errors, device_result, host_result, i, j
+    errors = 0
+    x = 0
+    device_result = 0
+    host_result = 0
+
+    DO i = 1, N
+       DO j = 1, N
+          host_result = host_result + j + i
+       END DO
+    END DO
+
+    !$omp target uses_allocators(omp_large_cap_mem_alloc) allocate(omp_large_cap_mem_alloc: x) firstprivate(x) map(from: device_result)
+    DO i = 1, N
+       DO j = 1, N
+          x = x + j + i
+       END DO
+    END DO
+    device_result = x
+    !$omp end target
+
+    OMPVV_TEST_AND_SET_VERBOSE(errors, host_result .ne. device_result)
+
+    test_target = errors
+  END FUNCTION test_target
+END PROGRAM test_uses_allocators_large_cap

--- a/tests/5.0/target/test_target_uses_allocators_low_lat.F90
+++ b/tests/5.0/target/test_target_uses_allocators_low_lat.F90
@@ -1,4 +1,4 @@
-!/===--- test_target_uses_allocators_low_lat.c ----------------------------===//
+!/===--- test_target_uses_allocators_low_lat.F90 --------------------------===//
 !
 ! OpenMP API Version 5.0 Nov 2018
 !

--- a/tests/5.0/target/test_target_uses_allocators_low_lat.F90
+++ b/tests/5.0/target/test_target_uses_allocators_low_lat.F90
@@ -1,0 +1,53 @@
+!/===--- test_target_uses_allocators_low_lat.c ----------------------------===//
+!
+! OpenMP API Version 5.0 Nov 2018
+!
+! The tests checks the uses_allocators clause with omp_low_lat_mem_alloc.
+! The variable allaocated in the target is modified. Result is copied back
+! to the host and checked with computed value on host.
+!
+!/===----------------------------------------------------------------------===//
+
+#include "ompvv.F90"
+
+#define N 1024
+
+PROGRAM test_uses_allocators_low_lat
+
+  USE iso_fortran_env
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+
+  OMPVV_TEST_VERBOSE(test_target() .ne. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION test_target()
+    INTEGER:: x, errors, device_result, host_result, i, j
+    errors = 0
+    x = 0
+    device_result = 0
+    host_result = 0
+
+    DO i = 1, N
+       DO j = 1, N
+          host_result = host_result + j + i
+       END DO
+    END DO
+
+    !$omp target uses_allocators(omp_low_lat_mem_alloc) allocate(omp_low_lat_mem_alloc: x) firstprivate(x) map(from: device_result)
+    DO i = 1, N
+       DO j = 1, N
+          x = x + j + i
+       END DO
+    END DO
+    device_result = x
+    !$omp end target
+
+    OMPVV_TEST_AND_SET_VERBOSE(errors, host_result .ne. device_result)
+
+    test_target = errors
+  END FUNCTION test_target
+END PROGRAM test_uses_allocators_low_lat

--- a/tests/5.0/target/test_target_uses_allocators_pteam.F90
+++ b/tests/5.0/target/test_target_uses_allocators_pteam.F90
@@ -1,0 +1,51 @@
+!/===--- test_target_uses_allocators_pteam.c ------------------------------===//
+!
+! OpenMP API Version 5.0 Nov 2018
+!
+! The tests checks the uses_allocators clause with omp_pteam_mem_alloc.
+! The variable allaocated in the target region is modified and used to compute
+! result in device envioronment. Result is copied back to the host and checked
+! with computed value on host.
+!
+!/===----------------------------------------------------------------------===//
+
+#include "ompvv.F90"
+
+#define N 1024
+
+PROGRAM test_uses_allocators_pteam
+
+  USE iso_fortran_env
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+
+  OMPVV_TEST_VERBOSE(test_target() .ne. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION test_target()
+    INTEGER,DIMENSION(N):: device_result, host_result
+    INTEGER:: x, errors, i
+    errors = 0
+    x = 0
+
+    DO i = 1, N
+       host_result(i) = 3*i
+       device_result(i) = 0
+    END DO
+
+    !$omp target teams distribute uses_allocators(omp_pteam_mem_alloc) allocate(omp_pteam_mem_alloc: x) private(x) map(from: device_result)
+    DO i = 1, N
+       x = 2*i
+       device_result(i) = i + x
+    END DO
+
+    DO i = 1, N
+       OMPVV_TEST_AND_SET_VERBOSE(errors, host_result(i) .ne. device_result(i))
+    END DO
+
+    test_target = errors
+  END FUNCTION test_target
+END PROGRAM test_uses_allocators_pteam

--- a/tests/5.0/target/test_target_uses_allocators_pteam.F90
+++ b/tests/5.0/target/test_target_uses_allocators_pteam.F90
@@ -1,4 +1,4 @@
-!/===--- test_target_uses_allocators_pteam.c ------------------------------===//
+!/===--- test_target_uses_allocators_pteam.F90 ---------------------------===//
 !
 ! OpenMP API Version 5.0 Nov 2018
 !

--- a/tests/5.0/target/test_target_uses_allocators_pteam.c
+++ b/tests/5.0/target/test_target_uses_allocators_pteam.c
@@ -2,9 +2,9 @@
 //
 // OpenMP API Version 5.0 Nov 2018
 //
-// The tests checks the uses_allocators clause with omp_pteam_mem_alloc. 
-// The variable allaocated in the target region is modified and used to compute 
-// result in device envioronment. Result is copied back to the host and checked 
+// The tests checks the uses_allocators clause with omp_pteam_mem_alloc.
+// The variable allaocated in the target region is modified and used to compute
+// result in device envioronment. Result is copied back to the host and checked
 // with computed value on host.
 //
 //===----------------------------------------------------------------------===//
@@ -45,9 +45,8 @@ int main() {
   OMPVV_TEST_OFFLOADING;
 
   int errors = 0;
-  
+
   OMPVV_TEST_AND_SET_VERBOSE(errors, test_uses_allocators_pteam() != 0);
 
   OMPVV_REPORT_AND_RETURN(errors);
 }
-

--- a/tests/5.0/target/test_target_uses_allocators_thread.F90
+++ b/tests/5.0/target/test_target_uses_allocators_thread.F90
@@ -1,0 +1,51 @@
+!/===--- test_target_uses_allocators_thread.c -----------------------------===//
+!
+! OpenMP API Version 5.0 Nov 2018
+!
+! The tests checks the uses_allocators clause with omp_thread_mem_alloc.
+! The variable allaocated in the target region is modified and used to compute
+! result in device envioronment. Result is copied back to the host and checked
+! with computed value on host.
+!
+!/===----------------------------------------------------------------------===//
+
+#include "ompvv.F90"
+
+#define N 1024
+
+PROGRAM test_uses_allocators_thread
+
+  USE iso_fortran_env
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+
+  OMPVV_TEST_VERBOSE(test_target() .ne. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION test_target()
+    INTEGER,DIMENSION(N):: device_result, host_result
+    INTEGER:: x, errors, i
+    errors = 0
+    x = 0
+
+    DO i = 1, N
+       host_result(i) = 3*i
+       device_result(i) = 0
+    END DO
+
+    !$omp target teams distribute uses_allocators(omp_thread_mem_alloc) allocate(omp_thread_mem_alloc: x) private(x) map(from: device_result)
+    DO i = 1, N
+       x = 2*i
+       device_result(i) = i + x
+    END DO
+
+    DO i = 1, N
+       OMPVV_TEST_AND_SET_VERBOSE(errors, host_result(i) .ne. device_result(i))
+    END DO
+
+    test_target = errors
+  END FUNCTION test_target
+END PROGRAM test_uses_allocators_thread

--- a/tests/5.0/target/test_target_uses_allocators_thread.F90
+++ b/tests/5.0/target/test_target_uses_allocators_thread.F90
@@ -1,4 +1,4 @@
-!/===--- test_target_uses_allocators_thread.c -----------------------------===//
+!/===--- test_target_uses_allocators_thread.F90 ---------------------------===//
 !
 ! OpenMP API Version 5.0 Nov 2018
 !

--- a/tests/5.0/target/test_target_uses_allocators_thread.c
+++ b/tests/5.0/target/test_target_uses_allocators_thread.c
@@ -2,8 +2,8 @@
 //
 // OpenMP API Version 5.0 Nov 2018
 //
-// The tests checks the uses_allocators clause with omp_thread_mem_alloc. 
-// The variable allaocated in the target region is modified and used to compute 
+// The tests checks the uses_allocators clause with omp_thread_mem_alloc.
+// The variable allaocated in the target region is modified and used to compute
 // result. Result is copied back to the host and checked with computed value on host.
 //
 //===----------------------------------------------------------------------===//
@@ -44,9 +44,8 @@ int main() {
   OMPVV_TEST_OFFLOADING;
 
   int errors = 0;
-  
+
   OMPVV_TEST_AND_SET_VERBOSE(errors, test_uses_allocators_thread() != 0);
 
   OMPVV_REPORT_AND_RETURN(errors);
 }
-


### PR DESCRIPTION
These do not compile on either of the Summit Fortran compilers