### PR TITLE
declare target directive requires at least one `to` or `link` clause

### DIFF
--- a/tests/5.0/declare_target/test_declare_target_device_type_nohost.c
+++ b/tests/5.0/declare_target/test_declare_target_device_type_nohost.c
@@ -21,6 +21,7 @@
 int errors = 0;
 
 void target_function();
+#pragma omp declare target to(target_function) device_type(nohost)
 
 #pragma omp declare target
 int a[N], b[N], c[N];  
@@ -36,7 +37,6 @@ void update() {
   }
 }
 
-#pragma omp declare target device_type(nohost)
 void target_function(){
   for (i = 0; i < N; i++) {
     a[i] += 1;


### PR DESCRIPTION
OpenMP 5.1 adds the following restriction:
> If the directive has a clause, it must contain at least one `to` clause or
> at least one `link` clause.

This restriction doesn't exist in OpenMP 5.0, but without a `to` clause
this test probably doesn't mean quite what it is supposed to:
> The form of the `declare target` directive that has no clauses and requires
> a matching `end declare target` directive defines an implicit _extended-list_
> to an implicit `to` clause.

Because the `declare target` directive in the test has a `device_type`
clause (and no `end declare target directive`), it is not of that form and
does not have an implicit `to`. Thus, the function `target_function` can
have a host version.