### PR TITLE
test_capture_omp_affinity.c: Init 'errors' var

### DIFF
--- a/tests/5.0/program_control/test_capture_omp_affinity.c
+++ b/tests/5.0/program_control/test_capture_omp_affinity.c
@@ -34,6 +34,7 @@ int main() {
    for (i = 0; i < n; i++) { 
       buffer[i]=(char *)malloc( sizeof(char) * BUFFER_STORE); 
    }
+   errors = 0;
    max_req_store = 0;
 
    #pragma omp parallel private(thrd_num,nchars) reduction(max:max_req_store)


### PR DESCRIPTION
* tests/5.0/program_control/test_capture_omp_affinity.c (main):
  Initialize 'errors' variable to 0.

As  `OMPVV_TEST_AND_SET_VERBOSE` uses `+=`, this gave spurious fails due to the uninitialized memory.