### PR TITLE
test_loop_bind.c - invalid API in teams; improve ...device_type_nohost.c

### DIFF
--- a/tests/5.0/declare_target/test_declare_target_device_type_nohost.c
+++ b/tests/5.0/declare_target/test_declare_target_device_type_nohost.c
@@ -58,9 +58,18 @@ int test_declare_target_device_type_nohost() {
 
   #pragma omp target update from (a,b,c)
   
-  for (i = 0; i < N; i++) { //check array values on host
-    if ( a[i] != 6 || b[i] != 7 || c[i] != 8 ) {
-      errors++;
+  if (omp_get_default_device () >= 0 && omp_get_default_device () < omp_get_num_devices ()) {
+    for (i = 0; i < N; i++) { //check array values on host
+      if ( a[i] != 6 || b[i] != 7 || c[i] != 8 ) {
+        errors++;
+      }
+    }
+  } else {
+    OMPVV_WARNING("Default device is the host device. Thus, test only ran on the host");
+    for (i = 0; i < N; i++) { //check array values on host
+      if ( a[i] != 10 || b[i] != 10 || c[i] != 10 ) {
+        errors++;
+      }
     }
   }
   

--- a/tests/5.0/loop/test_loop_bind.c
+++ b/tests/5.0/loop/test_loop_bind.c
@@ -135,7 +135,8 @@ int test_loop_bind_thread_teams() {
         x[i][j] += y[i]*z[i];
       }
     }
-    if (omp_get_thread_num() == 0 && omp_get_team_num() == 0) {
+#pragma omp parallel if(0)
+    if (omp_get_team_num() == 0) {
       num_teams = omp_get_num_teams();
     }
     for (int i = 0; i < N; i++) {


### PR DESCRIPTION
* tests/5.0/loop/test_loop_bind.c: Add parallel if(0) wrapper to avoid invalid omp_get_thread_num call strictly nested in teams. -> Issue #417.
* tests/5.0/declare_target/test_declare_target_device_type_nohost.c: Fix check when no offload device is available.

_The first issue I was missed when doing the updates for #417; the second one failed rather non-transparently if no no offloading device is available. I hope this default_device_check make sense. Alternatively, a var could be set to omp_is_initial_device() inside a separate target region; the >= 0 check is to avoid issues with omp_invalid_device/omp_initial_device which are both < 0._

@spophale @tmh97 @nolanbaker31 - please review.