### PR TITLE
Fix testcase: test_target_enter_data_global_array.c: #include "ompvv.h" was missing

### DIFF
--- a/tests/4.5/target_enter_data/test_target_enter_data_global_array.c
+++ b/tests/4.5/target_enter_data/test_target_enter_data_global_array.c
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <omp.h>
+#include "ompvv.h"
 
 // Test for OpenMP 4.5 target enter data with global arrays.
 


### PR DESCRIPTION
* tests/4.5/target_enter_data/test_target_enter_data_global_array.c:
  Add missing '#include "ompvv.h"'.