### PR TITLE
Target 'has_device_addr' 5.1 Test

### DIFF
--- a/tests/5.1/target/test_target_has_device_addr.c
+++ b/tests/5.1/target/test_target_has_device_addr.c
@@ -28,16 +28,25 @@ int test_target_has_device_addr() {
   int *first_arr_device_addr;
   int *second_scalar_device_addr;
   int *second_arr_device_addr;
-  #pragma omp target map(from: first_scalar_device_addr, first_arr_device_addr)
+  #pragma omp target enter data map(to: x, arr)
+  #pragma omp target map(from: first_scalar_device_addr, first_arr_device_addr) map(to: x, arr)
   {
     first_scalar_device_addr = &x;
     first_arr_device_addr = &arr[0];
   }
-  #pragma omp target map(from:second_scalar_device_addr, second_arr_device_addr) has_device_addr(x, arr[N]) 
+  int *data_x, *data_arr;
+  #pragma omp target data use_device_addr(x,arr)
+  {
+  data_x = &x; data_arr = &arr[0];
+  #pragma omp target map(from:second_scalar_device_addr, second_arr_device_addr) has_device_addr(x, arr) 
   {
     second_scalar_device_addr = &x;
     second_arr_device_addr = &arr[0];
   }
+  }
+ #pragma omp target exit data map(release: x, arr)
+ OMPVV_TEST_AND_SET(errors, first_scalar_device_addr != data_x);
+ OMPVV_TEST_AND_SET(errors, first_arr_device_addr != data_arr);
   OMPVV_TEST_AND_SET(errors, first_scalar_device_addr != second_scalar_device_addr);
   OMPVV_TEST_AND_SET(errors, first_arr_device_addr != second_arr_device_addr)
   return errors;

--- a/tests/5.1/target/test_target_has_device_addr.c
+++ b/tests/5.1/target/test_target_has_device_addr.c
@@ -35,6 +35,7 @@ int test_target_has_device_addr() {
   }
   int *second_scalar_device_addr, *second_arr_device_addr;
   //check addresses are same on device region
+  #pragma omp target data use_device_addr(x, arr)
   #pragma omp target map(from:second_scalar_device_addr, second_arr_device_addr) has_device_addr(x, arr) 
   {
     second_scalar_device_addr = &x;

--- a/tests/5.1/target/test_target_has_device_addr.c
+++ b/tests/5.1/target/test_target_has_device_addr.c
@@ -3,9 +3,9 @@
 // OpenMP API Version 5.1 Nov 2020
 //
 // This test verifies the 'has_device_addr' feature added to the target construct.
-// We tested this by checking a scalar & array address in one target region, and
-// verifying that the address remains the same in a second target region which
-// uses the 'has_device_addr' feature.
+// We tested this by mapping a scalar & array to the device (using both target map
+// & omp_target_alloc) and ensuring that the address does not change when using
+// has_device_addr on another target region.
 //
 ////===----------------------------------------------------------------------===//
 #include <assert.h>
@@ -16,18 +16,17 @@
 
 #define N 1000
 
+//test by mapping to device use 'target map' construct
 int test_target_has_device_addr() {
   OMPVV_INFOMSG("test_target_has_device_addr");
   int errors = 0;
   int x = 10;
   int arr[N];
   for(int i=0;i<N;i++){
-      arr[i] = i;
+    arr[i] = i;
   }
   int *first_scalar_device_addr;
   int *first_arr_device_addr;
-  int *second_scalar_device_addr;
-  int *second_arr_device_addr;
   #pragma omp target enter data map(to: x, arr)
   #pragma omp target map(from: first_scalar_device_addr, first_arr_device_addr) map(to: x, arr)
   {
@@ -35,18 +34,54 @@ int test_target_has_device_addr() {
     first_arr_device_addr = &arr[0];
   }
   int *data_x, *data_arr;
+  int *second_scalar_device_addr, *second_arr_device_addr;
+  //check addresses are same on both target data region & device region
   #pragma omp target data use_device_addr(x,arr)
   {
-  data_x = &x; data_arr = &arr[0];
-  #pragma omp target map(from:second_scalar_device_addr, second_arr_device_addr) has_device_addr(x, arr) 
+    data_x = &x; data_arr = &arr[0];
+    #pragma omp target map(from:second_scalar_device_addr, second_arr_device_addr) has_device_addr(x, arr) 
+    {
+      second_scalar_device_addr = &x;
+      second_arr_device_addr = &arr[0];
+    }
+  }
+  #pragma omp target exit data map(release: x, arr)
+  OMPVV_TEST_AND_SET(errors, first_scalar_device_addr != data_x);
+  OMPVV_TEST_AND_SET(errors, first_arr_device_addr != data_arr);
+  OMPVV_TEST_AND_SET(errors, first_scalar_device_addr != second_scalar_device_addr);
+  OMPVV_TEST_AND_SET(errors, first_arr_device_addr != second_arr_device_addr)
+  return errors;
+}
+
+//test by mapping to device use 'omp_target_alloc' construct
+int test_target_has_dev_addr_alloc(){
+
+  OMPVV_INFOMSG("test_target_has_device_addr_alloc");
+  int errors = 0;
+  int x = 10;
+  int arr[N];
+  for(int i=0;i<N;i++){
+    arr[i] = i;
+  }
+  int dev = omp_get_default_device();
+  int *first_scalar_device_addr = (int *)omp_target_alloc(sizeof(int), omp_get_default_device());
+  int *first_arr_device_addr = (int *)omp_target_alloc(sizeof(int) * N, omp_get_default_device());
+  #pragma omp target enter data map(to: x, arr)
+  int *data_x, *data_arr;
+  int *second_scalar_device_addr, *second_arr_device_addr;
+  //check addresses are same on both target data region & device region
+  #pragma omp target data use_device_addr(x,arr)
   {
-    second_scalar_device_addr = &x;
-    second_arr_device_addr = &arr[0];
+    data_x = &x; data_arr = &arr[0];
+    #pragma omp target map(from:second_scalar_device_addr, second_arr_device_addr) has_device_addr(x, arr) 
+    {
+      second_scalar_device_addr = &x;
+      second_arr_device_addr = &arr[0];
+    }
   }
-  }
- #pragma omp target exit data map(release: x, arr)
- OMPVV_TEST_AND_SET(errors, first_scalar_device_addr != data_x);
- OMPVV_TEST_AND_SET(errors, first_arr_device_addr != data_arr);
+  #pragma omp target exit data map(release: x, arr)
+  OMPVV_TEST_AND_SET(errors, first_scalar_device_addr != data_x);
+  OMPVV_TEST_AND_SET(errors, first_arr_device_addr != data_arr);
   OMPVV_TEST_AND_SET(errors, first_scalar_device_addr != second_scalar_device_addr);
   OMPVV_TEST_AND_SET(errors, first_arr_device_addr != second_arr_device_addr)
   return errors;
@@ -56,7 +91,6 @@ int main() {
   OMPVV_TEST_OFFLOADING;
   int errors = 0;
   OMPVV_TEST_AND_SET_VERBOSE(errors, test_target_has_device_addr());
-
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_target_has_dev_addr_alloc());
   OMPVV_REPORT_AND_RETURN(errors);
 }
-

--- a/tests/5.1/target/test_target_has_device_addr.c
+++ b/tests/5.1/target/test_target_has_device_addr.c
@@ -3,8 +3,8 @@
 // OpenMP API Version 5.1 Nov 2020
 //
 // This test verifies the 'has_device_addr' feature added to the target construct.
-// We tested this by mapping a scalar & array to the device (using both target map
-// & omp_target_alloc) and ensuring that the address does not change when using
+// We tested this by mapping a scalar & array to the device
+// and ensuring that the address does not change when using
 // has_device_addr on another target region.
 //
 ////===----------------------------------------------------------------------===//
@@ -33,55 +33,14 @@ int test_target_has_device_addr() {
     first_scalar_device_addr = &x;
     first_arr_device_addr = &arr[0];
   }
-  int *data_x, *data_arr;
   int *second_scalar_device_addr, *second_arr_device_addr;
-  //check addresses are same on both target data region & device region
-  #pragma omp target data use_device_addr(x,arr)
+  //check addresses are same on device region
+  #pragma omp target map(from:second_scalar_device_addr, second_arr_device_addr) has_device_addr(x, arr) 
   {
-    data_x = &x; data_arr = &arr[0];
-    #pragma omp target map(from:second_scalar_device_addr, second_arr_device_addr) has_device_addr(x, arr) 
-    {
-      second_scalar_device_addr = &x;
-      second_arr_device_addr = &arr[0];
-    }
+    second_scalar_device_addr = &x;
+    second_arr_device_addr = &arr[0];
   }
   #pragma omp target exit data map(release: x, arr)
-  OMPVV_TEST_AND_SET(errors, first_scalar_device_addr != data_x);
-  OMPVV_TEST_AND_SET(errors, first_arr_device_addr != data_arr);
-  OMPVV_TEST_AND_SET(errors, first_scalar_device_addr != second_scalar_device_addr);
-  OMPVV_TEST_AND_SET(errors, first_arr_device_addr != second_arr_device_addr)
-  return errors;
-}
-
-//test by mapping to device use 'omp_target_alloc' construct
-int test_target_has_dev_addr_alloc(){
-
-  OMPVV_INFOMSG("test_target_has_device_addr_alloc");
-  int errors = 0;
-  int x = 10;
-  int arr[N];
-  for(int i=0;i<N;i++){
-    arr[i] = i;
-  }
-  int dev = omp_get_default_device();
-  int *first_scalar_device_addr = (int *)omp_target_alloc(sizeof(int), omp_get_default_device());
-  int *first_arr_device_addr = (int *)omp_target_alloc(sizeof(int) * N, omp_get_default_device());
-  #pragma omp target enter data map(to: x, arr)
-  int *data_x, *data_arr;
-  int *second_scalar_device_addr, *second_arr_device_addr;
-  //check addresses are same on both target data region & device region
-  #pragma omp target data use_device_addr(x,arr)
-  {
-    data_x = &x; data_arr = &arr[0];
-    #pragma omp target map(from:second_scalar_device_addr, second_arr_device_addr) has_device_addr(x, arr) 
-    {
-      second_scalar_device_addr = &x;
-      second_arr_device_addr = &arr[0];
-    }
-  }
-  #pragma omp target exit data map(release: x, arr)
-  OMPVV_TEST_AND_SET(errors, first_scalar_device_addr != data_x);
-  OMPVV_TEST_AND_SET(errors, first_arr_device_addr != data_arr);
   OMPVV_TEST_AND_SET(errors, first_scalar_device_addr != second_scalar_device_addr);
   OMPVV_TEST_AND_SET(errors, first_arr_device_addr != second_arr_device_addr)
   return errors;
@@ -91,6 +50,5 @@ int main() {
   OMPVV_TEST_OFFLOADING;
   int errors = 0;
   OMPVV_TEST_AND_SET_VERBOSE(errors, test_target_has_device_addr());
-  OMPVV_TEST_AND_SET_VERBOSE(errors, test_target_has_dev_addr_alloc());
   OMPVV_REPORT_AND_RETURN(errors);
 }

--- a/tests/5.1/target/test_target_has_device_addr.c
+++ b/tests/5.1/target/test_target_has_device_addr.c
@@ -1,0 +1,53 @@
+//===--- test_target_has_device_addr.c --------------------------------------===//
+//
+// OpenMP API Version 5.1 Nov 2020
+//
+// This test verifies the 'has_device_addr' feature added to the target construct.
+// We tested this by checking a scalar & array address in one target region, and
+// verifying that the address remains the same in a second target region which
+// uses the 'has_device_addr' feature.
+//
+////===----------------------------------------------------------------------===//
+#include <assert.h>
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1000
+
+int test_target_has_device_addr() {
+  OMPVV_INFOMSG("test_target_has_device_addr");
+  int errors = 0;
+  int x = 10;
+  int arr[N];
+  for(int i=0;i<N;i++){
+      arr[i] = i;
+  }
+  int *first_scalar_device_addr;
+  int *first_arr_device_addr;
+  int *second_scalar_device_addr;
+  int *second_arr_device_addr;
+  #pragma omp target map(from: first_scalar_device_addr, first_arr_device_addr)
+  {
+    first_scalar_device_addr = &x;
+    first_arr_device_addr = &arr[0];
+  }
+  #pragma omp target map(from:second_scalar_device_addr, second_arr_device_addr) has_device_addr(x, arr[N]) 
+  {
+    second_scalar_device_addr = &x;
+    second_arr_device_addr = &arr[0];
+  }
+  OMPVV_TEST_AND_SET(errors, first_scalar_device_addr != second_scalar_device_addr);
+  OMPVV_TEST_AND_SET(errors, first_arr_device_addr != second_arr_device_addr)
+  return errors;
+}
+
+int main() {
+  OMPVV_TEST_OFFLOADING;
+  int errors = 0;
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_target_has_device_addr());
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}
+


### PR DESCRIPTION
Currently passes, with the target 'has_device_addr' clause unrecognized. (currently not implemented in LLVM).

Let me know if test seems to properly test the clause, not sure if there is a better way to test that would only pass if the clause functions properly.