### PR TITLE
Issue 417: Only call permitted routines strictly nested in 'teams'

### DIFF
--- a/tests/5.0/loop/test_loop_bind.c
+++ b/tests/5.0/loop/test_loop_bind.c
@@ -41,7 +41,8 @@ int test_loop_bind_teams() {
         x[i][j] += y[i]*z[i];
       }
     }
-    if (omp_get_thread_num() == 0 && omp_get_team_num() == 0) {
+    #pragma omp parallel if(0)
+    if (omp_get_team_num() == 0) {
       num_teams = omp_get_num_teams();
     }
   }

--- a/tests/5.0/loop/test_loop_bind_device.c
+++ b/tests/5.0/loop/test_loop_bind_device.c
@@ -42,7 +42,8 @@ int test_loop_bind_teams() {
         x[i][j] += y[i]*z[i];
       }
     }
-    if (omp_get_thread_num() == 0 && omp_get_team_num() == 0) {
+    #pragma omp parallel if(0)
+    if (omp_get_team_num() == 0) {
       num_teams = omp_get_num_teams();
     }
   }
@@ -135,7 +136,8 @@ int test_loop_bind_thread_teams() {
         x[i][j] += y[i]*z[i];
       }
     }
-    if (omp_get_thread_num() == 0 && omp_get_team_num() == 0) {
+    #pragma omp parallel if(0)
+    if (omp_get_team_num() == 0) {
       num_teams = omp_get_num_teams();
     }
     for (int i = 0; i < N; i++) {

--- a/tests/5.0/loop/test_loop_nested.c
+++ b/tests/5.0/loop/test_loop_nested.c
@@ -41,7 +41,8 @@ int test_loop_nested_teams() {
         x[i][j] += y[i]*z[i];
       }
     }
-    if (omp_get_thread_num() == 0 && omp_get_team_num() == 0) {
+    #pragma omp parallel if(0)
+    if (omp_get_team_num() == 0) {
       num_teams = omp_get_num_teams();
     }
   }

--- a/tests/5.0/loop/test_loop_nested_device.c
+++ b/tests/5.0/loop/test_loop_nested_device.c
@@ -42,7 +42,8 @@ int test_loop_nested_teams() {
         x[i][j] += y[i]*z[i];
       }
     }
-    if (omp_get_thread_num() == 0 && omp_get_team_num() == 0) {
+    #pragma omp parallel if(0)
+    if (omp_get_team_num() == 0) {
       num_teams = omp_get_num_teams();
     }
   }

--- a/tests/5.0/teams/test_teams.F90
+++ b/tests/5.0/teams/test_teams.F90
@@ -47,10 +47,9 @@ CONTAINS
 
     !$omp teams num_teams(OMPVV_NUM_TEAMS_DEVICE) thread_limit(OMPVV_NUM_THREADS_DEVICE)
       num_teams(omp_get_team_num() + 1) = omp_get_num_teams()
-      !$omp parallel
-        !$omp atomic write
+      !$omp parallel master
         num_threads(omp_get_team_num() + 1) = omp_get_num_threads()
-      !$omp end parallel
+      !$omp end parallel master
     !$omp end teams 
   
     OMPVV_WARNING_IF(num_teams(1) .eq. 1, "Test operated with one team, num_teams requested is inconsistent with this result")

--- a/tests/5.0/teams/test_teams.F90
+++ b/tests/5.0/teams/test_teams.F90
@@ -46,8 +46,11 @@ CONTAINS
     END DO
 
     !$omp teams num_teams(OMPVV_NUM_TEAMS_DEVICE) thread_limit(OMPVV_NUM_THREADS_DEVICE)
-    num_teams(omp_get_team_num() + 1) = omp_get_num_teams()
-    num_threads(omp_get_team_num() + 1) = omp_get_num_threads()
+      num_teams(omp_get_team_num() + 1) = omp_get_num_teams()
+      !$omp parallel
+        !$omp atomic write
+        num_threads(omp_get_team_num() + 1) = omp_get_num_threads()
+      !$omp end parallel
     !$omp end teams 
   
     OMPVV_WARNING_IF(num_teams(1) .eq. 1, "Test operated with one team, num_teams requested is inconsistent with this result")

--- a/tests/5.0/teams/test_teams.c
+++ b/tests/5.0/teams/test_teams.c
@@ -31,6 +31,8 @@ int main() {
 #pragma omp teams num_teams(OMPVV_NUM_TEAMS_DEVICE) thread_limit(OMPVV_NUM_THREADS_DEVICE)
   {
     num_teams[omp_get_team_num()] = omp_get_num_teams();
+#pragma omp parallel
+#pragma omp atomic write
     num_threads[omp_get_team_num()]= omp_get_num_threads();
   }
 

--- a/tests/5.0/teams/test_teams.c
+++ b/tests/5.0/teams/test_teams.c
@@ -31,8 +31,7 @@ int main() {
 #pragma omp teams num_teams(OMPVV_NUM_TEAMS_DEVICE) thread_limit(OMPVV_NUM_THREADS_DEVICE)
   {
     num_teams[omp_get_team_num()] = omp_get_num_teams();
-#pragma omp parallel
-#pragma omp atomic write
+#pragma omp parallel master
     num_threads[omp_get_team_num()]= omp_get_num_threads();
   }
 


### PR DESCRIPTION
Issue #417

OpenMP only permits omp_get_num_teams() and omp_get_team_num() strictly
nested inside of a teams construct, all other have to be wrapped in
distribute, parallel or loop. Hence, this patch wraps them.

I have used `parallel if(0)` and `parallel`, but also `distribute` (possibly with `dist_schedule(static,1)` clause) or `loop` could be used.