### PR TITLE
test_omp_get_device_num.c: Improve value checking

### DIFF
--- a/tests/5.0/program_control/test_omp_get_device_num.c
+++ b/tests/5.0/program_control/test_omp_get_device_num.c
@@ -51,6 +51,17 @@ int test_omp_get_dev_num(void) {
       OMPVV_TEST_AND_SET_VERBOSE(errors, a[i] != i + 5);
    }
 
+   target_device_num = 99;
+
+   for (int i = 0; i <= omp_get_num_devices(); i++) {
+     #pragma omp target map(from: target_device_num) device(i)
+     {
+       target_device_num = omp_get_device_num();
+     }
+
+     OMPVV_TEST_AND_SET_VERBOSE(errors, target_device_num != i);
+   }
+
    return errors;
 }
 


### PR DESCRIPTION
Run 'target' with device clause for all targets and check whether the device number matches the number returned by `omp_get_device_num()`.

With this change, it runs on all non-host devices and then on the host device.

Background: I did run into one implementation bug which always returned 0 on non-host devices. With this change, that's detectable is there is more than a single non-host device.

_Disclaimer: I have so far only run this modified version without offloading (→ omp_get_num_devices() == 0)._

* I want to note that `tests/5.0/target/test_target_device.c` has a similar check – but as it uses `omp requires reverse_offload`, that test case is not as widely supported. _(Side remark: I had called the var "last_device_num" and not "first_device_num".)_
https://github.com/SOLLVE/sollve_vv/blob/b8c1c0c6ca758664d588c1fce46c8843d43f4254/tests/5.0/target/test_target_device.c#L76-L83
* I am also wondering whether it makes sense to call `omp_get_num_devices()` and/or `omp_get_initial_device()` in the target region (+ check whether its value matches the value on the host).