### PR TITLE
Adding -qopenmp flag for Intel ICX, ICPX, IFX compilers in Make.def

### DIFF
--- a/sys/make/make.def
+++ b/sys/make/make.def
@@ -105,7 +105,7 @@ endif
 
 # Intel ICX compiler
 ifeq ($(CC), icx)
-  COFFLOADING = -fopenmp-targets=spir64
+  COFFLOADING = -qopenmp -fopenmp-targets=spir64
   C_NO_OFFLOADING =
   CFLAGS += -lm -O3 -fiopenmp $(COFFLOADING) -D__STRICT_ANSI__
   CLINK = icx
@@ -217,7 +217,7 @@ endif
 
 # Intel ICPX compiler
 ifeq ($(CXX), icpx)
-  CXXOFFLOADING = -fopenmp-targets=spir64
+  CXXOFFLOADING = -qopenmp -fopenmp-targets=spir64
   CXX_NO_OFFLOADING =
   CXXFLAGS += -lm -O3 -fiopenmp $(CXXOFFLOADING) -D__STRICT_ANSI__
   CXXLINK = icpx
@@ -314,7 +314,7 @@ endif
 
 # Intel IFX compiler
 ifeq ($(FC), ifx)
-  FOFFLOADING = -fopenmp-targets=spir64
+  FOFFLOADING = -qopenmp -fopenmp-targets=spir64
   F_NO_OFFLOADING =
   FFLAGS += -O3 -fiopenmp $(FOFFLOADING)
   FLINK = ifx


### PR DESCRIPTION
According to [Intel]( https://www.intel.com/content/www/us/en/develop/documentation/get-started-with-cpp-fortran-compiler-openmp/top.html), 

> Compile the source code with an icx, icpx, or ifx compiler driver that invokes GPU offloading with:
> $ icx -qopenmp -fopenmp-targets=spir64 matmul_offload.c -o matmul

Adding -qopenmp as it seems this properly enables GPU offloading. I have tested this with all 3 compilers, and am getting limited errors. 