### PR TITLE
Update issue templates: remove jhdavis

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: ''
 labels: ''
-assignees: jhdavis8, tmh97
+assignees: tmh97
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: ''
 labels: ''
-assignees: tmh97
+assignees: nolanbaker31, tmh97
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,7 @@ name: Feature request
 about: Suggest an idea for this project
 title: ''
 labels: enhancement
-assignees: tmh97
+assignees: nolanbaker31, tmh97
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,7 @@ name: Feature request
 about: Suggest an idea for this project
 title: ''
 labels: enhancement
-assignees: jhdavis8, tmh97
+assignees: tmh97
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/test-request.md
+++ b/.github/ISSUE_TEMPLATE/test-request.md
@@ -3,7 +3,7 @@ name: Test request
 about: Idea for a test to be implemented
 title: ''
 labels: new test
-assignees: tmh97
+assignees: nolanbaker31, tmh97
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/test-request.md
+++ b/.github/ISSUE_TEMPLATE/test-request.md
@@ -3,7 +3,7 @@ name: Test request
 about: Idea for a test to be implemented
 title: ''
 labels: new test
-assignees: tmh97, jhdavis8
+assignees: tmh97
 
 ---
 


### PR DESCRIPTION
This is just to remove myself from the issue template auto-assign, since I'm not actively working on the test suite anymore, and otherwise it sends me emails for new issues and PRs related to those issues.

Feel free to add anyone else working on the project as a new auto-assignee to replace me if desired!

Best wishes, Josh