### PR TITLE
Fix memleak in tests/5.0/task/test_task_affinity*.c

### DIFF
--- a/tests/5.0/task/test_task_affinity.c
+++ b/tests/5.0/task/test_task_affinity.c
@@ -52,6 +52,9 @@ int test_task_affinity() {
     OMPVV_TEST_AND_SET_VERBOSE(errors, A[i] != 0);
   }
 
+  free (A);
+  free (B);
+
   return errors;
 }
 

--- a/tests/5.0/task/test_task_affinity_device.c
+++ b/tests/5.0/task/test_task_affinity_device.c
@@ -61,6 +61,9 @@ int test_task_affinity() {
     OMPVV_TEST_AND_SET_VERBOSE(errors, B[i] != i*3);
   }
 
+  free(A);
+  free(B);
+
   return errors;
 }
 


### PR DESCRIPTION
Silence address sanitizer memleak warning by freeing two
variables in
* tests/5.0/task/test_task_affinity.c
* tests/5.0/task/test_task_affinity_device.c

Found when re-testing those tests from pull request #354