### PR TITLE
Add new_test/test_target_allocate.F90.

### DIFF
--- a/tests/5.0/target/test_target_allocate.F90
+++ b/tests/5.0/target/test_target_allocate.F90
@@ -35,7 +35,7 @@ CONTAINS
     END DO
 
 
-    !$omp target allocate(x) firstprivate(x) map(from: device_result)
+    !$omp target allocate(omp_default_mem_alloc:x) firstprivate(x) map(from: device_result)
     DO i = 1, N
        x = x + i
     END DO

--- a/tests/5.0/target/test_target_allocate.F90
+++ b/tests/5.0/target/test_target_allocate.F90
@@ -1,0 +1,49 @@
+!===--- test_target_allocate.F90 -------------------------------===//
+!
+! OpenMP API Version 5.0 Nov 2018
+!
+! Tests the target directive with allocate clause.
+! 
+!//===----------------------------------------------------------------------===//
+#include "ompvv.F90"
+
+#define N 1024
+
+PROGRAM test_target_allocate
+  USE iso_fortran_env
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+  OMPVV_TEST_OFFLOADING
+
+  OMPVV_TEST_VERBOSE(target_allocate() .ne. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION target_allocate()
+    INTEGER :: errors, i
+    INTEGER :: x, host_result, device_result
+
+    errors = 0
+    x = 0
+    host_result = 0
+    device_result = 0
+
+    DO i = 1, N
+       host_result = host_result + i
+    END DO
+
+
+    !$omp target allocate(x) firstprivate(x) map(from: device_result)
+    DO i = 1, N
+       x = x + i
+    END DO
+    device_result = x
+    !$omp end target
+
+    OMPVV_TEST_AND_SET(errors, device_result /= host_result)
+
+    target_allocate = errors
+  END FUNCTION target_allocate
+END PROGRAM test_target_allocate

--- a/tests/5.0/target/test_target_allocate.c
+++ b/tests/5.0/target/test_target_allocate.c
@@ -24,7 +24,7 @@ int test_target_allocate() {
       host_result += i;
    }
    
-   #pragma omp target allocate(x) firstprivate(x) map(from: device_result)
+   #pragma omp target allocate(omp_default_mem_alloc:x) firstprivate(x) map(from: device_result)
    {
       for (int i = 0; i < N; i++) {
          x += i;

--- a/tests/5.0/target/test_target_allocate.c
+++ b/tests/5.0/target/test_target_allocate.c
@@ -1,4 +1,4 @@
-//===------ test_allocate_allocators.c --------------------------------------===//
+//===------ test_target_allocate.c --------------------------------------===//
 //
 // OpenMP API Version 5.0 Nov 2018
 //


### PR DESCRIPTION
Test fails with both GCC11.1.0 and XLF16.1.1-10 (not supported).

OpenMP V5.0 spec says the following restriction (section 2.11.4 - allocate clause, line 17 ~ 19 on page 159): 

"allocate clauses that appear on a target construct or on constructs in a target region must specify an allocator expression unless a requires directive with the dynamic_allocators clause is present in the same compilation unit."

However, the C version (and Fortran version too) does not use an allocator expression, but the C version compiled with GCC11.1.0 passes the test. 