### PR TITLE
Issue 393: Fix restriction violations on test_target_device.c

### DIFF
--- a/tests/5.0/target/test_target_device.c
+++ b/tests/5.0/target/test_target_device.c
@@ -15,6 +15,9 @@
 
 #define N 1028
 
+// Required for 'device(ancestor: 1)
+#pragma omp requires reverse_offload
+
 int test_target_device_ancestor() {
 
     int i, which_device;
@@ -36,12 +39,15 @@ int test_target_device_ancestor() {
 	    for (int i = 0; i < N; i++) {
                 a[i] = a[i] + 2;
 	    }
-	
-	    which_device = omp_is_initial_device();
+	    // We like to use omp_is_initial_device(), but for ancestor:
+	    // "No OpenMP constructs or calls to OpenMP API runtime routines are allowed"
+	    // Thus, settle on the following. Note: With unified-shared memory, it is
+	    // not actually testing that this target region is executed on the initial device.
+	    which_device = 42;
 	}
     }
 
-    OMPVV_TEST_AND_SET(errors, which_device != 1);
+    OMPVV_TEST_AND_SET(errors, which_device != 42);
     OMPVV_ERROR_IF(which_device != 1, "Target region was executed on device. Due to ancestor device-modifier,"
                                          "this region should execute on host");
 

--- a/tests/5.0/target/test_target_device.c
+++ b/tests/5.0/target/test_target_device.c
@@ -39,15 +39,12 @@ int test_target_device_ancestor() {
 	    for (int i = 0; i < N; i++) {
                 a[i] = a[i] + 2;
 	    }
-	    // We like to use omp_is_initial_device(), but for ancestor:
-	    // "No OpenMP constructs or calls to OpenMP API runtime routines are allowed"
-	    // Thus, settle on the following. Note: With unified-shared memory, it is
-	    // not actually testing that this target region is executed on the initial device.
-	    which_device = 42;
+	    // For ancestor, the spec mandates: "No OpenMP constructs or calls to
+	    // OpenMP API runtime routines are allowed":
+	    // which_device = omp_is_initial_device();
 	}
     }
 
-    OMPVV_TEST_AND_SET(errors, which_device != 42);
     OMPVV_ERROR_IF(which_device != 1, "Target region was executed on device. Due to ancestor device-modifier,"
                                          "this region should execute on host");
 


### PR DESCRIPTION
Issue #393
* tests/5.0/target/test_target_device.c: Add 'requires reverse_offload'
  required by 'device(ancestor:)' + avoid using an OpenMP runtime
  routine inside that target region.

@spophale , @tmh97, @jhdavis8 – please review.

Cf. OpenMP 5.0 spec, 11th bullet point under 'Restrictions' in '2.12.5  target Construct':
https://www.openmp.org/spec-html/5.0/openmpsu60.html#x86-2880002.12.5