### PR TITLE
Allocate directive new tests

### DIFF
--- a/tests/5.0/allocate/test_allocate.c
+++ b/tests/5.0/allocate/test_allocate.c
@@ -1,0 +1,47 @@
+//===----------------- test_allocate.c ------------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// Tests the allocate directive. A variable 'x' is allocated using 
+// the omp_alloc call. If no clause is specified then the memory allocator s
+// pecified by the def-allocator-var ICV will be used. The tests 
+// checks that the values were written correctly, and then frees the memory.
+//
+//===----------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+int test_allocate() {
+  int errors = 0;
+  int* x;
+
+#pragma omp allocate(x) 
+  x = (int *) omp_alloc(N*sizeof(int), omp_null_allocator);
+
+#pragma omp parallel for 
+  for (int i = 0; i < N; i++) {
+    x[i] = i;
+  }
+
+  for (int i = 0; i < N; i++) {
+    OMPVV_TEST_AND_SET_VERBOSE(errors, x[i] != i);
+  }
+
+  omp_free(x,omp_default_mem_alloc);
+
+  return errors;
+}
+
+int main() {
+
+  int errors = 0;
+
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_allocate() != 0);
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.0/allocate/test_allocate.c
+++ b/tests/5.0/allocate/test_allocate.c
@@ -21,7 +21,6 @@ int test_allocate() {
   int* x;
 
 #pragma omp allocate(x) 
-  x = (int *) omp_alloc(N*sizeof(int), omp_null_allocator);
 
 #pragma omp parallel for 
   for (int i = 0; i < N; i++) {
@@ -32,7 +31,6 @@ int test_allocate() {
     OMPVV_TEST_AND_SET_VERBOSE(errors, x[i] != i);
   }
 
-  omp_free(x,omp_default_mem_alloc);
 
   return errors;
 }

--- a/tests/5.0/allocate/test_allocate.c
+++ b/tests/5.0/allocate/test_allocate.c
@@ -18,7 +18,7 @@
 
 int test_allocate() {
   int errors = 0;
-  int* x;
+  int x[N];
 
 #pragma omp allocate(x) 
 

--- a/tests/5.0/allocate/test_allocate_on_device.c
+++ b/tests/5.0/allocate/test_allocate_on_device.c
@@ -7,7 +7,9 @@
 // According to the spec omp_alloc invocations that appear in target regions 
 // must not pass omp_null_allocator as the allocator argument, which must be 
 // a constant expression that evaluates to one of the predefined memory allocator 
-// values. The test checks that the values were written correctly, and then frees the memory.
+// values. Predefined allocators appearing in a uses_allocators clause cannot 
+// have traits specified. The test checks that the values were written correctly, 
+// and then frees the memory.
 //
 //===----------------------------------------------------------------------===//
 
@@ -22,7 +24,7 @@ int test_allocate_on_device() {
 
   int A[N], errors = 0;
 
-#pragma omp target map(tofrom: errors, A)
+#pragma omp target map(tofrom: errors, A) uses_allocators(omp_default_mem_alloc)
   {
    int* x;
    #pragma omp allocate(x) allocator(omp_default_mem_alloc)

--- a/tests/5.0/allocate/test_allocate_on_device.c
+++ b/tests/5.0/allocate/test_allocate_on_device.c
@@ -1,0 +1,55 @@
+//===----------------- test_allocate_on_device.c ------------------------------------===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// Tests the allocate directive with allocator clause in the target region.
+// A variable 'x' is allocated using and omp_default_mem_alloc allocator. 
+// According to the spec omp_alloc invocations that appear in target regions 
+// must not pass omp_null_allocator as the allocator argument, which must be 
+// a constant expression that evaluates to one of the predefined memory allocator 
+// values. The test checks that the values were written correctly, and then frees the memory.
+//
+//===----------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+int test_allocate_on_device() {
+
+  int A[N], errors = 0;
+
+#pragma omp target map(tofrom: errors, A)
+  {
+   int* x;
+   #pragma omp allocate(x) allocator(omp_default_mem_alloc)
+   x = (int *) omp_alloc(N*sizeof(int), omp_default_mem_alloc);
+
+   #pragma omp parallel for 
+    for (int i = 0; i < N; i++) {
+      x[i] = 2*i;
+    }
+    for (int i = 0; i < N; i++) {
+      A[i] = x[i] + i;
+    }
+    omp_free(x, omp_default_mem_alloc);
+  }
+  for (int i = 0; i < N; i++) {
+    OMPVV_TEST_AND_SET_VERBOSE(errors, A[i] != 3*i);
+  }
+  return errors;
+}
+
+int main() {
+
+  int errors = 0;
+
+  OMPVV_TEST_OFFLOADING;
+
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_allocate_on_device() != 0);
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.1/allocate/test_allocate_allocator_align.c
+++ b/tests/5.1/allocate/test_allocate_allocator_align.c
@@ -1,4 +1,4 @@
-//===------ test_allocate_allocators.c ------------------------------------===//
+//===------ test_allocate_allocator_align.c ------------------------------------===//
 //
 // OpenMP API Version 5.1 Nov 2020
 //
@@ -18,7 +18,7 @@
 
 #define N 1024
 
-int test_allocate_allocator() {
+int test_allocate_allocator_align() {
   int errors = 0;
 
   int* x;
@@ -48,7 +48,7 @@ int main() {
 
   int errors = 0;
 
-  OMPVV_TEST_AND_SET_VERBOSE(errors, test_allocate_allocator() != 0);
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_allocate_allocator_align() != 0);
 
   OMPVV_REPORT_AND_RETURN(errors);
 }

--- a/tests/5.1/allocate/test_allocate_allocator_align.c
+++ b/tests/5.1/allocate/test_allocate_allocator_align.c
@@ -37,8 +37,6 @@ int test_allocate_allocator_align() {
     OMPVV_TEST_AND_SET_VERBOSE(errors, x[i] != i);
   }
 
-  omp_free(x, omp_default_mem_alloc);
-
   return errors;
 }
 

--- a/tests/5.1/allocate/test_allocate_allocator_align.c
+++ b/tests/5.1/allocate/test_allocate_allocator_align.c
@@ -1,0 +1,54 @@
+//===------ test_allocate_allocators.c ------------------------------------===//
+//
+// OpenMP API Version 5.1 Nov 2020
+//
+// Tests the allocate directive with allocator and align clause.
+// The declarative allocator statement uses the omp_default_mem_alloc handle
+// for default memory allocation for "x", aligned to 64-byte alignment via the 
+// align clause. Parallel region checks that 64-byte alignment is correct 
+// and that the memory can be written to in and the values
+// were written correctly, and then frees the memory.
+//
+//===----------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+int test_allocate_allocator() {
+  int errors = 0;
+
+  int* x;
+
+#pragma omp allocate(x) allocator(omp_default_mem_alloc) align(64)
+
+  x = (int *) omp_alloc(N*sizeof(int), omp_default_mem_alloc);
+
+#pragma omp target map(from:x[:N])
+{	
+#pragma omp parallel for simd simdlen(16) aligned(x: 64)
+  for (int i = 0; i < N; i++) {
+    x[i] = i;
+  }
+}
+  for (int i = 0; i < N; i++) {
+    OMPVV_TEST_AND_SET_VERBOSE(errors, x[i] != i);
+  }
+
+  omp_free(x, omp_default_mem_alloc);
+
+  return errors;
+}
+
+int main() {
+  OMPVV_TEST_OFFLOADING;
+
+  int errors = 0;
+
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_allocate_allocator() != 0);
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.1/allocate/test_allocate_allocator_align.c
+++ b/tests/5.1/allocate/test_allocate_allocator_align.c
@@ -21,11 +21,10 @@
 int test_allocate_allocator_align() {
   int errors = 0;
 
-  int* x;
+  int x[N];
 
 #pragma omp allocate(x) allocator(omp_default_mem_alloc) align(64)
 
-  x = (int *) omp_alloc(N*sizeof(int), omp_default_mem_alloc);
 
 #pragma omp target map(from:x[:N])
 {	


### PR DESCRIPTION
New 5.0 and 5.1 allocate tests. 
5.0 host test tested with LLVM. Device version not supported by GCC or LLVM.
5.1 feature not supported by LLVM trunk.