### PR TITLE
Fix enum conversion and int overflow

### DIFF
--- a/tests/4.5/application_kernels/declare_target_subroutine.F90
+++ b/tests/4.5/application_kernels/declare_target_subroutine.F90
@@ -52,6 +52,7 @@ PROGRAM declare_target_subroutine
 
   OMPVV_TEST_VERBOSE(sum .ne. N)
 
+  DEALLOCATE(a)
   OMPVV_REPORT_AND_RETURN()
 END PROGRAM declare_target_subroutine
 

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_defaultmap.c
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_defaultmap.c
@@ -221,7 +221,7 @@ int test_defaultmap_off() {
     float_array_b[x] = 0;
     double_array_a[x] = x / 50.0;
     double_array_b[x] = 0;
-    enum_array_a[x] = x%4 + 1;
+    enum_array_a[x] = (enum enum_type)(x%4 + 1);
     enum_array_b[x] = VAL1;
   }
 
@@ -261,7 +261,7 @@ int test_defaultmap_off() {
     double_array_b[x] = scalar_double;
     scalar_enum = VAL1;
     for (int y = 1; y < enum_array_a[x]; ++y) {
-      scalar_enum += 1;
+      scalar_enum = (enum enum_type)(scalar_enum + 1);
     }
     enum_array_b[x] = scalar_enum;
   }
@@ -313,7 +313,7 @@ int test_defaultmap_off() {
   scalar_int = 5126;
   scalar_float = 5.126;
   scalar_double = 51.26;
-  scalar_enum = 2;
+  scalar_enum = VAL2;
 
   scalar_char_copy = scalar_char;
   scalar_short_copy = scalar_short;
@@ -344,7 +344,7 @@ int test_defaultmap_off() {
     scalar_int = 0;
     scalar_float = 0;
     scalar_double = 0;
-    scalar_enum = 0;
+    scalar_enum = VAL3;
   }
 
   for (int x = 0; x < ARRAY_SIZE; ++x) {

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_nowait.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_nowait.F90
@@ -30,9 +30,10 @@ PROGRAM test_target_teams_distribute_nowait
   OMPVV_REPORT_AND_RETURN()
 CONTAINS
   INTEGER FUNCTION test_nowait()
+    USE ISO_Fortran_env, only: INT64
     INTEGER:: errors, x, y, z, was_async, my_ticket
     INTEGER,DIMENSION(N_TASKS):: order
-    INTEGER,DIMENSION(N, N_TASKS):: work_storage
+    INTEGER(INT64),DIMENSION(N, N_TASKS):: work_storage
     INTEGER,DIMENSION(1):: ticket
 
     ticket(1) = 0

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_nowait.c
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_nowait.c
@@ -10,6 +10,7 @@
 ////===----------------------------------------------------------------------===//
 
 #include <omp.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include "ompvv.h"
@@ -22,7 +23,7 @@ int main() {
   OMPVV_WARNING("This test does not throw an error if tasks fail to execute asynchronously, as this is still correct behavior. If execution is not asynchronous, we will throw a warning.");
   int isOffloading = 0;
   OMPVV_TEST_AND_SET_OFFLOADING(isOffloading);
-  int work_storage[N_TASKS][N];
+  int64_t work_storage[N_TASKS][N];
   int order[N_TASKS];  // Each position marks the order in which that task executed
   int errors = 0;
   int ticket[1] = {0};
@@ -33,6 +34,7 @@ int main() {
   for (int i = 0; i < N_TASKS; ++i) {
 #pragma omp target teams distribute map(alloc: work_storage[i][0:N], ticket[0:1]) nowait
     for (int j = 0; j < N; ++j) {
+      work_storage[i][j] = 0;
       for (int k = 0; k < N*(N_TASKS - i); ++k) { // Creates skewed work distribution
 	work_storage[i][j] += k*i*j;              // This value will not be verified
       }


### PR DESCRIPTION
* tests/4.5/target_teams_distribute/test_target_teams_distribute_defaultmap.c:
  Add casts or use enum value directly to avoid the compile-time
  error: invalid conversion from ‘int’ to ‘enum_type’
* tests/4.5/target_teams_distribute/test_target_teams_distribute_nowait.c: Zero
  initialize used array elements and use int64_t to avoid with UBSAN the error:
  runtime error: signed integer overflow: 2147457775 + 731520 cannot be represented in type 'int'

UBSAN = undefined-behavior sanitizer, `-fsanitize=undefined`; here, the result with GCC 12.