### PR TITLE
Update ompvv.F90

### DIFF
--- a/ompvv/ompvv.F90
+++ b/ompvv/ompvv.F90
@@ -105,7 +105,7 @@ module ompvv_lib
   use iso_fortran_env
   implicit none
 OMPVV_MODULE_REQUIRES_LINE
-    LOGICAL, PRIVATE :: ompvv_isHost
+    LOGICAL, PRIVATE :: ompvv_isHost = .true.
     INTEGER, PRIVATE :: ompvv_errors = 0
     LOGICAL, PRIVATE :: ompvv_sharedEnv
   contains


### PR DESCRIPTION
This edit was suggested by @tob2 to prevent tests from reporting execution on target when target device is absent.