### PR TITLE
Adding test_target_enter_exit_data_depend.F90 per issue #81

### DIFF
--- a/tests/4.5/target_enter_data/test_target_enter_data_allocate_array_to.F90
+++ b/tests/4.5/target_enter_data/test_target_enter_data_allocate_array_to.F90
@@ -1,11 +1,11 @@
-!===--test_target_enter_data_allocate_array_to.F90 - allocate array map to--===!
+!===--test_target_enter_data_allocate_array_to.F90 - allocate array map to ---===!
 ! 
 ! OpenMP API Version 4.5 Nov 2015
 !
 ! Testing the mapping of arrays that are allocated dynamically. This tests
 ! covers multiple array dimmensions and uses target enter data map(to) 
 !
-!!===----------------------------------------------------------------------===!
+!===--------------------------------------------------------------------------===!
 #include "ompvv.F90"
 
 #define N 20
@@ -23,16 +23,9 @@
         INTEGER, DIMENSION(N,N) :: my2DArr
         INTEGER, DIMENSION(N,N,N) :: my3DArr
         ! Helper functions
-        LOGICAL :: isSharedEnv
-        CHARACTER (len = 400) :: helperMsg
         INTEGER :: errors, i
       
         OMPVV_TEST_OFFLOADING
-        OMPVV_TEST_AND_SET_SHARED_ENVIRONMENT(isSharedEnv)
-
-        WRITE(helperMsg, *) "Omitting part of the test due to &
-          &shared data environment"
-        OMPVV_WARNING_IF(isSharedEnv, helperMsg)
 
         OMPVV_TEST_VERBOSE(test_allocate_array1D_map_to() .ne. 0)
         OMPVV_TEST_VERBOSE(test_allocate_array2D_map_to() .ne. 0)
@@ -56,22 +49,11 @@
             ! Mapping the array
             !$omp target enter data map(to: my1DPtr(:))
 
-            ! make sure it does not get mapped again
-            IF (.NOT. isSharedEnv) THEN
-              my1DPtr(:) = 10
-            END IF
- 
             ! Confirm mapping with target region
             !$omp target map(tofrom: my1DArr) 
               my1DArr = my1DPtr
             !$omp end target
 
-            ! This is not part of the test but it is necessary to avoid
-
-            ! Make sure it is not copied back
-            IF (.NOT. isSharedEnv) THEN
-              OMPVV_TEST_AND_SET_VERBOSE(errors, ANY(my1DPtr /= 10))
-            END IF
             OMPVV_TEST_AND_SET_VERBOSE(errors, SUM(my1DArr) /= ((N*(N+1)/2)))
             ! having memory leaks
             !$omp target exit data map(delete: my1DPtr(:))
@@ -93,20 +75,11 @@
             ! Mapping the array
             !$omp target enter data map(to: my2DPtr(:,:))
 
-            ! make sure it does not get mapped again
-            IF (.NOT. isSharedEnv) THEN
-              my2DPtr(:,:) = 10
-            END IF
- 
             ! Confirm mapping with target region
             !$omp target map(from: my2DArr) 
               my2DArr = my2DPtr
             !$omp end target
 
-            ! Make sure it is not copied back
-            IF (.NOT. isSharedEnv) THEN
-              OMPVV_TEST_AND_SET_VERBOSE(errors, ANY(my2DPtr /= 10))
-            END IF
             OMPVV_TEST_AND_SET_VERBOSE(errors, SUM(my2DArr) /= ((N**2*(N**2+1)/2)))
 
             ! Mapping the array
@@ -129,20 +102,11 @@
             ! Mapping the array
             !$omp target enter data map(to: my3DPtr(:,:,:))
 
-            ! make sure it does not get mapped again
-            IF (.NOT. isSharedEnv) THEN
-              my3DPtr(:,:,:) = 10
-            END IF
- 
             ! Confirm mapping with target region
             !$omp target map(from: my3DArr) 
               my3DArr = my3DPtr
             !$omp end target
 
-            ! Make sure it is not copied back
-            IF (.NOT. isSharedEnv) THEN
-              OMPVV_TEST_AND_SET_VERBOSE(errors, ANY(my3DPtr /= 10))
-            END IF
             OMPVV_TEST_AND_SET_VERBOSE(errors, SUM(my3DArr) /= (N**6+N**3)/2)
 
             ! Mapping the array

--- a/tests/4.5/target_enter_exit_data/test_target_enter_exit_data_depend.F90
+++ b/tests/4.5/target_enter_exit_data/test_target_enter_exit_data_depend.F90
@@ -1,0 +1,121 @@
+!===--- test_target_enter_exit_data_depend.F90 ------------------------------===//
+!
+! OpenMP API Version 4.5 Nov 2015
+! 
+! This test checks functionality of target enter data and target exit
+! data to depend 'in' and 'out' using two separate functions. The first
+! function test_async_between_task_target() mixes host-based tasks with
+! target-based tasks, while the second function test_async_between_target() 
+! is testing for target enter exit data to depend 'in' and 'out' respectively,
+! while also checking that a nowait clause can be used to ensure asynchronous
+! behavior. 
+!
+!===-------------------------------------------------------------------------===//
+
+#include "ompvv.F90"
+
+#define N 1024
+
+PROGRAM test_target_enter_exit_data_depend
+   USE iso_fortran_env
+   USE ompvv_lib
+   USE omp_lib
+   implicit none
+
+   OMPVV_TEST_OFFLOADING
+
+   OMPVV_TEST_VERBOSE(test_async_between_task_target() .ne. 0)
+   OMPVV_TEST_VERBOSE(test_async_between_target() .ne. 0) 
+   
+   OMPVV_REPORT_AND_RETURN()
+
+   CONTAINS 
+      INTEGER FUNCTION test_async_between_task_target()
+         INTEGER :: errors, i
+         REAL :: summation
+         REAL, TARGET, DIMENSION(N) :: compute_array, in_1, in_2
+         REAL, POINTER, DIMENSION(:) :: h_array, in_1_ptr, in_2_ptr
+         compute_array(:) = 0
+         in_1(:) = 0
+         in_2(:) = 0
+         h_array => compute_array
+         in_1_ptr => in_1
+         in_2_ptr => in_2
+        
+         errors = 0
+         summation = 0.0
+         !$omp task depend(out: in_1_ptr) shared(in_1_ptr)
+            DO i = 1, N
+               in_1_ptr(i) = 1
+            END DO
+         !$omp end task
+
+         !$omp task depend(out: in_2_ptr) shared(in_2_ptr)
+            DO i = 1, N
+               in_2_ptr(i) = 2
+            END DO
+         !$omp end task
+
+         !$omp target enter data map(alloc: h_array) map(to: in_1_ptr)&
+         !$omp& map(to: in_2_ptr) depend(out: h_array) depend(in: in_1_ptr) depend(in: in_2_ptr)
+         
+         !$omp task shared (h_array, in_1_ptr, in_2_ptr) depend(inout: h_array) depend(in: in_1_ptr) depend(in: in_2_ptr)
+            !$omp target
+               DO i = 1, N
+                  h_array(i) = in_1_ptr(i) * in_2_ptr(i)
+               END DO
+            !$omp end target
+         !$omp end task
+ 
+         !$omp target exit data map(from: h_array) depend(inout: h_array)
+ 
+         !$omp task depend(in: h_array) shared(summation, h_array)
+            !---checking results---!
+            DO i = 1, N 
+               summation = summation + compute_array(i)
+            END DO
+         !$omp end task
+         
+         !$omp taskwait
+
+         OMPVV_TEST_AND_SET(errors, 2.0*N .ne. summation)
+
+         test_async_between_task_target = errors
+      END FUNCTION test_async_between_task_target
+
+      INTEGER FUNCTION test_async_between_target()
+         INTEGER :: errors, i, summation, val
+         INTEGER, TARGET, DIMENSION(N) :: compute_array
+         INTEGER, POINTER, DIMENSION(:) :: h_array2
+         compute_array(:) = 0
+         h_array2 => compute_array
+         errors = 0
+         summation = 0
+         val = 2
+
+         !$omp target enter data map(alloc: h_array2) depend(out: h_array2)
+
+         !$omp target enter data map(to: val) depend(out: val)
+ 
+         !$omp target depend(inout: h_array2) depend(in: val)
+            DO i = 1, N
+               h_array2(i) = val
+            END DO
+         !$omp end target
+         
+         !$omp target exit data map(from: h_array2) depend(in: h_array2)
+
+         !$omp taskwait
+           
+         !---checking results---!
+         DO i = 1, N
+            summation = summation + compute_array(i)
+         END DO
+
+         OMPVV_TEST_AND_SET(errors, 2*N .ne. summation)
+
+         test_async_between_target = errors
+      
+      END FUNCTION test_async_between_target
+         
+END PROGRAM test_target_enter_exit_data_depend

--- a/tests/4.5/target_enter_exit_data/test_target_enter_exit_data_depend.c
+++ b/tests/4.5/target_enter_exit_data/test_target_enter_exit_data_depend.c
@@ -119,7 +119,8 @@ int test_async_between_target() {
   for (int i = 0; i < N; ++i) {
     sum += h_array[i];
   }
-  errors = 2*N != sum;
+  
+  OMPVV_TEST_AND_SET(errors, 2*N != sum);
 
   return errors;
 }


### PR DESCRIPTION
The two integer functions defined in this test pass when called individually, however, a segmentation error occurs when both are called in the same program.

All tests pass with gcc/11.1.0 on summit