### PR TITLE
Add test of parallel reduction nested in C from issue #90

### DIFF
--- a/tests/5.0/parallel/test_parallel_reduction_nested.c
+++ b/tests/5.0/parallel/test_parallel_reduction_nested.c
@@ -1,0 +1,36 @@
+//===--- test_parallel_reduction_nested.c -----------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// This is a simple test of the parallel directive with a reduction clause
+// nested within the same, and offloaded to the device. Thanks to Kelvin Li
+// for providing this test.
+//
+////===----------------------------------------------------------------------===//
+#include <assert.h>
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+int main() {
+  int errors = 0;
+  int t = -1;
+
+  OMPVV_TEST_OFFLOADING;
+
+#pragma omp target teams map(tofrom: t)
+  {
+#pragma omp parallel reduction(+: t)
+    {
+#pragma omp parallel reduction(+: t)
+      {
+        t = 1;
+      }
+    }
+  }
+
+  OMPVV_TEST_AND_SET_VERBOSE(errors, t != 1);
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}


### PR DESCRIPTION
See issue #90. This is a test of the parallel construct with a reduction clause nested within a parallel construct with a reduction clause. Here are the results per compiler:

Clang:
```
/tmp/test_parallel_reduction_nested-d6a240.o: In function `main':
test_parallel_reduction_nested.c:(.text+0x3c): undefined reference to `omp_is_initial_device'
/usr/bin/ld: link errors found, deleting executable `bin/test_parallel_reduction_nested.c.o'
clang-13: error: linker command failed with exit code 1 (use -v to see invocation)
```

GCC:
```
test_parallel_reduction_nested.c.o:
[OMPVV_INFO: test_parallel_reduction_nested.c:20] Test is running on device.

libgomp: cuCtxSynchronize error: an illegal instruction was encountered

libgomp: cuMemFree_v2 error: an illegal instruction was encountered

libgomp: device finalization failed
```

XL:
```
test_parallel_reduction_nested.c.o:
[OMPVV_ERROR: test_parallel_reduction_nested.c:33]  Condition t != 1 failed 
[OMPVV_INFO: test_parallel_reduction_nested.c:20] Test is running on device.
[OMPVV_INFO: test_parallel_reduction_nested.c:35] The value of errors is 1.
[OMPVV_RESULT: test_parallel_reduction_nested.c] Test failed on the device.
```

Closes #90.