### PR TITLE
Fix requires with test_requires_unified_shared_memory.F90

### DIFF
--- a/ompvv/ompvv.F90
+++ b/ompvv/ompvv.F90
@@ -16,6 +16,10 @@
 #define EXIT_FAILURE 1
 #endif
 
+#ifndef OMPVV_MODULE_REQUIRES_LINE
+#define OMPVV_MODULE_REQUIRES_LINE
+#endif
+
 ! Macro for output of information, warning and error messages
 #ifdef VERBOSE_MODE
 #define OMPVV_WARNING_HELPER(message, filename, line) WRITE(*, OMPVV_HEADER_FMT(OMPVV_WARNING)) TRIM(clean_fn(filename)), line, TRIM(message)
@@ -100,6 +104,7 @@ module ompvv_lib
   use omp_lib
   use iso_fortran_env
   implicit none
+OMPVV_MODULE_REQUIRES_LINE
     LOGICAL, PRIVATE :: ompvv_isHost
     INTEGER, PRIVATE :: ompvv_errors = 0
     LOGICAL, PRIVATE :: ompvv_sharedEnv

--- a/tests/5.0/requires/test_requires_unified_shared_memory.F90
+++ b/tests/5.0/requires/test_requires_unified_shared_memory.F90
@@ -7,6 +7,7 @@
 !
 !===------------------------------------------------------------------------------===//
 
+#define OMPVV_MODULE_REQUIRES_LINE !$omp requires unified_shared_memory
 #include "ompvv.F90"
 
 PROGRAM test_requires_unified_shared_memory


### PR DESCRIPTION
Fixes the OpenMP requirement:

"Either all compilation units of a program that contain `declare target` directives, device constructs or device routines or none of them must specify a requires directive that specifies the `reverse_offload`, `unified_address` or `unified_shared_memory` requirement."

with

"compilation unit = For Fortran, a program unit."

* ompvv/ompvv.F90: Define as empty and use OMPVV_MODULE_REQUIRES_LINE in the module.
* tests/5.0/requires/test_requires_unified_shared_memory.F90: Define OMPVV_MODULE_REQUIRES_LINE to '!$omp requires unified_shared_memory".

Avoids the following GCC/gfortran error when compiling `tests/5.0/requires/test_requires_unified_shared_memory.F90`:
```
ompvv/ompvv.F90:99:16:

   99 | module ompvv_lib
      |                1
Error: Program unit at (1) has OpenMP device constructs/routines but does not set !$OMP REQUIRES UNIFIED_SHARED_MEMORY but other program units do

```