### PR TITLE
Issue 426: Free device vars before stack-local var lifetime ends

### DIFF
--- a/tests/4.5/target_enter_data/test_target_enter_data_depend.c
+++ b/tests/4.5/target_enter_data/test_target_enter_data_depend.c
@@ -121,7 +121,7 @@ int test_async_between_task_target() {
 // Garbage collection
 // This is outside of the testing area but we need to clear memory on the device 
 // created with the target enter data
-#pragma omp target exit data map(delete: h_array[0:N])
+#pragma omp target exit data map(delete: h_array[0:N], in_1[0:N], in_2[0:N])
   free(h_array);
   free(h_array_copy);
   free(in_1);
@@ -186,7 +186,7 @@ int test_async_between_target() {
 // Garbage collection
 // This is outside of the testing area but we need to clear memory on the device 
 // created with the target enter data
-#pragma omp target exit data map(delete: h_array[0:N])
+#pragma omp target exit data map(delete: h_array[0:N], val)
 
   free(h_array);
   free(h_array_copy);

--- a/tests/4.5/target_enter_exit_data/test_target_enter_exit_data_depend.c
+++ b/tests/4.5/target_enter_exit_data/test_target_enter_exit_data_depend.c
@@ -81,6 +81,7 @@ int test_async_between_task_target() {
 
   errors = 2.0*N != sum;
 
+#pragma omp target exit data map(release: h_array[0:N], in_1[0:N], in_2[0:N])
   free(h_array);
   free(in_1);
   free(in_2);
@@ -124,6 +125,7 @@ int test_async_between_target() {
   }
   errors = 2*N != sum;
 
+#pragma omp target exit data map(release: h_array[0:N], val)
   free(h_array);
   return errors;
 }


### PR DESCRIPTION
Issue #426 

Free memory belonging to stack-local variables on the device before
their lifetime ends on the host.

* tests/4.5/target_enter_data/test_target_enter_data_depend.c
  (test_async_between_task_target, test_async_between_target): Add
  stack local vars to 'omp target exit data'.
* tests/4.5/target_enter_exit_data/test_target_enter_exit_data_depend.c
  (test_async_between_task_target, test_async_between_target): Likewise.


I concur with @simoatze  that the memory should be freed – but I also could not spot it in the spec. (Hence, I asked on the omp-lang mailing list.) Still, I think it should be freed.

@simoatze – does the patch look right?
@spophale @tmh97 @nolanbaker31 – please review.