### PR TITLE
Fix mapping for test_loop_collapse_device.c

### DIFF
--- a/tests/5.0/loop/test_loop_collapse_device.c
+++ b/tests/5.0/loop/test_loop_collapse_device.c
@@ -34,7 +34,7 @@ int test_collapse1() {
     }
   }
 
-#pragma omp target parallel num_threads(OMPVV_NUM_THREADS_DEVICE) map(tofrom: a, b)
+#pragma omp target parallel num_threads(OMPVV_NUM_THREADS_DEVICE) map(tofrom: a[:N][:N], b[:N][:N+1])
   {
 #pragma omp loop collapse(1)
     for (int x = 0; x < N; ++x) {
@@ -76,7 +76,7 @@ int test_collapse2() {
     }
   }
 
-#pragma omp target parallel num_threads(OMPVV_NUM_THREADS_DEVICE) map(tofrom: a, b, num_threads)
+#pragma omp target parallel num_threads(OMPVV_NUM_THREADS_DEVICE) map(tofrom: a[:N][:N][:N], b[:N][:N][:N+1], num_threads)
   {
     if (omp_get_thread_num() == 0) {
       num_threads = omp_get_num_threads();


### PR DESCRIPTION
OpenMP 5.1 has: "A variable that is of type pointer, but not a function
pointer or (for C++) a pointer to a member function, is treated as if it
is the base pointer of a zero-length array section that had appeared as
a list item in a map clause."

However, the code relies on mapping more than a zero-length array or
only the pointer.

* tests/5.0/loop/test_loop_collapse_device.c (test_collapse1, test_collapse2):
  Actually map the whole array and not just a zero-length one.

NOTE: An alternative variant would be for `test_collapse1` (similar for the other function):
`a[:N],b[:N]` instead of `a[:N][:N],b[:N][:N+1]`