### PR TITLE
Adding preliminary test for map clause w/ present map-type-modifier

### DIFF
--- a/tests/5.1/map/test_map_present_tofrom.c
+++ b/tests/5.1/map/test_map_present_tofrom.c
@@ -1,0 +1,60 @@
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+#include <math.h>
+
+#define N 1024
+
+int test_map_present() {
+
+   struct test_struct {
+     int s;
+     int S[N];
+   };
+
+   int errors = 0;
+   int i; 
+   int scalar; // scalar
+   int A[N]; // aggregate
+   struct test_struct new_struct; // aggregate
+   int *ptr; // scalar, pointer
+
+
+   for(i = 0; i<N; i++){
+	A[i] = i;
+   }
+
+   //scalar = 1;
+   /*
+   A[0] = 0; A[50] = 50;
+   new_struct.s = 10; new_struct.S[0] = 10; new_struct.S[1] = 10;
+   ptr = &A[0];
+   ptr[50] = 50; ptr[51] = 51;
+   */
+
+
+#pragma omp target enter data map (to :A)
+#pragma omp target map(from: A) map(present, to: A) map(tofrom: errors)
+{
+   for (i=0; i<N; i++) {
+      if (A[i] != i) {
+	 errors++;
+      }
+      A[i] = 2*i;
+   }
+}
+   for(i=0; i<N; i++){
+	if( i== 1023)   
+	  printf("%d\n", A[i]);
+   }
+
+   return errors;
+
+}
+   int main() {
+   int errors = 0;
+   OMPVV_TEST_OFFLOADING;
+   OMPVV_TEST_AND_SET_VERBOSE(errors, test_map_present() != 0);
+   OMPVV_REPORT_AND_RETURN(errors);
+}              


### PR DESCRIPTION
We are looking to test the 5.1 specification page 347 lines (26-28): 

- "If a **map** clause with a **present** map-type-modifier appears in a **map** clause, then the effect of the clause if ordered before all other **map** clauses that do not have the **present** modifier.

A few issues encountered when trying to formulate a test:

1. Cannot use delete in a target region
2. Cannot use present clause unless a mapping already exists
3. We tried using target enter data map clause to circumvent issue number 2, however in the target region the map(present, to) and map(from) were ignored and instead the mapping established from the target enter data map was used