### PR TITLE
Target Update w/ Motion Modifier Present

### DIFF
--- a/tests/5.1/motion/test_motion_present.c
+++ b/tests/5.1/motion/test_motion_present.c
@@ -17,35 +17,37 @@
 
 #define N 1024
 
-int errors, i;
+int errors;
+int i;
 
 int test_motion_present() {
    
+   errors = 0;
+
    struct test_struct {
      int s; 
      int S[N]; 
    }; 
 
-   int scalar; // scalar 
+   int scalar_var; // scalar 
    int A[N]; // aggregate 
    struct test_struct new_struct; // aggregate
    int *ptr; // scalar, pointer 
 
-   scalar = 1; 
+   scalar_var = 1; 
    A[0] = 0; A[50] = 50;
    new_struct.s = 10; new_struct.S[0] = 10; new_struct.S[1] = 10;
    ptr = &A[0]; 
    ptr[50] = 50; ptr[51] = 51;
 
-   #pragma omp target enter data map(alloc:scalar) map(alloc: A[N]) map(alloc: new_struct) //map(alloc: *ptr)
-   #pragma omp target update to(present) // Present means values should remain as if already declared in map as alloc
-   #pragma omp target map(tofrom: errors)
+   #pragma omp target update to(present: scalar_var, new_struct) // Only looking to test lines 5-6 on page 207
+   #pragma omp target map(tofrom: errors) defaultmap(none) //map(tofrom: errors) map(from: scalar_var, A, new_struct) 
    {     
-        if(scalar != 1){errors++;}
+        if(scalar_var != 1){errors++;}
         if(A[0] != 0 || A[50] != 50){errors++;}
         if(A[50] != 50 || A[51] != 51){errors++;}
-        if(new_struct.s != 10){errors++;}
-        if(new_struct.S[0] != 10){errors++;}
+        if(new_struct.s == 10){errors++;}
+        if(new_struct.S[0] == 10){errors++;}
    }
 
   return errors;

--- a/tests/5.1/motion/test_motion_present.c
+++ b/tests/5.1/motion/test_motion_present.c
@@ -1,0 +1,59 @@
+//===--- test_motion_present.c --------------------------------------------------------------===//
+//
+//  OpenMP API Version 5.1 Aug 2021
+//
+//  This test checks behavior of the target update clause when the specified motion-modifier  
+//  is present. The motion-clauses available for target update are to & from, and when
+//  motion-modifier 'present' is used, all variables are mapped as if they had been listed
+//  in a map clause with map-type 'alloc'.
+//
+////===-------------------------------------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+#include <math.h>
+
+#define N 1024
+
+int errors, i;
+
+int test_motion_present() {
+   
+   struct test_struct {
+     int s; 
+     int S[N]; 
+   }; 
+
+   int scalar; // scalar 
+   int A[N]; // aggregate 
+   struct test_struct new_struct; // aggregate
+   int *ptr; // scalar, pointer 
+
+   scalar = 1; 
+   A[0] = 0; A[50] = 50;
+   new_struct.s = 10; new_struct.S[0] = 10; new_struct.S[1] = 10;
+   ptr = &A[0]; 
+   ptr[50] = 50; ptr[51] = 51;
+
+   #pragma omp target enter data map(alloc:scalar) map(alloc: A[N]) map(alloc: new_struct) //map(alloc: *ptr)
+   #pragma omp target update to(present) // Present means values should remain as if already declared in map as alloc
+   #pragma omp target map(tofrom: errors)
+   {     
+        if(scalar != 1){errors++;}
+        if(A[0] != 0 || A[50] != 50){errors++;}
+        if(A[50] != 50 || A[51] != 51){errors++;}
+        if(new_struct.s != 10){errors++;}
+        if(new_struct.S[0] != 10){errors++;}
+   }
+
+  return errors;
+}
+
+int main() {
+   errors = 0;
+   OMPVV_TEST_OFFLOADING;
+   OMPVV_TEST_AND_SET_VERBOSE(errors, test_motion_present() != 0);
+   OMPVV_REPORT_AND_RETURN(errors);
+}           

--- a/tests/5.1/motion/test_motion_present.c
+++ b/tests/5.1/motion/test_motion_present.c
@@ -3,11 +3,14 @@
 //  OpenMP API Version 5.1 Aug 2021
 //
 //  This test checks behavior of the target update clause when the specified motion-modifier  
-//  is present. The motion-clauses available for target update are to & from, and when
-//  motion-modifier 'present' is used, all variables are mapped as if they had been listed
-//  in a map clause with map-type 'alloc'.
+//  is present. Tests 1. A corresponding list item and an original list item exist for each 
+//  list item in a to or from clause. If the corresponding list item is not present in the
+//  device data environment and the present modifier is not specified in the clause then no
+//  assignment occurs to or from the original list item. Also tests 2. Otherwise, each
+//  corresponding list item in the device data environment has an original list item in the
+//  current task's data environment. 
 //
-////===-------------------------------------------------------------------------------------------------===//
+////===--------------------------------------------------------------------------------------===//
 
 #include <omp.h>
 #include <stdio.h>
@@ -17,12 +20,11 @@
 
 #define N 1024
 
-int errors;
-int i;
 
 int test_motion_present() {
    
-   errors = 0;
+   int errors = 0;
+   int i;
 
    struct test_struct {
      int s; 
@@ -39,22 +41,32 @@ int test_motion_present() {
    new_struct.s = 10; new_struct.S[0] = 10; new_struct.S[1] = 10;
    ptr = &A[0]; 
    ptr[50] = 50; ptr[51] = 51;
-
-   #pragma omp target update to(present: scalar_var, new_struct) // Only looking to test lines 5-6 on page 207
-   #pragma omp target map(tofrom: errors) defaultmap(none) //map(tofrom: errors) map(from: scalar_var, A, new_struct) 
+   
+   #pragma omp target update to(scalar_var, A, new_struct) // Only looking to test lines 5-6 on page 207
+   #pragma omp target map(tofrom: errors) defaultmap(none) map(from: scalar_var, A, new_struct)
    {     
-        if(scalar_var != 1){errors++;}
-        if(A[0] != 0 || A[50] != 50){errors++;}
-        if(A[50] != 50 || A[51] != 51){errors++;}
+        if(scalar_var == 1){errors++;}
+        if(A[0] == 0 || A[50] == 50){errors++;}
+        if(A[50] == 50 || A[51] == 51){errors++;}
         if(new_struct.s == 10){errors++;}
         if(new_struct.S[0] == 10){errors++;}
    }
 
-  return errors;
+   #pragma omp target update to(present: scalar_var, A, new_struct) 
+   #pragma omp target map(tofrom: errors) defaultmap(none) map(from: scalar_var, A, new_struct)
+   {     
+        if(scalar_var != 1){errors++;}
+        if(A[0] != 0 || A[50] != 50){errors++;}
+        if(A[50] != 50 || A[51] != 51){errors++;}
+        if(new_struct.s != 10){errors++;}
+        if(new_struct.S[0] != 10){errors++;}
+   }
+   
+   return errors;
 }
 
 int main() {
-   errors = 0;
+   int errors = 0;
    OMPVV_TEST_OFFLOADING;
    OMPVV_TEST_AND_SET_VERBOSE(errors, test_motion_present() != 0);
    OMPVV_REPORT_AND_RETURN(errors);


### PR DESCRIPTION
Very rough test of motion_present 5.1 test.

Motion-modifier 'present' can be used for both to & from, **should both be used**?

Also, SPEC 5.1 (https://www.openmp.org/wp-content/uploads/OpenMP-API-Specification-5-1.pdf#page=229) lists how " For a list item that is replaced with a set of list items as a result of a user-defined mapper, the present modifier only applies to those mapper list items that share storage with the original list item." **Should this be tested or is it a minuscule case?**