### PR TITLE
Issue 407: Fix 5.0/task/test_task_depend_iterator.cpp testcase

### DIFF
--- a/tests/5.0/task/test_task_depend_iterator.cpp
+++ b/tests/5.0/task/test_task_depend_iterator.cpp
@@ -37,8 +37,20 @@ int test_task_depend_iterator() {
       }
     } // end single
   } // end parallel
-  std::sort(threadOrder.begin() + 1, threadOrder.begin() + 5);
-  std::sort(threadOrder.begin() + 5, threadOrder.begin() + 7);
+
+  std::vector<int>::iterator idx[8];
+  for (int i = 0; i < 8; ++i)
+    idx[i] = std::find (threadOrder.begin(), threadOrder.end(), i);
+  if (idx[0] != threadOrder.begin())
+    threadOrderError |= true;
+  if (idx[1] > idx[5] || idx[2] > idx[5])
+    threadOrderError |= true;
+  if (idx[3] > idx[6] || idx[4] > idx[6])
+    threadOrderError |= true;
+  if (idx[5] > idx[7] || idx[5] > idx[7])
+    threadOrderError |= true;
+
+  std::sort(threadOrder.begin(), threadOrder.end());
   for(int i = 0; i < 8; ++i)
     threadOrderError = (threadOrder[i] != i) || threadOrderError;
   OMPVV_ERROR_IF(threadOrderError, "The dependencies between tasks were not enforced in the correct order.");


### PR DESCRIPTION
* tests/5.0/task/test_task_depend_iterator.cpp (test_task_depend_iterator):
  Fix check for the expected outcome.

As discussed in Issue #407:
>  Task 0 is always first, 1, 2, 3, 4 depend on it, 5 comes after 1 and 2, 6 comes after 3 and 4 and 7 comes after 5 and 6.

The patch implements this.