### PR TITLE
Add test of parallel reduction with two elements of the same array from issue #151

### DIFF
--- a/tests/5.0/parallel_reduction/test_parallel_reduction_multiple_array_elements.c
+++ b/tests/5.0/parallel_reduction/test_parallel_reduction_multiple_array_elements.c
@@ -1,0 +1,38 @@
+//===--- test_parallel_reduction_nested.c -----------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// This is a simple test of the parallel directive with a reduction clause
+// which performs a reduction on two different elements of the same array,
+// in an offloaded region.
+//
+////===----------------------------------------------------------------------===//
+#include <assert.h>
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+static double temps[2];
+
+int main() {
+  int errors = 0;
+
+  OMPVV_TEST_OFFLOADING;
+
+  temps[0] = 0;
+  temps[1] = 0;
+
+#pragma omp target map(tofrom: temps)
+  {
+#pragma omp parallel reduction(+:temps[0], temps[1])
+    {
+      temps[0] += 1;
+      temps[1] += 1;
+    }
+  }
+
+  OMPVV_TEST_AND_SET_VERBOSE(errors, temps[0] != 1 || temps[1] != 1);
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}


### PR DESCRIPTION
See issue #151. This is a simple test of a reduction on the device with two array elements from the same array. Here are the per-compiler results:

Clang:
```
/tmp/test_parallel_reduction_nested-d6a240.o: In function `main':
test_parallel_reduction_nested.c:(.text+0x3c): undefined reference to `omp_is_initial_device'
/usr/bin/ld: link errors found, deleting executable `bin/test_parallel_reduction_nested.c.o'
clang-13: error: linker command failed with exit code 1 (use -v to see invocation)
```

GCC:
```
/autofs/nccs-svm1_home1/jhdavis/sollve-project/sollve_vv/tests/5.0/parallel_reduction/test_parallel_reduction_multiple_array_elements.c: In function 'main':
/autofs/nccs-svm1_home1/jhdavis/sollve-project/sollve_vv/tests/5.0/parallel_reduction/test_parallel_reduction_multiple_array_elements.c:28:31: error: 'temps' appears more than once in data clauses
   28 | #pragma omp parallel reduction(+:temps[0], temps[1])
      |                               ^
```

XL:
```
/autofs/nccs-svm1_home1/jhdavis/sollve-project/sollve_vv/tests/5.0/parallel_reduction/test_parallel_reduction_multiple_array_elements.c:28:44: error: variable can appear only once in OpenMP 'reduction' clause
#pragma omp parallel reduction(+:temps[0], temps[1])
                                           ^
/autofs/nccs-svm1_home1/jhdavis/sollve-project/sollve_vv/tests/5.0/parallel_reduction/test_parallel_reduction_multiple_array_elements.c:28:34: note: previously referenced here
#pragma omp parallel reduction(+:temps[0], temps[1])
                                 ^
```

Closes #151.