### PR TITLE
test_target_uses_allocators_pteam.c: Remove invalid { ... } before 'for'

### DIFF
--- a/tests/5.0/target/test_target_uses_allocators_pteam.c
+++ b/tests/5.0/target/test_target_uses_allocators_pteam.c
@@ -27,12 +27,11 @@ int test_uses_allocators_pteam() {
   }
 
 #pragma omp target teams distribute uses_allocators(omp_pteam_mem_alloc) allocate(omp_pteam_mem_alloc: x) private(x) map(from: device_result)
-{
   for (int i = 0; i < N; i++) {
     x = 2 * i;
     device_result[i] = i + x;
   }
-}
+
   for (int i = 0; i < N; i++) {
     OMPVV_TEST_AND_SET_VERBOSE(errors, result[i] != device_result[i]);
   }


### PR DESCRIPTION
OpenMP requires that the loop/_loop-nest_ follows immediately after the `distribute` directive without additional `{ ... }` grouping.

@spophale @nolanbaker31 @tmh97 – please review

_Side note: Found because GCC chokes on it. It still does not compile in GCC as the `uses_allocators` clause is not supported. (Strictly speaking, the clause is not needed as the allocator is used on the target construct (in the `allocate` clause) but not _in_ the target region. For code written for portability, I think it should be removed. But as this a testsuite, having valid but unnecessary clauses is fine.)_

 * * *

OpenMP 5.1 has in "2.11.6 distribute Loop Constructs":
> #pragma omp distribute [clause[ [,] clause] ... ] new-line
>    loop-nest

Likewise in OpenMP 5.2, just a bit more hidden: "11.6 distribute Construct" has "Association: loop".

And _loop-nest_  is "2.11.1 Canonical Loop Nest Form" (OpenMP 5.2: 4.4.1 Canonical Loop Nest Form):
> for (init-expr; test-expr; incr-expr)
>   loop-body