### PR TITLE
test_omp_display_env.c: Don't call routine in target

### DIFF
--- a/tests/5.1/runtime_calls/test_omp_display_env.c
+++ b/tests/5.1/runtime_calls/test_omp_display_env.c
@@ -2,7 +2,7 @@
 //
 // OpenMP API Version 5.1 Aug 2021
 //
-// Tests the behavior of omp_display_env. This testshould print out the OpenMP
+// Tests the behavior of omp_display_env. This test should print out the OpenMP
 // version number and the initial values of the ICV's associated with the
 // environment variables
 //

--- a/tests/5.1/runtime_calls/test_omp_display_env.c
+++ b/tests/5.1/runtime_calls/test_omp_display_env.c
@@ -17,7 +17,6 @@
 int errors;
 
 int test_omp_display_env(){
-#pragma omp target
 	omp_display_env(1);
 	return 0;
 }

--- a/tests/5.1/runtime_calls/test_omp_display_env.c
+++ b/tests/5.1/runtime_calls/test_omp_display_env.c
@@ -1,3 +1,5 @@
+//===-- test_omp_display_env.c --------------------------------------------===//
+//
 // OpenMP API Version 5.1 Aug 2021
 //
 // Tests the behavior of omp_display_env. This testshould print out the OpenMP

--- a/tests/5.1/runtime_calls/test_omp_display_env.c
+++ b/tests/5.1/runtime_calls/test_omp_display_env.c
@@ -1,20 +1,16 @@
-//---------test_omp_display_env.c-------------------
+// OpenMP API Version 5.1 Aug 2021
 //
-//OpenMP API Version 5.1 Aug 2021
+// Tests the behavior of omp_display_env. This testshould print out the OpenMP
+// version number and the initial values of the ICV's associated with the
+// environment variables
 //
-//Tests the behavior of omp_display_env. This test 
-//should print out the OpenMP version number and 
-//the initial values of the ICV's associated with 
-//the environment variables.
-//------------------------------------------------
+//===----------------------------------------------------------------------===//
 
 #include <omp.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include "ompvv.h"
 #include <math.h>
-
-int errors;
 
 int test_omp_display_env(){
 	omp_display_env(1);


### PR DESCRIPTION
Move call to 'omp_display_env' OpenMP API routine out of the
target region (and remove then empty target region).

Reason: Fails in the real world and OpenMP 5.1 states:
"Restrictions to the omp_display_env routine are as follows.
* When called from within a target region the effect is unspecified."

In case of GCC, the routine is supported in mainline since July 2021 (GCC 12; to be released soon) – but only when called on the host. The function is not built for devices – such that linking fails with `undefined symbol: omp_display_env` (unless compiled with `-foffload=disable`).

@spophale @tmh97 @nolanbaker31  @seyonglee – please review.