### PR TITLE
Add new_test/test_master_taskloop_simd_device.F90

### DIFF
--- a/tests/5.0/master_taskloop_simd/test_master_taskloop_simd_device.F90
+++ b/tests/5.0/master_taskloop_simd/test_master_taskloop_simd_device.F90
@@ -1,0 +1,63 @@
+!/===--- test_master_taskloop_simd_device.F90 -------------------------------------===//
+!
+! OpenMP API Version 5.0 Nov 2018
+!
+! This test checks the master taskloop simd directive in a parallel region.
+! The test performs simple operations on an int array which are then checked
+! for correctness. This test checks the above in a target region.
+!
+!/===----------------------------------------------------------------------===//
+
+#include "ompvv.F90"
+
+#define N 1024
+
+PROGRAM test_master_taskloop_simd_device
+  USE iso_fortran_env
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+
+  OMPVV_TEST_OFFLOADING
+
+  OMPVV_TEST_VERBOSE(master_taskloop_simd_device() .ne. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION master_taskloop_simd_device()
+    INTEGER:: errors = 0
+    INTEGER, DIMENSION(N):: x, y, z
+    INTEGER:: i
+    INTEGER:: num_threads = -1
+
+    OMPVV_INFOMSG("test_master_taskloop_simd_device")
+
+    DO i = 1, N
+       x(i) = 1
+       y(i) = i + 1
+       z(i) = 2*(i + 1)
+    END DO
+
+    !$omp target parallel num_threads(OMPVV_NUM_THREADS_DEVICE) shared(x, y, z, num_threads) map(tofrom: x, num_threads) map(to: y, z)
+    !$omp master taskloop simd
+    DO i = 1, N
+       x(i) = x(i) + y(i) * z(i)
+    END DO
+    !$omp end master taskloop simd
+    IF (omp_get_thread_num() .eq. 0) THEN
+       num_threads = omp_get_num_threads()
+    ENDIF
+    !$omp end target parallel
+
+    DO i = 1, N
+       OMPVV_TEST_AND_SET_VERBOSE(errors, x(i) .ne. 1 + y(i)*z(i))
+    END DO
+
+    OMPVV_WARNING_IF(num_threads .eq. 1, "Test ran with one thread, so parallelism of taskloop can't be guaranteed.")
+    OMPVV_ERROR_IF(num_threads .lt. 1, "Test returned an invalid number of threads.")
+    OMPVV_INFOMSG("This test does not guarantee vector instructions were generated for the simd construct.")
+
+    master_taskloop_simd_device= errors
+  END FUNCTION master_taskloop_simd_device
+END PROGRAM test_master_taskloop_simd_device

--- a/tests/5.0/master_taskloop_simd/test_master_taskloop_simd_device.c
+++ b/tests/5.0/master_taskloop_simd/test_master_taskloop_simd_device.c
@@ -15,8 +15,8 @@
 
 #define N 1024
 
-int test_master_taskloop_simd() {
-  OMPVV_INFOMSG("test_master_taskloop_simd");
+int test_master_taskloop_simd_device() {
+  OMPVV_INFOMSG("test_master_taskloop_simd_device");
   int errors = 0;
   int num_threads = -1;
   int x[N];
@@ -47,6 +47,7 @@ int test_master_taskloop_simd() {
   OMPVV_WARNING_IF(num_threads == 1, "Test ran with one thread, so parallelism of taskloop can't be guaranteed.");
   OMPVV_ERROR_IF(num_threads < 1, "Test returned an invalid number of threads.");
   OMPVV_TEST_AND_SET_VERBOSE(errors, num_threads < 1);
+  OMPVV_INFOMSG("This test does not guarantee vector instructions were generated for the simd construct.");
 
   return errors;
 }
@@ -57,7 +58,7 @@ int main() {
 
   int errors = 0;
 
-  OMPVV_TEST_AND_SET_VERBOSE(errors, test_master_taskloop_simd());
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_master_taskloop_simd_device());
 
   OMPVV_REPORT_AND_RETURN(errors);
 }


### PR DESCRIPTION
Fails with XLF 16.1.1-10, GCC 11.1, and NVHPC 21.11.