### PR TITLE
test_atomic_compare.c: Init pmax variable

### DIFF
--- a/tests/5.1/atomic/test_atomic_compare.c
+++ b/tests/5.1/atomic/test_atomic_compare.c
@@ -20,7 +20,7 @@ int test_atomic_compare() {
 
   int arr[N];
   int errors = 0;
-  int pmax, max = 0;
+  int pmax = 0, max = 0;
 
    for(int i=0; i<N; i++){
       arr[i] = rand()%1000;


### PR DESCRIPTION
* tests/5.1/atomic/test_atomic_compare.c (test_atomic_compare):
  init pmax variable to 0.

Here, I got spurious fails, where pmax = 32756 and max = 996 – when pmax uninitialized value happened to be >max. As `max` is initialized to 0, do the same for pmax.

@spophale, @tmh97, @nolanbaker31, @jhdavis8 – please review. Thanks!