### PR TITLE
ompvv/ompvv.F90 (clean_fn): Remove unused var

### DIFF
--- a/ompvv/ompvv.F90
+++ b/ompvv/ompvv.F90
@@ -112,7 +112,7 @@ OMPVV_MODULE_REQUIRES_LINE
     function clean_fn(fn)
       CHARACTER(len = *) :: fn
       CHARACTER(len = 400) :: clean_fn
-      INTEGER :: ln, fn_cut_point
+      INTEGER :: fn_cut_point
 
       ! Avoid unused variables warning
       fn_cut_point = SCAN(fn, "/", .TRUE.)


### PR DESCRIPTION
Showed up when compiling with `gfortran -Wall` — and I think it makes sense to silence warnings:

```
ompvv/ompvv.F90:115:19:

  115 |       INTEGER :: ln, fn_cut_point
      |                   1
Warning: Unused variable ‘ln’ declared at (1) [-Wunused-variable]
```