### PR TITLE
Plug memory leaks, fix cast errors

### DIFF
--- a/tests/4.5/application_kernels/linked_list.c
+++ b/tests/4.5/application_kernels/linked_list.c
@@ -139,6 +139,12 @@ int main() {
   
   OMPVV_TEST_AND_SET_VERBOSE(error, check(head));
 
+  while (head) {
+    node_t * next = head->next;
+    free (head);
+    head = next;
+  }
+
   OMPVV_REPORT_AND_RETURN(error);
   return 0;
 }

--- a/tests/4.5/application_kernels/mmm_target.c
+++ b/tests/4.5/application_kernels/mmm_target.c
@@ -60,6 +60,9 @@ int main (int argc, char *argv[])
       OMPVV_ERROR_IF(500 != c[i*rowA+j], "Error: [%d][%d] should be 500 is %d",i,j,c[i*rowA+j]);
     }
   }
+  free(a);
+  free(b);
+  free(c);
 
   OMPVV_REPORT_AND_RETURN(error);
 }

--- a/tests/4.5/application_kernels/mmm_target_parallel_for_simd.c
+++ b/tests/4.5/application_kernels/mmm_target_parallel_for_simd.c
@@ -61,6 +61,9 @@ int main (int argc, char *argv[])
       OMPVV_ERROR_IF(500 != c[i*rowA+j], "Error: [%d][%d] should be 500 is %d",i,j,c[i*rowA+j]);
     }
   }
+  free(a);
+  free(b);
+  free(c);
 
   OMPVV_REPORT_AND_RETURN(error);
 }

--- a/tests/4.5/application_kernels/omp_default_device.c
+++ b/tests/4.5/application_kernels/omp_default_device.c
@@ -44,9 +44,11 @@ int test_omp_device() {
   OMPVV_TEST_AND_SET(errors, iDev1 != setDev);
 
 
-  buf1 = omp_target_alloc (sizeof(double)* N, iDev1);
+  buf1 = (double *)omp_target_alloc (sizeof(double)* N, iDev1);
   iDev2 = omp_get_default_device();
   OMPVV_TEST_AND_SET(errors, iDev2 != iDev1);
+
+  omp_target_free (buf1, iDev1);
 
   return errors;
 }

--- a/tests/4.5/target_data/test_target_data_map_devices.c
+++ b/tests/4.5/target_data/test_target_data_map_devices.c
@@ -57,7 +57,7 @@ int test_map_set_default_dev() {
   }
 
   omp_set_default_device(def_dev);
-
+  free(h_matrix);
   return errors;
 }
 
@@ -96,6 +96,7 @@ int test_map_device() {
     OMPVV_TEST_AND_SET_VERBOSE(errors, (dev * N != sum[dev]));
   }
 
+  free(h_matrix);
   return errors;
 }
 

--- a/tests/4.5/target_enter_data/test_target_enter_data_depend.c
+++ b/tests/4.5/target_enter_data/test_target_enter_data_depend.c
@@ -122,6 +122,10 @@ int test_async_between_task_target() {
 // This is outside of the testing area but we need to clear memory on the device 
 // created with the target enter data
 #pragma omp target exit data map(delete: h_array[0:N])
+  free(h_array);
+  free(h_array_copy);
+  free(in_1);
+  free(in_2);
 
   return errors;
 }
@@ -184,6 +188,8 @@ int test_async_between_target() {
 // created with the target enter data
 #pragma omp target exit data map(delete: h_array[0:N])
 
+  free(h_array);
+  free(h_array_copy);
   return errors;
 }
 

--- a/tests/4.5/target_enter_data/test_target_enter_data_global_array.c
+++ b/tests/4.5/target_enter_data/test_target_enter_data_global_array.c
@@ -38,6 +38,7 @@ int main (){
      errors += 1;
    }
 
+#pragma omp target exit data map(release: A[:n])
 
   OMPVV_REPORT_AND_RETURN(errors);
 }

--- a/tests/4.5/target_enter_data/test_target_enter_data_struct.c
+++ b/tests/4.5/target_enter_data/test_target_enter_data_struct.c
@@ -86,6 +86,10 @@ int test_struct() {
   // to do garbage collection without target exit data
 #pragma omp target exit data map(delete: single, array[0:ARRAY_SIZE])
 
+  free(single.p);
+  for (int i = 0; i < ARRAY_SIZE; ++i) {
+    free(array[i].p);
+  }
   return errors;
 }
 
@@ -159,6 +163,10 @@ int test_typedef() {
   // to do garbage collection without target exit data
 #pragma omp target exit data map(delete: single, array[0:ARRAY_SIZE])
 
+  free(single.p);
+  for (int i = 0; i < ARRAY_SIZE; ++i) {
+    free(array[i].p);
+  }
   return errors;
 }
 

--- a/tests/4.5/target_enter_exit_data/test_target_enter_exit_data_depend.c
+++ b/tests/4.5/target_enter_exit_data/test_target_enter_exit_data_depend.c
@@ -80,7 +80,10 @@ int test_async_between_task_target() {
 #pragma omp taskwait
 
   errors = 2.0*N != sum;
-  
+
+  free(h_array);
+  free(in_1);
+  free(in_2);
   return errors;
 }
 
@@ -121,6 +124,7 @@ int test_async_between_target() {
   }
   errors = 2*N != sum;
 
+  free(h_array);
   return errors;
 }
 
@@ -136,4 +140,3 @@ int main(){
 
   OMPVV_REPORT_AND_RETURN(errors);
 }
-

--- a/tests/4.5/target_enter_exit_data/test_target_enter_exit_data_map_malloced_array.c
+++ b/tests/4.5/target_enter_exit_data/test_target_enter_exit_data_map_malloced_array.c
@@ -49,7 +49,7 @@ int test_tofrom() {
   for (i = 0; i < N; i++) {
     OMPVV_TEST_AND_SET_VERBOSE(errors, A[i] != N);
   }
-
+  free(A);
   return errors;
 }
 
@@ -88,6 +88,8 @@ int test_delete() {
   for (i = 0; i < N; i++) {
     OMPVV_TEST_AND_SET_VERBOSE(errors, B[i] != 0);
   }
+  free(A);
+  free(B);
 
   return errors;
 }

--- a/tests/4.5/target_enter_exit_data/test_target_enter_exit_data_struct.c
+++ b/tests/4.5/target_enter_exit_data/test_target_enter_exit_data_struct.c
@@ -67,6 +67,11 @@ int test_struct() {
       OMPVV_TEST_AND_SET_VERBOSE(errors, (array[i].b[j] != 1));
     OMPVV_TEST_AND_SET_VERBOSE(errors, (pointers[i + 1] != array[i].p));
   }
+
+  free(single.p);
+  for (int i = 0; i < 5; ++i) {
+    free(array[i].p);
+  }
   
   return errors;
 }
@@ -124,7 +129,11 @@ int test_typedef() {
     OMPVV_TEST_AND_SET_VERBOSE(errors, (pointers[i + 1] != array[i].p));
   }
   
-  return errors;
+  free(single.p);
+  for (int i = 0; i < 5; ++i) {
+    free(array[i].p);
+  }
+   return errors;
 }
 
 int main () {

--- a/tests/4.5/target_simd/test_target_simd_collapse.c
+++ b/tests/4.5/target_simd/test_target_simd_collapse.c
@@ -18,8 +18,8 @@
 
 int test_collapse1() {
   OMPVV_INFOMSG("Testing for collapse(1)");
-  int * a_mem = malloc(ARRAY_SIZE*ARRAY_SIZE*sizeof(int));
-  int * b_mem = malloc(ARRAY_SIZE*(ARRAY_SIZE+1)*sizeof(int));
+  int * a_mem = (int*)malloc(ARRAY_SIZE*ARRAY_SIZE*sizeof(int));
+  int * b_mem = (int*)malloc(ARRAY_SIZE*(ARRAY_SIZE+1)*sizeof(int));
   int (*a)[ARRAY_SIZE] = (int (*)[ARRAY_SIZE])a_mem;
   int (*b)[ARRAY_SIZE + 1] = (int (*)[ARRAY_SIZE+1])b_mem;
   int errors = 0;
@@ -50,13 +50,16 @@ int test_collapse1() {
       }
     }
   }
+  free(a_mem);
+  free(b_mem);
+
   return errors;
 }
 
 int test_collapse2() {
   OMPVV_INFOMSG("Testing for collapse(2)");
-  int * a_mem = malloc(ARRAY_SIZE*ARRAY_SIZE*ARRAY_SIZE*sizeof(int));
-  int * b_mem = malloc(ARRAY_SIZE*ARRAY_SIZE*(ARRAY_SIZE+1)*sizeof(int));
+  int * a_mem = (int *)malloc(ARRAY_SIZE*ARRAY_SIZE*ARRAY_SIZE*sizeof(int));
+  int * b_mem = (int *)malloc(ARRAY_SIZE*ARRAY_SIZE*(ARRAY_SIZE+1)*sizeof(int));
   int (*a)[ARRAY_SIZE][ARRAY_SIZE] = (int (*)[ARRAY_SIZE][ARRAY_SIZE])a_mem;
   int (*b)[ARRAY_SIZE][ARRAY_SIZE + 1] = (int (*)[ARRAY_SIZE][ARRAY_SIZE+1])b_mem;
   int errors = 0;
@@ -102,6 +105,8 @@ int test_collapse2() {
     OMPVV_WARNING("Test operated with one team.  Parallelism of teams distribute can't be guarunteed.");
   }
 
+  free(a_mem);
+  free(b_mem);
   return errors;
 }
 

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_collapse.c
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_collapse.c
@@ -18,8 +18,8 @@
 
 int test_collapse1() {
 
-  int * a_mem = malloc(ARRAY_SIZE*ARRAY_SIZE*sizeof(int));
-  int * b_mem = malloc(ARRAY_SIZE*(ARRAY_SIZE+1)*sizeof(int));
+  int * a_mem = (int *)malloc(ARRAY_SIZE*ARRAY_SIZE*sizeof(int));
+  int * b_mem = (int *)malloc(ARRAY_SIZE*(ARRAY_SIZE+1)*sizeof(int));
   int (*a)[ARRAY_SIZE] = (int (*)[ARRAY_SIZE])a_mem;
   int (*b)[ARRAY_SIZE + 1] = (int (*)[ARRAY_SIZE+1])b_mem;
   int errors = 0;
@@ -50,12 +50,15 @@ int test_collapse1() {
       }
     }
   }
+
+  free (a_mem);
+  free (b_mem);
   return errors;
 }
 
 int test_collapse2() {
-  int * a_mem = malloc(ARRAY_SIZE*ARRAY_SIZE*ARRAY_SIZE*sizeof(int));
-  int * b_mem = malloc(ARRAY_SIZE*ARRAY_SIZE*(ARRAY_SIZE+1)*sizeof(int));
+  int * a_mem = (int *)malloc(ARRAY_SIZE*ARRAY_SIZE*ARRAY_SIZE*sizeof(int));
+  int * b_mem = (int *)malloc(ARRAY_SIZE*ARRAY_SIZE*(ARRAY_SIZE+1)*sizeof(int));
   int (*a)[ARRAY_SIZE][ARRAY_SIZE] = (int (*)[ARRAY_SIZE][ARRAY_SIZE])a_mem;
   int (*b)[ARRAY_SIZE][ARRAY_SIZE + 1] = (int (*)[ARRAY_SIZE][ARRAY_SIZE+1])b_mem;
   int errors = 0;
@@ -101,6 +104,8 @@ int test_collapse2() {
     OMPVV_WARNING("Test operated with one team.  Parallelism of teams distribute can't be guarunteed.");
   }
 
+  free (a_mem);
+  free (b_mem);
   return errors;
 }
 

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_is_device_ptr.c
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_is_device_ptr.c
@@ -48,6 +48,8 @@ int main() {
       }
     }
 
+    omp_target_free (c, omp_get_default_device());
+
     OMPVV_REPORT_AND_RETURN(errors);
   }
 }

--- a/tests/4.5/target_update/test_target_update_depend.c
+++ b/tests/4.5/target_update/test_target_update_depend.c
@@ -111,6 +111,9 @@ int test_async_between_hosts_tasks() {
   OMPVV_TEST_AND_SET(errors, (N * ALL_TASKS_BITS != sum));
   OMPVV_INFOMSG("Test test_async_between_task_target ran on the %s", (isHost ? "host" : "device"));
  
+  free(h_array);
+  free(in_1);
+  free(in_2);
 
   return errors;
 }
@@ -200,6 +203,9 @@ int test_async_between_host_and_device() {
   OMPVV_TEST_AND_SET(errors, (N * ALL_TASKS_BITS != sum));
   OMPVV_INFOMSG("Test test_async_between_task_target ran on the %s", (isHost ? "host" : "device"));
  
+  free(h_array);
+  free(in_1);
+  free(in_2);
 
   return errors;
 }
@@ -213,4 +219,3 @@ int main(){
 
   OMPVV_REPORT_AND_RETURN(errors);
 }
-

--- a/tests/5.0/loop/test_loop_collapse.c
+++ b/tests/5.0/loop/test_loop_collapse.c
@@ -18,8 +18,8 @@
 
 int test_collapse1() {
 
-  int * a_mem = malloc(N*N*sizeof(int));
-  int * b_mem = malloc(N*(N+1)*sizeof(int));
+  int * a_mem = (int *)malloc(N*N*sizeof(int));
+  int * b_mem = (int *)malloc(N*(N+1)*sizeof(int));
   int (*a)[N] = (int (*)[N])a_mem;
   int (*b)[N + 1] = (int (*)[N+1])b_mem;
   int errors = 0;
@@ -53,12 +53,14 @@ int test_collapse1() {
       }
     }
   }
+  free(a_mem);
+  free(b_mem);
   return errors;
 }
 
 int test_collapse2() {
-  int * a_mem = malloc(N*N*N*sizeof(int));
-  int * b_mem = malloc(N*N*(N+1)*sizeof(int));
+  int * a_mem = (int *)malloc(N*N*N*sizeof(int));
+  int * b_mem = (int *)malloc(N*N*(N+1)*sizeof(int));
   int (*a)[N][N] = (int (*)[N][N])a_mem;
   int (*b)[N][N + 1] = (int (*)[N][N+1])b_mem;
   int errors = 0;
@@ -107,6 +109,8 @@ int test_collapse2() {
     OMPVV_WARNING("Test operated with one thread.  Parallelism of loop directive in parallel region can't be guaranteed.");
   }
 
+  free(a_mem);
+  free(b_mem);
   return errors;
 }
 

--- a/tests/5.0/loop/test_loop_collapse_device.c
+++ b/tests/5.0/loop/test_loop_collapse_device.c
@@ -19,8 +19,8 @@
 
 int test_collapse1() {
 
-  int * a_mem = malloc(N*N*sizeof(int));
-  int * b_mem = malloc(N*(N+1)*sizeof(int));
+  int * a_mem = (int *)malloc(N*N*sizeof(int));
+  int * b_mem = (int *)malloc(N*(N+1)*sizeof(int));
   int (*a)[N] = (int (*)[N])a_mem;
   int (*b)[N + 1] = (int (*)[N+1])b_mem;
   int errors = 0;
@@ -54,12 +54,14 @@ int test_collapse1() {
       }
     }
   }
+  free (a_mem);
+  free (b_mem);
   return errors;
 }
 
 int test_collapse2() {
-  int * a_mem = malloc(N*N*N*sizeof(int));
-  int * b_mem = malloc(N*N*(N+1)*sizeof(int));
+  int * a_mem = (int *)malloc(N*N*N*sizeof(int));
+  int * b_mem = (int *)malloc(N*N*(N+1)*sizeof(int));
   int (*a)[N][N] = (int (*)[N][N])a_mem;
   int (*b)[N][N + 1] = (int (*)[N][N+1])b_mem;
   int errors = 0;
@@ -108,6 +110,8 @@ int test_collapse2() {
     OMPVV_WARNING("Test operated with one thread.  Parallelism of loop directive in parallel region can't be guaranteed.");
   }
 
+  free (a_mem);
+  free (b_mem);
   return errors;
 }
 

--- a/tests/5.0/taskgroup/test_taskgroup_task_reduction_device.c
+++ b/tests/5.0/taskgroup/test_taskgroup_task_reduction_device.c
@@ -75,5 +75,11 @@ int main(int argc, char *argv[]) {
 
   OMPVV_TEST_AND_SET_VERBOSE(errors, result != seq_linked_list_sum(root));
 
+  while (root) {
+    temp = root->next;
+    free (root);
+    root = temp;
+  }
+
   OMPVV_REPORT_AND_RETURN(errors);
 }


### PR DESCRIPTION
Plug memory leaks reported by `-fsanitize=address` (ASAN).
Fix errors of the type
  `error: invalid conversion from ‘void*’ to ‘int*’`
with `malloc`.

Follow up to Pull Request #415, which plugged one memory leak,
tested with GCC 12.