### PR TITLE
Add tests/5.0/target/test_target_imperfect_loop.F90

### DIFF
--- a/tests/5.0/target/test_target_imperfect_loop.F90
+++ b/tests/5.0/target/test_target_imperfect_loop.F90
@@ -3,7 +3,7 @@
 ! OpenMP API Version 5.0 Nov 2018
 !
 ! The test maps two arrays to the device and uses the collapse clause on the work 
-! sharing loop construct enclosing two loops. Accorging to 5.0 Spec if more than 
+! sharing loop construct enclosing two loops. According to 5.0 Spec if more than 
 ! one loop is associated with the worksharing-loop construct then the number of 
 ! times that any intervening code between any two associated loops will be executed 
 ! is unspecified but will be at least once per iteration of the loop enclosing the 

--- a/tests/5.0/target/test_target_imperfect_loop.F90
+++ b/tests/5.0/target/test_target_imperfect_loop.F90
@@ -16,6 +16,7 @@
 #include "ompvv.F90"
 
 #define N 10
+#define M 16
 
 PROGRAM test_target_imperfect_loop
   USE iso_fortran_env
@@ -31,14 +32,14 @@ PROGRAM test_target_imperfect_loop
 CONTAINS
   INTEGER FUNCTION target_imperfect_loop()
     INTEGER, DIMENSION(N) :: data1
-    INTEGER, DIMENSION(N,N) :: data2
+    INTEGER, DIMENSION(N,M) :: data2
     INTEGER :: errors, i, j
 
     errors = 0
 
     DO i = 1, N
        data1(i) = 0
-       DO j = 1, N
+       DO j = 1, M
           data2(i,j) = 0
        END DO
     END DO
@@ -47,7 +48,7 @@ CONTAINS
     !$omp parallel do collapse(2)
     DO i = 1, N
        data1(i) = data1(i) + i
-       DO j = 1, N
+       DO j = 1, M
           data2(i,j) = data2(i,j) + i + j
        END DO
     END DO
@@ -56,9 +57,9 @@ CONTAINS
 
     DO i = 1, N
        OMPVV_TEST_AND_SET(errors, data1(i) .lt. i)
-       OMPVV_TEST_AND_SET(errors, data1(i) .gt. i * N)
-       DO j = 1, N
-          OMPVV_TEST_AND_SET(errors, data2(i,j) .ne. i * j)
+       OMPVV_TEST_AND_SET(errors, data1(i) .gt. i * M)
+       DO j = 1, M
+          OMPVV_TEST_AND_SET(errors, data2(i,j) .ne. i + j)
        END DO
     END DO
 

--- a/tests/5.0/target/test_target_imperfect_loop.F90
+++ b/tests/5.0/target/test_target_imperfect_loop.F90
@@ -1,0 +1,67 @@
+!===--- test_target_imperfect_loop.F90 -------------------------------===//
+!
+! OpenMP API Version 5.0 Nov 2018
+!
+! The test maps two arrays to the device and uses the collapse clause on the work 
+! sharing loop construct enclosing two loops. Accorging to 5.0 Spec if more than 
+! one loop is associated with the worksharing-loop construct then the number of 
+! times that any intervening code between any two associated loops will be executed 
+! is unspecified but will be at least once per iteration of the loop enclosing the 
+! intervening code and at most once per iteration of the innermost loop associated 
+! with the construct.The value modified on the device(if oddloaded) and is verified 
+! on the host for correctness.
+! This test is a modified version of an example and provided by LLNL.  
+! 
+!//===----------------------------------------------------------------------===//
+#include "ompvv.F90"
+
+#define N 10
+
+PROGRAM test_target_imperfect_loop
+  USE iso_fortran_env
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+  OMPVV_TEST_OFFLOADING
+
+  OMPVV_TEST_VERBOSE(target_imperfect_loop() .ne. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION target_imperfect_loop()
+    INTEGER, DIMENSION(N) :: data1
+    INTEGER, DIMENSION(N,N) :: data2
+    INTEGER :: errors, i, j
+
+    errors = 0
+
+    DO i = 1, N
+       data1(i) = 0
+       DO j = 1, N
+          data2(i,j) = 0
+       END DO
+    END DO
+
+    !$omp target map(tofrom: data1, data2)
+    !$omp parallel do collapse(2)
+    DO i = 1, N
+       data1(i) = data1(i) + i
+       DO j = 1, N
+          data2(i,j) = data2(i,j) + i + j
+       END DO
+    END DO
+    !$omp end parallel do
+    !$omp end target
+
+    DO i = 1, N
+       OMPVV_TEST_AND_SET(errors, data1(i) .lt. i)
+       OMPVV_TEST_AND_SET(errors, data1(i) .gt. i * N)
+       DO j = 1, N
+          OMPVV_TEST_AND_SET(errors, data2(i,j) .ne. i * j)
+       END DO
+    END DO
+
+    target_imperfect_loop = errors
+  END FUNCTION target_imperfect_loop
+END PROGRAM test_target_imperfect_loop

--- a/tests/5.0/target/test_target_imperfect_loop.c
+++ b/tests/5.0/target/test_target_imperfect_loop.c
@@ -3,7 +3,7 @@
 // OpenMP API Version 5.0 Nov 2018
 //
 // The test maps two arrays to the device and uses the collapse clause on the work 
-// sharing loop construct enclosing two loops. Accorging to 5.0 Spec if more than 
+// sharing loop construct enclosing two loops. According to 5.0 Spec if more than 
 // one loop is associated with the worksharing-loop construct then the number of 
 // times that any intervening code between any two associated loops will be executed 
 // is unspecified but will be at least once per iteration of the loop enclosing the 

--- a/tests/5.0/target/test_target_imperfect_loop.c
+++ b/tests/5.0/target/test_target_imperfect_loop.c
@@ -21,17 +21,18 @@
 #include "ompvv.h"
 
 #define N 10
+#define M 16
 
 int test_target_imperfect_loop() {
   OMPVV_INFOMSG("test_target_imperfect_loop");
 
-  int data1[N], data2[N][N];
+  int data1[N], data2[N][M];
   int errors = 0;
 
 
   for( int i = 0; i < N; i++){
     data1[i] = 0;
-    for(int j = 0; j < N; j++){
+    for(int j = 0; j < M; j++){
       data2[i][j] = 0;
     }
   }
@@ -42,7 +43,7 @@ int test_target_imperfect_loop() {
 #pragma omp parallel for collapse(2)
       for( int i = 0; i < N; i++){
         data1[i] += i;
-        for(int j = 0; j < N; j++){
+        for(int j = 0; j < M; j++){
           data2[i][j] += i + j;
         }
       }
@@ -50,8 +51,8 @@ int test_target_imperfect_loop() {
 
   for( int i=0;i<N;i++){
     OMPVV_TEST_AND_SET(errors,data1[i] < i);
-    OMPVV_TEST_AND_SET(errors,data1[i] > i * N);
-    for(int j=0;j<N;j++){
+    OMPVV_TEST_AND_SET(errors,data1[i] > i * M);
+    for(int j=0;j<M;j++){
       OMPVV_TEST_AND_SET(errors,data2[i][j] != (i+j));
     }
   }


### PR DESCRIPTION
With XLF 16.1.1-10, compiled without errors, but runtime error occurs.
With GCC 11.1.0, compilation fails (Error: not enough DO loops for collapsed !$OMP PARALLEL DO at (1)).