### PR TITLE
Adding -fopenmp-version flags for clang/clang++ to make.def file

### DIFF
--- a/sys/make/make.def
+++ b/sys/make/make.def
@@ -116,7 +116,13 @@ endif
 # Clang compiler
 ifeq ($(DEVICE_TYPE),nvidia)
   ifeq ($(CC), clang)
-    COFFLOADING = -fopenmp-targets=nvptx64-nvidia-cuda -Xopenmp-target -march=sm_70
+    ifeq ($(OMP_VERSION), 5.0)
+      COFFLOADING = -fopenmp-targets=nvptx64 -Xopenmp-target -march=sm_70 -fopenmp-version=50
+    else ifeq ($(OMP_VERSION), 5.1)
+      COFFLOADING = -fopenmp-targets=nvptx64 -Xopenmp-target -march=sm_70 -fopenmp-version=51
+    else 
+      COFFLOADING = -fopenmp-targets=nvptx64 -Xopenmp-target -march=sm_70
+    endif
     C_NO_OFFLOADING =
     CFLAGS += -lm -O3 -fopenmp $(COFFLOADING)
     #Adding this to fix problem with math.h
@@ -127,7 +133,13 @@ ifeq ($(DEVICE_TYPE),nvidia)
   endif
 else ifeq ($(DEVICE_TYPE),amd)
   ifeq ($(CC), clang)
-    COFFLOADING = -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908
+    ifeq ($(OMP_VERSION), 5.0)
+      COFFLOADING = -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908 -fopenmp-version=50
+    else ifeq ($(OMP_VERSION), 5.1)
+      COFFLOADING = -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908 -fopenmp-version=51
+    else
+      COFFLOADING = -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908
+    endif
     C_NO_OFFLOADING =
     CFLAGS += $(COFFLOADING)
     #Adding this to fix problem with math.h
@@ -228,7 +240,13 @@ endif
 # Clang compiler
 ifeq ($(DEVICE_TYPE),nvidia)
   ifeq ($(CXX), clang++)
-    CXXOFFLOADING = -fopenmp-targets=nvptx64-nvidia-cuda -Xopenmp-target -march=sm_70
+    ifeq ($(OMP_VERSION), 5.0)
+      CXXOFFLOADING = -fopenmp-targets=nvptx64 -Xopenmp-target -march=sm_70 -fopenmp-version=50
+    else ifeq ($(OMP_VERSION), 5.1)
+      CXXOFFLOADING = -fopenmp-targets=nvptx64 -Xopenmp-target -march=sm_70 -fopenmp-version=51
+    else
+      CXXOFFLOADING = -fopenmp-targets=nvptx64 -Xopenmp-target -march=sm_70
+    endif 
     CXX_NO_OFFLOADING =
     CXXFLAGS += -std=c++11 -lm -O3 -fopenmp $(CXXOFFLOADING)
     #Adding this to fix problem with math.h
@@ -239,7 +257,13 @@ ifeq ($(DEVICE_TYPE),nvidia)
   endif
 else ifeq ($(DEVICE_TYPE),amd)
   ifeq ($(CXX), clang++)
-    CXXOFFLOADING = -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908 
+    ifeq ($(OMP_VERSION), 5.0)
+      CXXOFFLOADING = -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908 -fopenmp-version=50
+    else ifeq ($(OMP_VERSION), 5.1)
+      CXXOFFLOADING = -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908 -fopenmp-version=51
+    else
+      CXXOFFLOADING = -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908 
+    endif
     CXX_NO_OFFLOADING =
     CXXFLAGS += -std=c++11 -lm -O3 -fopenmp $(CXXOFFLOADING)
     #Adding this to fix problem with math.h


### PR DESCRIPTION
When OMP_VERSION is added as part of the make command and is set to either 5.0 or 5.1, the corresponding -fopenmp-version={5.0 or 5.1} flag will be set.

If OMP_VERSION is not specified or is set equal to 4.5, the flag will not be set. When the flag is not set, it appears that -fopenmp-version defaults to 5.0.

I tested -fopenmp-version=4.5 and it forced all of the 4.5 offloading tests to fail, seems to not work properly for 4.5 only.