### PR TITLE
Adding last tests for defaultmap present

### DIFF
--- a/tests/5.1/target/test_target_defaultmap_present_aggregate.c
+++ b/tests/5.1/target/test_target_defaultmap_present_aggregate.c
@@ -26,39 +26,41 @@ int test_defaultmap_present_aggregate() {
    int a[N];
    struct test_struct {
      int s; 
-     int S[N]; 
-   }; 
-
+     int S[2];
+   };
+   
    //Initialize aggregate array
    for (i = 0; i < N; i++) {
       a[i] = i;
    }
-
+   
    //Initialize struct and associated members
    struct test_struct new_struct;
    new_struct.s = 10; new_struct.S[0] = 100; new_struct.S[1] = 1000;
-
-
-   #pragma omp target enter data map(to: a, new_struct)
-   #pragma omp target map(tofrom: errors) defaultmap(present: aggregate)
+   
+   
+   #pragma omp target data map(tofrom: a, new_struct)
    {
+   #pragma omp target map(tofrom: errors) defaultmap(present: aggregate)
+   {  
       for (i = 0; i < N; i++) {
          if(a[i] != i){errors++;}
-         a[i] = 2+i;
+         a[i] += 2;
       }
       
-      if(new_struct.s != 10 || new_struct.S[0] != 100 || new_struct.S[1] != 1000) {errors++;}
+      if(new_struct.s != 10 && new_struct.S[0] != 100 && new_struct.S[1] != 1000) {errors++;}
       new_struct.s = 7; new_struct.S[0] = 70; new_struct.S[1] = 700;
    }
-
+   }
+     
    OMPVV_ERROR_IF(errors > 0, "Values were not mapped to the device properly");
 
    for (i = 0; i < N; i++) {
-      OMPVV_TEST_AND_SET_VERBOSE(errors, a[i] == 2+i);
+      OMPVV_TEST_AND_SET(errors, a[i] != 2+i);
    }
 
-   OMPVV_TEST_AND_SET_VERBOSE(errors, new_struct.s == 7 ||  new_struct.S[0] == 70 || new_struct.S[1] == 700);
-  
+   OMPVV_TEST_AND_SET(errors, new_struct.s != 7 &&  new_struct.S[0] != 70 && new_struct.S[1] != 700);
+ 
    return errors;
 }
 
@@ -68,4 +70,5 @@ int main() {
    OMPVV_TEST_AND_SET_VERBOSE(errors, test_defaultmap_present_aggregate() != 0);
    OMPVV_REPORT_AND_RETURN(errors);
 }
+
     

--- a/tests/5.1/target/test_target_defaultmap_present_aggregate.c
+++ b/tests/5.1/target/test_target_defaultmap_present_aggregate.c
@@ -1,0 +1,71 @@
+//===--- test_target_defaultmap_present_aggregate.c -------------------------===//
+//
+//  OpenMP API Version 5.1 Aug 2021
+//
+//  This test checks behavior of the defaultmap clause when the specified 
+//  implicit-behavior is present. The variable-categories available for defaultmap
+//  are scalar, aggregate, and pointer. If implicit-behavior is present, each 
+//  variable referenced in the construct in the category specified by 
+//  variable-category is treated as if it had been listed in a map clause wih the
+//  map-type of alloc and map-type-modifier of present.
+//
+////===----------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+#include <math.h>
+
+#define N 1024
+
+int test_defaultmap_present_aggregate() {
+
+   int errors = 0;
+   int i;
+   int a[N];
+   struct test_struct {
+     int s; 
+     int S[N]; 
+   }; 
+
+   //Initialize aggregate array
+   for (i = 0; i < N; i++) {
+      a[i] = i;
+   }
+
+   //Initialize struct and associated members
+   struct test_struct new_struct;
+   new_struct.s = 10; new_struct.S[0] = 100; new_struct.S[1] = 1000;
+
+
+   #pragma omp target enter data map(to: a, new_struct)
+   #pragma omp target map(tofrom: errors) defaultmap(present: aggregate)
+   {
+      for (i = 0; i < N; i++) {
+         if(a[i] != i){errors++;}
+         a[i] = 2+i;
+      }
+      
+      if(new_struct.s != 10 || new_struct.S[0] != 100 || new_struct.S[1] != 1000) {errors++;}
+      new_struct.s = 7; new_struct.S[0] = 70; new_struct.S[1] = 700;
+   }
+
+   OMPVV_ERROR_IF(errors > 0, "Values were not mapped to the device properly");
+
+   for (i = 0; i < N; i++) {
+      OMPVV_TEST_AND_SET_VERBOSE(errors, a[i] == 2+i);
+   }
+
+   OMPVV_TEST_AND_SET_VERBOSE(errors, new_struct.s == 7 ||  new_struct.S[0] == 70 || new_struct.S[1] == 700);
+  
+   return errors;
+}
+
+int main() {
+   int errors = 0;
+   OMPVV_TEST_OFFLOADING;
+   OMPVV_TEST_AND_SET_VERBOSE(errors, test_defaultmap_present_aggregate() != 0);
+   OMPVV_REPORT_AND_RETURN(errors);
+}
+    

--- a/tests/5.1/target/test_target_defaultmap_present_aggregate.c
+++ b/tests/5.1/target/test_target_defaultmap_present_aggregate.c
@@ -48,7 +48,7 @@ int test_defaultmap_present_aggregate() {
          a[i] += 2;
       }
       
-      if(new_struct.s != 10 && new_struct.S[0] != 100 && new_struct.S[1] != 1000) {errors++;}
+      if(new_struct.s != 10 || new_struct.S[0] != 100 || new_struct.S[1] != 1000) {errors++;}
       new_struct.s = 7; new_struct.S[0] = 70; new_struct.S[1] = 700;
    }
    }
@@ -59,7 +59,7 @@ int test_defaultmap_present_aggregate() {
       OMPVV_TEST_AND_SET(errors, a[i] != 2+i);
    }
 
-   OMPVV_TEST_AND_SET(errors, new_struct.s != 7 &&  new_struct.S[0] != 70 && new_struct.S[1] != 700);
+   OMPVV_TEST_AND_SET(errors, new_struct.s != 7 ||  new_struct.S[0] != 70 || new_struct.S[1] != 700);
  
    return errors;
 }

--- a/tests/5.1/target/test_target_defaultmap_present_pointer.c
+++ b/tests/5.1/target/test_target_defaultmap_present_pointer.c
@@ -1,0 +1,59 @@
+//===--- test_target_defaultmap_present_pointer.c ---------------------------===//
+//
+//  OpenMP API Version 5.1 Aug 2021
+//
+//  This test checks behavior of the defaultmap clause when the specified 
+//  implicit-behavior is present. The variable-categories available for defaultmap
+//  are scalar, aggregate, and pointer. If implicit-behavior is present, each 
+//  variable referenced in the construct in the category specified by 
+//  variable-category is treated as if it had been listed in a map clause wih the
+//  map-type of alloc and map-type-modifier of present.
+//
+////===----------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+#include <math.h>
+
+#define N 1024
+
+int test_defaultmap_present_pointer() {
+
+   int errors = 0;
+   int i;
+
+   int *pointer1 = malloc(N * sizeof(int));
+
+   for (i = 0; i < N; i++) {
+      pointer1[i] = i;
+   }
+
+
+   #pragma omp target enter data map(to: pointer1)
+   #pragma omp target map(tofrom: errors, pointer1) defaultmap(present: pointer)
+   {
+      for (i = 0; i < N; i++) {
+	 if (pointer1[i] != i) {errors++;}
+	 pointer1[i] = 2+i;
+      }
+   }
+
+   OMPVV_ERROR_IF(errors > 0, "Values were not mapped to the device properly");
+
+   for (i = 0; i < N; i++) {
+      OMPVV_TEST_AND_SET_VERBOSE(errors, pointer1[i] == 2+i);
+   }
+
+   OMPVV_INFOMSG_IF(pointer1[1] == 3, "Values were mapped back to the device, inproper behavior");
+
+   return errors;
+}
+
+int main() {
+   int errors = 0;
+   OMPVV_TEST_OFFLOADING;
+   OMPVV_TEST_AND_SET_VERBOSE(errors, test_defaultmap_present_pointer() != 0);
+   OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.1/target/test_target_defaultmap_present_pointer.c
+++ b/tests/5.1/target/test_target_defaultmap_present_pointer.c
@@ -32,7 +32,7 @@ int test_defaultmap_present_pointer() {
 
 
    #pragma omp target enter data map(to: pointer1)
-   #pragma omp target map(tofrom: errors, pointer1) defaultmap(present: pointer)
+   #pragma omp target map(tofrom: errors) defaultmap(present: pointer)
    {
       for (i = 0; i < N; i++) {
 	 if (pointer1[i] != i) {errors++;}

--- a/tests/5.1/target/test_target_defaultmap_present_pointer.c
+++ b/tests/5.1/target/test_target_defaultmap_present_pointer.c
@@ -20,33 +20,35 @@
 #define N 1024
 
 int test_defaultmap_present_pointer() {
-
+   
    int errors = 0;
    int i;
-
-   int *pointer1 = malloc(N * sizeof(int));
-
+   
+   int *ptr;
+   int A[N];
+   
    for (i = 0; i < N; i++) {
-      pointer1[i] = i;
+      A[i] = i;
    }
-
-
-   #pragma omp target enter data map(to: pointer1)
+   
+   
+   #pragma omp target enter data map(to: ptr)
    #pragma omp target map(tofrom: errors) defaultmap(present: pointer)
-   {
+   {  
+      ptr = &A[0];
       for (i = 0; i < N; i++) {
-	 if (pointer1[i] != i) {errors++;}
-	 pointer1[i] = 2+i;
+         if (ptr[i] != i) {
+           errors++;
+         }
+         ptr[i] = 2+i;
       }
    }
-
+   
    OMPVV_ERROR_IF(errors > 0, "Values were not mapped to the device properly");
-
+   
    for (i = 0; i < N; i++) {
-      OMPVV_TEST_AND_SET_VERBOSE(errors, pointer1[i] == 2+i);
+      OMPVV_TEST_AND_SET_VERBOSE(errors, A[i] != 2+i);
    }
-
-   OMPVV_INFOMSG_IF(pointer1[1] == 3, "Values were mapped back to the device, inproper behavior");
 
    return errors;
 }


### PR DESCRIPTION
Tests for defaultmap with the present clause when pointer or aggregate is specified. Test for when scalar is specified already exists, so does the test for defaultmap with no variable-type specified.

**The first test for defaultmap(aggregate) passes. The second test for defaultmap(pointer) does not, due to values improperly mapped back to the device**