### PR TITLE
test_loop_order_concurrent*.F90: Fix out of bounds issue

### DIFF
--- a/tests/5.0/loop/test_loop_order_concurrent.F90
+++ b/tests/5.0/loop/test_loop_order_concurrent.F90
@@ -59,7 +59,7 @@ CONTAINS
     DO x = 1, N
        a(x) = a(x) + b(x)*c(x)
     END DO
-    IF (a(rand_indexes(omp_get_thread_num())) .eq. 1) THEN
+    IF (a(rand_indexes(omp_get_thread_num() + 1)) .eq. 1) THEN
        !$omp atomic update
        wait_errors = wait_errors + 1
     END IF

--- a/tests/5.0/loop/test_loop_order_concurrent_device.F90
+++ b/tests/5.0/loop/test_loop_order_concurrent_device.F90
@@ -60,7 +60,7 @@ CONTAINS
     DO x = 1, N
        a(x) = a(x) + b(x)*c(x)
     END DO
-    IF (a(rand_indexes(omp_get_thread_num())) .eq. 1) THEN
+    IF (a(rand_indexes(omp_get_thread_num()+1)) .eq. 1) THEN
        !$omp atomic update
        wait_errors = wait_errors + 1
     END IF


### PR DESCRIPTION
The problem is that the variable is `rand_indexes` is defined as (respectively for the two testcases):
```F90
    INTEGER,DIMENSION(OMPVV_NUM_THREADS_HOST):: rand_indexes
    INTEGER,DIMENSION(OMPVV_NUM_THREADS_DEVICE):: rand_indexes
```

That's the bounds 1 to number of threads. It is properly initialized as:
```F90
    DO x = 1, OMPVV_NUM_THREADS   ! or OMPVV_NUM_THREADS_DEVICE
...
       rand_indexes(x) = ...
```

But later it is accessed is via `omp_get_thread_num()` which returns `0` to `omp_get_num_threads() – 1`:
```F90
    IF (a(rand_indexes(omp_get_thread_num())) .eq. 1) THEN
```
Thus, for the primary thread, this leads to an out-of-bounds access. 

_ALTERNATIVE: Declare `rand_indexes` with a bound which starts at `0` (i.e. `dimension(0:...NUM_THREADS... - 1)`)._

@spophale @seyonglee @tmh97 – please review.