### PR TITLE
4.5/target_teams_distribute*: Janitorial Fortran fixes

### DIFF
--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_nowait.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_nowait.F90
@@ -44,6 +44,7 @@ CONTAINS
     DO x = 1, N_TASKS
        !$omp target teams distribute map(alloc: work_storage(1:N, x), ticket(1:1)) private(my_ticket) nowait
        DO y = 1, N
+          work_storage(y, x) = 0
           DO z = 1, N*(N_TASKS - x)
              work_storage(y, x) = work_storage(y, x) + x*y*z
           END DO

--- a/tests/4.5/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_num_threads.F90
+++ b/tests/4.5/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_num_threads.F90
@@ -30,7 +30,7 @@ CONTAINS
       CHARACTER(len=400) :: difNumMessage, oneThreadMessage
       WRITE(difNumMessage, *) "When testing num_threads, the &
        &actual number of threads was different. This is not a &
-       compliance error with the specs."
+       &compliance error with the specs."
      
       WRITE(oneThreadMessage, *) "The number of threads was &
       &always one, regardless of the num_threads clause. This is not a &


### PR DESCRIPTION
* tests/4.5/target_teams_distribute/test_target_teams_distribute_nowait.F90:
  Initialize variable to zero before reading its value.
* tests/4.5/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_num_threads.F90:
  Silence "Warning: Missing '&' in continued character constant".

Two minor issues - one just a warning (but still invalid Fortran), the other showed up with GCC's -fsanitize=undefined as the variable is uninitialized. – Especially with GCN, I saw actual fails as GCN more often than other systems seems to have nonzero initialized stack variables.

@spophale @tmh97 @nolanbaker31 – please review. Thanks!