### PR TITLE
Fix for test test_target_teams_distribute_reduction_bitand.F90

### DIFF
--- a/tests/5.0/target_teams_distribute/test_target_teams_distribute_reduction_bitand.F90
+++ b/tests/5.0/target_teams_distribute/test_target_teams_distribute_reduction_bitand.F90
@@ -47,7 +47,7 @@ CONTAINS
        CALL RANDOM_NUMBER(randoms)
        DO x = 1, N
           a(x) = 0
-          DO y = 1, 32
+          DO y = 1, 16
              IF (randoms(x, y) .lt. false_margin) THEN
                 a(x) = a(x) + (2**y)
                 tested_true = .TRUE.
@@ -59,7 +59,7 @@ CONTAINS
 
        result = 0
        host_result = 0
-       DO y = 1, 32
+       DO y = 1, 16
           result = result + (2**y)
           host_result = host_result + (2**y)
        END DO


### PR DESCRIPTION
This test has the same issue as its 4.5 version, see https://github.com/SOLLVE/sollve_vv/issues/380