### PR TITLE
5.0 Fortran tests of task affinity

### DIFF
--- a/tests/5.0/task/test_task_affinity.F90
+++ b/tests/5.0/task/test_task_affinity.F90
@@ -1,0 +1,61 @@
+!/===-- test_task_affinity.F90 --------------------------------------------===//
+!
+! OpenMP API Version 5.0 Nov 2018
+!
+! This is a test of the affinity clause on a task construct. The affinity
+! clause indicates to the compiler that the task should execute physically
+! near to the memory location of the list items in the clause. This test
+! checks that the affinity clause can be used in the appropriate context
+! of a task construct but cannot guarantee that the compiler provides any
+! exact semantics for the clause.
+!
+!/===----------------------------------------------------------------------===//
+
+#include "ompvv.F90"
+
+#define N 1024
+
+PROGRAM test_task_affinity
+  USE iso_c_binding
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+  OMPVV_TEST_OFFLOADING
+
+  OMPVV_TEST_VERBOSE(run_tasks() .ne. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION run_tasks()
+    INTEGER:: errors, i
+    INTEGER,ALLOCATABLE:: A(:), B(:)
+
+    allocate(A(N))
+    DO i = 1, N
+       A(i) = 0
+    END DO
+
+    !$omp task depend(out: B) shared(B) affinity(A)
+    allocate(B(N))
+    DO i = 1, N
+       B(i) = A(i)
+    END DO
+    !$omp end task
+
+    !$omp task depend(in: B) shared(B) affinity(A)
+    DO i = 1, N
+       B(i) = i*2
+    END DO
+    !$omp end task
+
+    !$omp taskwait
+
+    DO i = 1, N
+       OMPVV_TEST_AND_SET_VERBOSE(errors, B(i) .ne. i*2)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, A(i) .ne. 0)
+    END DO
+
+    run_tasks = errors
+  END FUNCTION run_tasks
+END PROGRAM test_task_affinity

--- a/tests/5.0/task/test_task_affinity.F90
+++ b/tests/5.0/task/test_task_affinity.F90
@@ -30,6 +30,8 @@ CONTAINS
     INTEGER:: errors, i
     INTEGER,ALLOCATABLE:: A(:), B(:)
 
+    errors = 0
+
     allocate(A(N))
     DO i = 1, N
        A(i) = 0

--- a/tests/5.0/task/test_task_affinity.F90
+++ b/tests/5.0/task/test_task_affinity.F90
@@ -33,12 +33,12 @@ CONTAINS
     errors = 0
 
     allocate(A(N))
+    allocate(B(N))
     DO i = 1, N
-       A(i) = 0
+       A(i) = i
     END DO
 
     !$omp task depend(out: B) shared(B) affinity(A)
-    allocate(B(N))
     DO i = 1, N
        B(i) = A(i)
     END DO
@@ -46,7 +46,7 @@ CONTAINS
 
     !$omp task depend(in: B) shared(B) affinity(A)
     DO i = 1, N
-       B(i) = i*2
+       B(i) += A(i) 
     END DO
     !$omp end task
 
@@ -54,7 +54,6 @@ CONTAINS
 
     DO i = 1, N
        OMPVV_TEST_AND_SET_VERBOSE(errors, B(i) .ne. i*2)
-       OMPVV_TEST_AND_SET_VERBOSE(errors, A(i) .ne. 0)
     END DO
 
     run_tasks = errors

--- a/tests/5.0/task/test_task_affinity.F90
+++ b/tests/5.0/task/test_task_affinity.F90
@@ -46,7 +46,7 @@ CONTAINS
 
     !$omp task depend(in: B) shared(B) affinity(A)
     DO i = 1, N
-       B(i) += A(i) 
+       B(i) = B(i) + A(i)
     END DO
     !$omp end task
 

--- a/tests/5.0/task/test_task_affinity_device.F90
+++ b/tests/5.0/task/test_task_affinity_device.F90
@@ -52,7 +52,7 @@ CONTAINS
 
     !$omp task depend(in: B) shared(B) affinity(A)
     DO i = 1, N
-       B(i) += A(i)
+       B(i) = B(i) + A(i)
     END DO
     !$omp end task
 

--- a/tests/5.0/task/test_task_affinity_device.F90
+++ b/tests/5.0/task/test_task_affinity_device.F90
@@ -32,6 +32,8 @@ CONTAINS
     INTEGER:: errors, i, t
     INTEGER,ALLOCATABLE:: A(:), B(:)
 
+    errors = 0
+
     t = omp_get_default_device()
 
     allocate(A(N))


### PR DESCRIPTION
These follow the format of the C tests of the feature. They do not compile with any available Summit compiler. I'm not as sure about the way the arrays are allocated and mapped in the device version of this test, so any feedback is appreciated.