### PR TITLE
Add new_test/test_master_taskloop_device.F90

### DIFF
--- a/tests/5.0/master_taskloop/test_master_taskloop_device.F90
+++ b/tests/5.0/master_taskloop/test_master_taskloop_device.F90
@@ -1,0 +1,63 @@
+!/===--- test_master_taskloop_device.F90 -------------------------------------===//
+!
+! OpenMP API Version 5.0 Nov 2018
+!
+! This test checks the master taskloop directive in a parallel region. The
+! test performs simple operations on an int array which are then checked for
+! correctness. This test checks the above in a target region.
+!
+!/===----------------------------------------------------------------------===//
+
+#include "ompvv.F90"
+
+#define N 1024
+
+PROGRAM test_master_taskloop_device
+  USE iso_fortran_env
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+
+  OMPVV_TEST_OFFLOADING
+
+  OMPVV_TEST_VERBOSE(master_taskloop_device() .ne. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION master_taskloop_device()
+    INTEGER:: errors = 0
+    INTEGER:: num_threads = -1
+    INTEGER, DIMENSION(N):: x, y, z
+    INTEGER:: i
+
+    OMPVV_INFOMSG("test_master_taskloop_device")
+
+    DO i = 1, N
+       x(i) = 1
+       y(i) = i + 1
+       z(i) = 2*(i + 1)
+    END DO
+
+    !$omp target parallel num_threads(OMPVV_NUM_THREADS_DEVICE) shared(x, y, z, num_threads) map(tofrom: x, y, z, num_threads)
+    !$omp master taskloop
+    DO i = 1, N
+       x(i) = x(i) + y(i) * z(i)
+    END DO
+    !$omp end master taskloop
+    IF (omp_get_thread_num() .eq. 0) THEN
+       num_threads = omp_get_num_threads()
+    END IF
+    !$omp end target parallel
+
+    DO i = 1, N
+       OMPVV_TEST_AND_SET_VERBOSE(errors, x(i) .ne. 1 + y(i)*z(i))
+    END DO
+
+    OMPVV_WARNING_IF(num_threads .eq. 1, "Test ran with one thread, so parallelism of taskloop can't be guaranteed.")
+    OMPVV_ERROR_IF(num_threads .lt. 1, "Test returned an invalid number of threads.")
+    OMPVV_TEST_AND_SET_VERBOSE(errors, num_threads .lt. 1)
+
+    master_taskloop_device = errors
+  END FUNCTION master_taskloop_device
+END PROGRAM test_master_taskloop_device

--- a/tests/5.0/master_taskloop/test_master_taskloop_device.c
+++ b/tests/5.0/master_taskloop/test_master_taskloop_device.c
@@ -15,8 +15,8 @@
 
 #define N 1024
 
-int test_master_taskloop() {
-  OMPVV_INFOMSG("test_master_taskloop");
+int test_master_taskloop_device() {
+  OMPVV_INFOMSG("test_master_taskloop_device");
   int errors = 0;
   int num_threads = -1;
   int x[N];
@@ -57,7 +57,7 @@ int main() {
 
   int errors = 0;
 
-  OMPVV_TEST_AND_SET_VERBOSE(errors, test_master_taskloop());
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_master_taskloop_device());
 
   OMPVV_REPORT_AND_RETURN(errors);
 }


### PR DESCRIPTION
Fails with XLF 16.1.1-10, GCC 11.1, and NVHPC 21.11.