### PR TITLE
New use_device_addr test in Fortran 5.0

### DIFF
--- a/tests/5.0/target_data/test_target_data_use_device_addr.F90
+++ b/tests/5.0/target_data/test_target_data_use_device_addr.F90
@@ -1,4 +1,4 @@
-!/===-- test_target_data_use_device_addr.c --------------------------------===//
+!/===-- test_target_data_use_device_addr.F90 ------------------------------===//
 !
 ! OpenMP API Version 5.0 Nov 2018
 !

--- a/tests/5.0/target_data/test_target_data_use_device_addr.F90
+++ b/tests/5.0/target_data/test_target_data_use_device_addr.F90
@@ -1,0 +1,60 @@
+!/===-- test_target_data_use_device_addr.c --------------------------------===//
+!
+! OpenMP API Version 5.0 Nov 2018
+!
+! This file is a test for the use_device_addr when used with the map
+! clause with target data directive. This test uses a scalar and an array
+! of size N which values are modified on the  device and tested in the
+! host. List items that appear in a use_device_addr clause have the address
+! of the corresponding object in the device data environment inside the
+! construct. This test also tests that address conversions of
+! use_device_addr clauses will occur as if performed after all variables
+! are mapped according to those map clauses.
+!
+!/===----------------------------------------------------------------------===//
+
+#include "ompvv.F90"
+
+#define N 1024
+
+PROGRAM test_target_data_use_device_addr
+  USE iso_c_binding
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+  OMPVV_TEST_OFFLOADING
+
+  OMPVV_TEST_VERBOSE(use_device_addr() .ne. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  SUBROUTINE run_target_region(device_data, device_out)
+    INTEGER,TARGET:: device_data(:), device_out(:)
+
+    !$omp target is_device_ptr(device_data, device_out)
+    device_out(1) = device_data(1)*N
+    !$omp end target
+
+  END SUBROUTINE run_target_region
+  INTEGER FUNCTION use_device_addr()
+    INTEGER:: errors, host_data
+    INTEGER,TARGET:: device_data, device_out
+    INTEGER,POINTER:: device_data_ptr(:), device_out_ptr(:)
+
+    errors = 0
+    device_data = N
+    host_data = N*N
+
+    !$omp target data map(to: device_data) map(from: device_out) use_device_addr(device_data, device_out)
+    call c_f_pointer(c_loc(device_data), device_data_ptr, shape=[1])
+    call c_f_pointer(c_loc(device_out), device_out_ptr, shape=[1])
+
+    call run_target_region(device_data_ptr, device_out_ptr)
+    !$omp end target data
+
+    OMPVV_TEST_AND_SET_VERBOSE(errors, device_out .ne. host_data)
+
+    use_device_addr = errors
+  END FUNCTION use_device_addr
+END PROGRAM test_target_data_use_device_addr

--- a/tests/5.0/target_data/test_target_data_use_device_addr.c
+++ b/tests/5.0/target_data/test_target_data_use_device_addr.c
@@ -1,14 +1,16 @@
-//===-- test_target_data_use_device_addr.c - test of use_device_addr on target data ----===//
-// 
+//===-- test_target_data_use_device_addr.c --------------------------------===//
+//
 // OpenMP API Version 5.0 Nov 2018
-// 
+//
 // This file is a test for the use_device_addr when used with the map
-// clause with target data directive. This test uses a scalar and an array of size N 
-// which values are modified on the  device and tested in the host. 
-// List items that appear in a use_device_addr clause have the address 
-// of the corresponding object in the device data environment inside the construct. 
-// This test also tests that address conversions of use_device_addr clauses will 
-// occur as if performed after all variables are mapped according to those map clauses.
+// clause with target data directive. This test uses a scalar and an array
+// of size N which values are modified on the  device and tested in the
+// host. List items that appear in a use_device_addr clause have the address
+// of the corresponding object in the device data environment inside the
+// construct. This test also tests that address conversions of
+// use_device_addr clauses will occur as if performed after all variables
+// are mapped according to those map clauses.
+//
 //===----------------------------------------------------------------------===//
 
 #include <omp.h>
@@ -24,31 +26,29 @@ int main() {
   OMPVV_TEST_OFFLOADING;
 
 #pragma omp target data map(to: device_data)
-    {
-        int *dev_ptr;
+  {
+    int *dev_ptr;
 #pragma omp target data use_device_addr(device_data)
-      {
-          dev_ptr = &device_data;
-      }
+    {
+      dev_ptr = &device_data;
+    }
 #pragma omp target map(to:device_data) map(tofrom: errors) map(from: host_data) is_device_ptr(dev_ptr)
-      {
-          if(&device_data != dev_ptr)
-            errors++;
-        
-      } // end target
+    {
+      if(&device_data != dev_ptr) {
+        errors++;
+      }
+    } // end target
 
 #pragma omp target map(from: host_data) is_device_ptr(dev_ptr)
-      {
-        host_data = *dev_ptr;
-      }
+    {
+      host_data = *dev_ptr;
+    }
 
-    } // end target data
+  } // end target data
 
 
   // checking results
   OMPVV_TEST_AND_SET(errors, host_data != 14);
 
-  
   OMPVV_REPORT_AND_RETURN(errors);
-
 }

--- a/tests/5.0/target_data/test_target_data_use_device_ptr.c
+++ b/tests/5.0/target_data/test_target_data_use_device_ptr.c
@@ -1,15 +1,16 @@
-//===-- test_target_data_use_device_ptr.c - test of use_device_ptr on target data ----===//
-// 
+//===-- test_target_data_use_device_ptr.c ---------------------------------===//
+//
 // OpenMP API Version 5.0 Nov 2018
-// 
-// This file is a test for the use_device_ptr when used with the map
-// clause with target data directive. This test uses arrays of size N 
-// which values are modified on the  device and tested in the host. 
-// Once the array has been mapped to the device, the use_device_ptr should 
-// be able to be used with the ptr to the array and 
-// subsequent modify values on the device.
-// This test focuses on address conversions of use_device_ptr clauses will 
-// occur as if performed after all variables are mapped according to those map clauses.
+//
+// This file is a test for the use_device_ptr when used with the map clause
+// with target data directive. This test uses arrays of size N which values
+// are modified on the  device and tested in the host. Once the array has
+// been mapped to the device, the use_device_ptr should be able to be used
+// with the ptr to the array and subsequent modify values on the device.
+// This test focuses on address conversions of use_device_ptr clauses will
+// occur as if performed after all variables are mapped according to those
+// map clauses.
+//
 //===----------------------------------------------------------------------===//
 
 #include <omp.h>
@@ -39,7 +40,7 @@ int main() {
       {
         for (int i = 0; i < N; ++i) {
           array_host[i] += *(array_device + i);
-        } 
+        }
       } // end target
     } // end target data
 
@@ -50,7 +51,7 @@ int main() {
 
   free(array_device);
   free(array_host);
-  
+
   OMPVV_REPORT_AND_RETURN(errors);
 
 }


### PR DESCRIPTION
This is a completely redesigned test for the use_device_addr clause on the target data construct for OpenMP 5.0 in Fortran. 

Thanks to @tob2 for pointing us to the GCC testcase which shows how to correctly use this feature in 5.0, working around the spec restrictions on `is_device_ptr` by converting the scalars to C addresses and then to one-element arrays.

It currently compiles and passes on the latest gfortran version on Summit. It will not compile with XLF.