### PR TITLE
compiler not allowing default(private) as a valid data-sharing type

### DIFF
--- a/tests/5.1/default/test_task_default_private.c
+++ b/tests/5.1/default/test_task_default_private.c
@@ -23,20 +23,21 @@
 int test_task_default_private(){
 	int errors = 0;
 	int test_num= 1;
-	int temp_errors1 = 0;
+	int sum = 0;
 	int *ptr1 = &test_num;
 
-	#pragma omp task shared(temp_errors1) private(test_num)
+	#pragma omp target map(tofrom: sum, test_num)
+	{
+	#pragma omp task shared(sum) private(test_num)
 	{
 
 		int test_num = 2;
-		if (*ptr1 != 1){
-			temp_errors1 = 1;
-		}
+		sum += test_num;
 		
+	}
 	}	
-	OMPVV_TEST_AND_SET_VERBOSE(errors, temp_errors1 != 0);
-	OMPVV_INFOMSG_IF(temp_errors1 == 1, "Original value was overridden");
+	OMPVV_TEST_AND_SET_VERBOSE(errors, sum != 2);
+	OMPVV_INFOMSG_IF(sum == 1, "Did not use variable delcared in task region");
 	return errors;
 }
 

--- a/tests/5.1/default/test_task_default_private.c
+++ b/tests/5.1/default/test_task_default_private.c
@@ -24,13 +24,11 @@ int test_task_default_private(){
 	int errors = 0;
 	int test_num= 1;
 	int sum = 0;
-	int *ptr1 = &test_num;
-
+	
+	#pragma omp task shared(sum) default(private)
+	{
 	#pragma omp target map(tofrom: sum, test_num)
 	{
-	#pragma omp task shared(sum) private(test_num)
-	{
-
 		int test_num = 2;
 		sum += test_num;
 		

--- a/tests/5.1/default/test_task_default_private.c
+++ b/tests/5.1/default/test_task_default_private.c
@@ -22,38 +22,22 @@
 
 int test_task_default_private(){
 	int errors = 0;
-	int test_num = 1;
-	int test_arr[N];
-	int sum = 0;
-	int old_sum = 0;
-	for (int i =0; i<N; i++){
-		test_arr[i] = i;
-		old_sum += i;
-	}
+	int test_num= 1;
+	int temp_errors1 = 0;
+	int *ptr1 = &test_num;
 
-	#pragma omp target map(tofrom: test_num, test_arr, sum)
+	#pragma omp task shared(temp_errors1) private(test_num)
 	{
-		#pragma omp task shared(test_num) private(test_arr, sum)
-		test_num += 1;
-		for (int i = 0; i<N; i++){
-			test_arr[i] = 1;
-			sum += test_arr[i];
-		}	
 
-	}
-
-	int new_sum = 0;
-	for (int i = 0; i<N; i++){
-		new_sum += test_arr[i];
-	}
-
-	OMPVV_TEST_AND_SET_VERBOSE(errors, test_num != 2);
-	OMPVV_INFOMSG_IF(test_num == 1, "Scalar was not private, changes made inside task region were not kept");
-	OMPVV_TEST_AND_SET_VERBOSE(errors, sum != new_sum);
-        
-	OMPVV_INFOMSG_IF(new_sum == old_sum, "Array was not private, changes made inside task region were not kept");
+		int test_num = 2;
+		if (*ptr1 != 1){
+			temp_errors1 = 1;
+		}
+		
+	}	
+	OMPVV_TEST_AND_SET_VERBOSE(errors, temp_errors1 != 0);
+	OMPVV_INFOMSG_IF(temp_errors1 == 1, "Original value was overridden");
 	return errors;
-
 }
 
 int main(){

--- a/tests/5.1/default/test_task_default_private.c
+++ b/tests/5.1/default/test_task_default_private.c
@@ -12,27 +12,28 @@
 //-----------------------------------------------------------------
 
 #include <omp.h>
+#include "ompvv.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
 
 #define N 1024
 
-int errors;
 
 int test_task_default_private(){
+	int errors = 0;
 	int test_num = 1;
 	int test_arr[N];
 	int sum = 0;
 	int old_sum = 0;
 	for (int i =0; i<N; i++){
 		test_arr[i] = i;
-		old_sum += 1;
+		old_sum += i;
 	}
 
-	#pragma target map(tofrom: test_num, test_arr, sum, N)
+	#pragma target map(tofrom: test_num, test_arr, sum)
 	{
-		#pragma omp task default(private)
+		#pragma omp task private(test_num, test_arr, sum)
 		test_num += 1;
 		for (int i = 0; i<N; i++){
 			test_arr[i] = 1;
@@ -46,16 +47,18 @@ int test_task_default_private(){
 		new_sum += test_arr[i];
 	}
 
-	OMPVV_TEST_AND_SET(errors, test_num != 2);
+	OMPVV_TEST_AND_SET_VERBOSE(errors, test_num != 2);
 	OMPVV_INFOMSG_IF(test_num == 1, "Scalar was not private, changes made inside task region were not kept");
-	OMPVV_TEST_AND_SET(errors, sum != new_sum);
-        OMPVV_TEST_AND_SET(new_sum == old_sum, "Array was not private, changes made inside task region were not kept");
+	OMPVV_TEST_AND_SET_VERBOSE(errors, sum != new_sum);
+        
+	OMPVV_INFOMSG_IF(new_sum == old_sum, "Array was not private, changes made inside task region were not kept");
+	printf("Hi");
 	return errors;
 
 }
 
 int main(){
-	errors = 0;
+	int errors = 0;
 	OMPVV_TEST_OFFLOADING;
 	OMPVV_TEST_AND_SET_VERBOSE(errors, test_task_default_private() != 0);
 	OMPVV_REPORT_AND_RETURN(errors);

--- a/tests/5.1/default/test_task_default_private.c
+++ b/tests/5.1/default/test_task_default_private.c
@@ -31,9 +31,9 @@ int test_task_default_private(){
 		old_sum += i;
 	}
 
-	#pragma target map(tofrom: test_num, test_arr, sum)
+	#pragma omp target map(tofrom: test_num, test_arr, sum)
 	{
-		#pragma omp task private(test_num, test_arr, sum)
+		#pragma omp task shared(test_num) private(test_arr, sum)
 		test_num += 1;
 		for (int i = 0; i<N; i++){
 			test_arr[i] = 1;
@@ -42,7 +42,7 @@ int test_task_default_private(){
 
 	}
 
-	int new_sum;
+	int new_sum = 0;
 	for (int i = 0; i<N; i++){
 		new_sum += test_arr[i];
 	}
@@ -52,7 +52,6 @@ int test_task_default_private(){
 	OMPVV_TEST_AND_SET_VERBOSE(errors, sum != new_sum);
         
 	OMPVV_INFOMSG_IF(new_sum == old_sum, "Array was not private, changes made inside task region were not kept");
-	printf("Hi");
 	return errors;
 
 }

--- a/tests/5.1/default/test_task_default_private.c
+++ b/tests/5.1/default/test_task_default_private.c
@@ -1,0 +1,62 @@
+//-----------test_task_default_private.c---------------------------
+//
+// OpenMP API Version 5.1 Aug 2021
+//
+// Test the behavior of the default clasue when the specified
+// data-sharing attribute is private. This test focuses on the
+// use of the task and target construct and should work for both
+// host and target implementations. Private should allow any data
+// initialized outside of the task region to have its own instance
+// within the task region and retain any value changes made within
+// the region.
+//-----------------------------------------------------------------
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+
+#define N 1024
+
+int errors;
+
+int test_task_default_private(){
+	int test_num = 1;
+	int test_arr[N];
+	int sum = 0;
+	int old_sum = 0;
+	for (int i =0; i<N; i++){
+		test_arr[i] = i;
+		old_sum += 1;
+	}
+
+	#pragma target map(tofrom: test_num, test_arr, sum, N)
+	{
+		#pragma omp task default(private)
+		test_num += 1;
+		for (int i = 0; i<N; i++){
+			test_arr[i] = 1;
+			sum += test_arr[i];
+		}	
+
+	}
+
+	int new_sum;
+	for (int i = 0; i<N; i++){
+		new_sum += test_arr[i];
+	}
+
+	OMPVV_TEST_AND_SET(errors, test_num != 2);
+	OMPVV_INFOMSG_IF(test_num == 1, "Scalar was not private, changes made inside task region were not kept");
+	OMPVV_TEST_AND_SET(errors, sum != new_sum);
+        OMPVV_TEST_AND_SET(new_sum == old_sum, "Array was not private, changes made inside task region were not kept");
+	return errors;
+
+}
+
+int main(){
+	errors = 0;
+	OMPVV_TEST_OFFLOADING;
+	OMPVV_TEST_AND_SET_VERBOSE(errors, test_task_default_private() != 0);
+	OMPVV_REPORT_AND_RETURN(errors);
+}


### PR DESCRIPTION
This is a test for default(private) on a task construct. Currently fails when placed inside of a target region.