### PR TITLE
Fix metadirectives testcases

### DIFF
--- a/tests/5.0/metadirective/test_metadirective_arch_is_nvidia.c
+++ b/tests/5.0/metadirective/test_metadirective_arch_is_nvidia.c
@@ -32,19 +32,19 @@ int metadirective1() {
    #pragma omp target map(to:v1,v2) map(from:v3, target_device_num) device(default_device)
    {
       #pragma omp metadirective \
-                   when(   device={arch("nvptx")}: teams loop) \
-                   default(                     parallel loop)
-
-         target_device_num = omp_get_device_num(); 
+                   when(   device={arch("nvptx")}: teams distribute parallel for) \
+                   default(                     parallel for)
 
          for (int i = 0; i < N; i++) {
+	    #pragma omp atomic write
+            target_device_num = omp_get_device_num();
             v3[i] = v1[i] * v2[i];
          }
-   } 
+   }
    
    OMPVV_TEST_AND_SET(errors, host_device_num == target_device_num);
-   OMPVV_ERROR_IF(host_device_num == target_device_num, "Device number that executes target region is"
-                                  "the same as the device number on the host");
+   OMPVV_ERROR_IF(host_device_num == target_device_num, "Device number that executes target region is "
+                                                        "the same as the device number on the host");
  
    for (int i = 0; i < N; i++) {
       OMPVV_TEST_AND_SET_VERBOSE(errors, v3[i] != v1[i] * v2[i]);

--- a/tests/5.0/metadirective/test_metadirective_arch_nvidia_or_amd.c
+++ b/tests/5.0/metadirective/test_metadirective_arch_nvidia_or_amd.c
@@ -25,7 +25,7 @@ int metadirective2() {
    }
    
    for (device_num = 0; device_num == 0 || device_num < omp_get_num_devices(); device_num++) {
-     #pragma omp target device(device_num)
+     #pragma omp target device(device_num) map(from:initial_device)
      {
        #pragma omp metadirective \
                   when( implementation={vendor(nvidia)}: \

--- a/tests/5.0/metadirective/test_metadirective_arch_nvidia_or_amd.c
+++ b/tests/5.0/metadirective/test_metadirective_arch_nvidia_or_amd.c
@@ -25,16 +25,15 @@ int metadirective2() {
    }
    
    for (device_num = 0; device_num == 0 || device_num < omp_get_num_devices(); device_num++) {
-      #pragma omp target device(device_num)
-      #pragma omp metadirective \
-                  when( implementation=vendor(nvidia): \
-                        teams num_teams(512) thread_limit(32) ) \
-                  when( implementation=vendor(amd): \
-                        teams num_teams(512) thread_limit(64) ) \
-                  default (teams)
+     #pragma omp target device(device_num)
      {
        initial_device = omp_is_initial_device();
-
+       #pragma omp metadirective \
+                  when( implementation={vendor(nvidia)}: \
+                        teams num_teams(512) thread_limit(32) ) \
+                  when( implementation={vendor(amd)}: \
+                        teams num_teams(512) thread_limit(64) ) \
+                  default (teams)
        #pragma omp distribute parallel for
          for (i = 0; i < N; i++) {
             a[i] = i;

--- a/tests/5.0/metadirective/test_metadirective_arch_nvidia_or_amd.c
+++ b/tests/5.0/metadirective/test_metadirective_arch_nvidia_or_amd.c
@@ -17,14 +17,14 @@ int errors = 0;
 
 int metadirective2() {
 
-   int i, device_num, which_device;
+   int i, device_num, initial_device;
    int a[N], total[N];
  
    for (int i = 0; i < N; i++) {
       a[i] = 0;  
    }
    
-   for (device_num = 0; device_num < omp_get_num_devices(); device_num++) {
+   for (device_num = 0; device_num == 0 || device_num < omp_get_num_devices(); device_num++) {
       #pragma omp target device(device_num)
       #pragma omp metadirective \
                   when( implementation=vendor(nvidia): \
@@ -32,17 +32,18 @@ int metadirective2() {
                   when( implementation=vendor(amd): \
                         teams num_teams(512) thread_limit(64) ) \
                   default (teams)
+     {
+       initial_device = omp_is_initial_device();
 
-      which_device = omp_is_initial_device();
-
-      #pragma omp distribute parallel for
+       #pragma omp distribute parallel for
          for (i = 0; i < N; i++) {
             a[i] = i;
          }
+     }
    }
 
-   OMPVV_TEST_AND_SET_VERBOSE(errors, which_device != 0);
-   OMPVV_ERROR_IF(which_device != 0, "NVIDIA and AMD architecture not available, ran on host");
+   OMPVV_TEST_AND_SET_VERBOSE(errors, initial_device != 0);
+   OMPVV_ERROR_IF(initial_device != 0, "NVIDIA and AMD architecture not available, ran on host");
 
    for (i = 0; i < N; i++) {
       OMPVV_TEST_AND_SET_VERBOSE(errors, a[i] != i); 
@@ -61,4 +62,3 @@ int main () {
    OMPVV_REPORT_AND_RETURN(errors);
 
 }
-                   

--- a/tests/5.0/metadirective/test_metadirective_arch_nvidia_or_amd.c
+++ b/tests/5.0/metadirective/test_metadirective_arch_nvidia_or_amd.c
@@ -27,7 +27,6 @@ int metadirective2() {
    for (device_num = 0; device_num == 0 || device_num < omp_get_num_devices(); device_num++) {
      #pragma omp target device(device_num)
      {
-       initial_device = omp_is_initial_device();
        #pragma omp metadirective \
                   when( implementation={vendor(nvidia)}: \
                         teams num_teams(512) thread_limit(32) ) \
@@ -36,6 +35,8 @@ int metadirective2() {
                   default (teams)
        #pragma omp distribute parallel for
          for (i = 0; i < N; i++) {
+            #pragma omp atomic write
+            initial_device = omp_is_initial_device();
             a[i] = i;
          }
      }


### PR DESCRIPTION
* tests/5.0/metadirective/test_metadirective_arch_is_nvidia.c:
  - Move omp_get_device_num() call inside loop.
  - Use 'for' instead of 'loop' as loop implies order(concurrent)
    which does not permit routine calls.
  - Add missing space between two words in an error message.
* tests/5.0/metadirective/test_metadirective_arch_nvidia_or_amd.c:
  - Add { } to apply metadirective also to the following loop.
  - Run device loop at least once to init a[i] also when only the
    host device is available.

As reported by a colleague, the testcases have several issues; I hope I got the fixes right.

@nolanbaker31 @spophale @tmh97  – please review.

(Rebased + force pushed: changed 'teams for' to 'teams distribute parallel for' as the nvptx as 'teams for' is not permitted.)