### PR TITLE
'target_memcpy_async' test

### DIFF
--- a/tests/5.1/target/test_target_memcpy_async.c
+++ b/tests/5.1/target/test_target_memcpy_async.c
@@ -1,0 +1,73 @@
+//===--- test_target_memcpy_async.c -----------------------------------===//
+//
+//  OpenMP API Version 5.1 Aug 2021
+//
+//  Inspired from OpenMP 5.1 Examples Doc, 5.16.4 & 8.9
+//  This test utilizes the omp_target_memcpy_async construct to
+//  allocate memory on the device asynchronously. The construct
+//  uses 'obj' for dependency, so that memory is only copied once
+//  the x variable is changed
+//
+////===----------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+#include <math.h>
+
+#define N 1024
+
+int errors, i;
+
+int test_target_memcpy_async() {
+
+    int h, t, i, x;
+    errors = 0;
+    double *mem;
+    double *mem_dev_cpy;
+    *mem = 10; 
+    h = omp_get_initial_device();
+    t = omp_get_default_device();
+
+    OMPVV_TEST_AND_SET_VERBOSE(errors, omp_get_num_devices() < 1 || def_dev < 0);
+
+    mem_dev_cpy = (double *)omp_target_alloc( sizeof(double)*N, def_dev);
+
+    OMPVV_TEST_AND_SET_VERBOSE(errors, mem_dev_cpy == NULL);
+
+    omp_depend_t obj;
+
+    #pragma omp depobj(obj) depend(inout: x)
+
+    /* dst src */
+    omp_target_memcpy_async(mem_dev_cpy, mem, sizeof(double)*N,
+                                0,          0,
+                                t,          h,
+                                1,          *obj);
+
+    #pragma omp target is_device_ptr(mem_dev_cpy) device(t)
+    #pragma omp teams distribute parallel for
+    for(i = 0;i<N;i++){
+        mem_dev_cpy[i] = cos((double)i); // initialize data
+    }
+    /* dst src */
+    omp_target_memcpy_async(mem_dev_cpy, mem, sizeof(double)*N,
+                                0,          0,
+                                h,          t,
+                                1,          *obj);
+
+    for(int i=0;i<N;i++){
+        OMPVV_TEST_AND_SET(errors, mem_dev_cpy[i]!=cos((double)i));
+    }
+    omp_target_free(mem_dev_cpy, def_dev);
+    #pragma omp depobj(obj) destroy // frees resource
+    return errors;
+}
+
+int main() {
+   errors = 0;
+   OMPVV_TEST_OFFLOADING;
+   OMPVV_TEST_AND_SET_VERBOSE(errors, test_target_memcpy_async() != 0);
+   OMPVV_REPORT_AND_RETURN(errors);
+}           

--- a/tests/5.1/target/test_target_memcpy_async.c
+++ b/tests/5.1/target/test_target_memcpy_async.c
@@ -53,7 +53,7 @@ int test_target_memcpy_async() {
         mem_dev_cpy[i] = cos((double)i); // initialize data
     }
     /* dst src */
-    omp_target_memcpy_async(mem_dev_cpy, mem, sizeof(double)*N,
+    omp_target_memcpy_async(mem, mem_dev_cpy, sizeof(double)*N,
                                 0,          0,
                                 h,          t,
                                 1,          *obj);

--- a/tests/5.1/target/test_target_memcpy_async.c
+++ b/tests/5.1/target/test_target_memcpy_async.c
@@ -46,7 +46,7 @@ int test_target_memcpy_async() {
                                 t,          h,
                                 1,          *obj);
 
-    #pragma omp target is_device_ptr(mem_dev_cpy) device(t)
+    #pragma omp target is_device_ptr(mem_dev_cpy) device(t) depend(depobj: *obj)
     #pragma omp teams distribute parallel for
     for(i = 0;i<N;i++){
         mem_dev_cpy[i] = cos((double)i); // initialize data

--- a/tests/5.1/target/test_target_memcpy_async.c
+++ b/tests/5.1/target/test_target_memcpy_async.c
@@ -33,7 +33,7 @@ int test_target_memcpy_async() {
     OMPVV_TEST_AND_SET_VERBOSE(errors, omp_get_num_devices() < 1 || t < 0);
 
     mem = (double *)malloc( sizeof(double)*N);
-    mem_dev_cpy = (double *)omp_target_alloc( sizeof(double)*N, def_dev);
+    mem_dev_cpy = (double *)omp_target_alloc( sizeof(double)*N, t);
 
     OMPVV_TEST_AND_SET_VERBOSE(errors, mem_dev_cpy == NULL);
 

--- a/tests/5.1/target/test_target_memcpy_async.c
+++ b/tests/5.1/target/test_target_memcpy_async.c
@@ -26,7 +26,6 @@ int test_target_memcpy_async() {
     errors = 0;
     double *mem;
     double *mem_dev_cpy;
-    *mem = 10; 
     h = omp_get_initial_device();
     t = omp_get_default_device();
 

--- a/tests/5.1/target/test_target_memcpy_async.c
+++ b/tests/5.1/target/test_target_memcpy_async.c
@@ -30,8 +30,9 @@ int test_target_memcpy_async() {
     h = omp_get_initial_device();
     t = omp_get_default_device();
 
-    OMPVV_TEST_AND_SET_VERBOSE(errors, omp_get_num_devices() < 1 || def_dev < 0);
+    OMPVV_TEST_AND_SET_VERBOSE(errors, omp_get_num_devices() < 1 || t < 0);
 
+    mem = (double *)malloc( sizeof(double)*N);
     mem_dev_cpy = (double *)omp_target_alloc( sizeof(double)*N, def_dev);
 
     OMPVV_TEST_AND_SET_VERBOSE(errors, mem_dev_cpy == NULL);

--- a/tests/5.1/target/test_target_memcpy_async_depobj.c
+++ b/tests/5.1/target/test_target_memcpy_async_depobj.c
@@ -35,7 +35,10 @@ int test_target_memcpy_async_depobj() {
     mem_dev_cpy = (double *)omp_target_alloc( sizeof(double)*N, t);
 
     OMPVV_TEST_AND_SET_VERBOSE(errors, mem_dev_cpy == NULL);
-
+    
+    for(i = 0; i < N; i++){
+        mem[i] = i;
+    }
     omp_depend_t obj;
 
     #pragma omp depobj(obj) depend(inout: mem_dev_cpy)
@@ -48,9 +51,8 @@ int test_target_memcpy_async_depobj() {
 
     #pragma omp taskwait depend(depobj: obj)
     #pragma omp target is_device_ptr(mem_dev_cpy) device(t) depend(depobj: obj)
-    #pragma omp teams distribute parallel for
     for(i = 0; i < N; i++){
-        mem_dev_cpy[i] = i*2; // initialize data
+        mem_dev_cpy[i] = mem_dev_cpy[i]*2; // initialize data
     }
     
     /* copy to host memory */
@@ -60,8 +62,8 @@ int test_target_memcpy_async_depobj() {
                                 1,          &obj);
 
     #pragma omp taskwait depend(depobj: obj)
-    for(int i=0;i<N;i++){
-        OMPVV_TEST_AND_SET(errors, mem_dev_cpy[i]!=i*2);
+    for(int i=0; i < N; i++){
+        OMPVV_TEST_AND_SET(errors, mem[i]!=i*2);
     }
     // free resources
     omp_target_free(mem_dev_cpy, t);

--- a/tests/5.1/target/test_target_memcpy_async_depobj.c
+++ b/tests/5.1/target/test_target_memcpy_async_depobj.c
@@ -1,4 +1,4 @@
-//===--- test_target_memcpy_async.c -----------------------------------===//
+//===--- test_target_memcpy_async_depobj.c ----------------------------===//
 //
 //  OpenMP API Version 5.1 Aug 2021
 //
@@ -6,7 +6,7 @@
 //  This test utilizes the omp_target_memcpy_async construct to
 //  allocate memory on the device asynchronously. The construct
 //  uses 'obj' for dependency, so that memory is only copied once
-//  the x variable is changed
+//  the variable listed in the depend clause is changed.
 //
 ////===----------------------------------------------------------------------===//
 
@@ -20,7 +20,7 @@
 
 int errors, i;
 
-int test_target_memcpy_async() {
+int test_target_memcpy_async_depobj() {
 
     int h, t, i, x;
     errors = 0;
@@ -68,6 +68,6 @@ int test_target_memcpy_async() {
 int main() {
    errors = 0;
    OMPVV_TEST_OFFLOADING;
-   OMPVV_TEST_AND_SET_VERBOSE(errors, test_target_memcpy_async() != 0);
+   OMPVV_TEST_AND_SET_VERBOSE(errors, test_target_memcpy_async_depobj() != 0);
    OMPVV_REPORT_AND_RETURN(errors);
 }           

--- a/tests/5.1/target/test_target_memcpy_async_depobj.c
+++ b/tests/5.1/target/test_target_memcpy_async_depobj.c
@@ -44,7 +44,7 @@ int test_target_memcpy_async_depobj() {
     omp_target_memcpy_async(mem_dev_cpy, mem, sizeof(double)*N,
                                 0,          0,
                                 t,          h,
-                                1,          obj_arr[0]);
+                                1,          obj_arr);
 
     #pragma omp taskwait depend(depobj: obj)
     #pragma omp target is_device_ptr(mem_dev_cpy) device(t) depend(depobj: obj)

--- a/tests/5.1/target/test_target_memcpy_async_depobj.c
+++ b/tests/5.1/target/test_target_memcpy_async_depobj.c
@@ -37,9 +37,8 @@ int test_target_memcpy_async_depobj() {
         mem[i] = i;
     }
     omp_depend_t obj;
-    omp_depend_t obj_arr[1] = {obj};
-
     #pragma omp depobj(obj) depend(inout: mem_dev_cpy)
+    omp_depend_t obj_arr[1] = {obj};
 
     /* copy to device memory */
     omp_target_memcpy_async(mem_dev_cpy, mem, sizeof(double)*N,

--- a/tests/5.1/target/test_target_memcpy_async_depobj.c
+++ b/tests/5.1/target/test_target_memcpy_async_depobj.c
@@ -56,7 +56,7 @@ int test_target_memcpy_async_depobj() {
     omp_target_memcpy_async(mem, mem_dev_cpy, sizeof(double)*N,
                                 0,          0,
                                 h,          t,
-                                1,          obj_arr[0]);
+                                1,          obj_arr);
 
     #pragma omp taskwait depend(depobj: obj)
     for(int i=0; i < N; i++){

--- a/tests/5.1/target/test_target_memcpy_async_depobj.c
+++ b/tests/5.1/target/test_target_memcpy_async_depobj.c
@@ -39,7 +39,7 @@ int test_target_memcpy_async_depobj() {
     for(i = 0; i < N; i++){
         mem[i] = i;
     }
-    omp_depend_t obj;
+    omp_depend_t obj[1];
 
     #pragma omp depobj(obj) depend(inout: mem_dev_cpy)
     
@@ -47,7 +47,7 @@ int test_target_memcpy_async_depobj() {
     omp_target_memcpy_async(mem_dev_cpy, mem, sizeof(double)*N,
                                 0,          0,
                                 t,          h,
-                                1,          &obj);
+                                1,          obj);
 
     #pragma omp taskwait depend(depobj: obj)
     #pragma omp target is_device_ptr(mem_dev_cpy) device(t) depend(depobj: obj)
@@ -59,7 +59,7 @@ int test_target_memcpy_async_depobj() {
     omp_target_memcpy_async(mem, mem_dev_cpy, sizeof(double)*N,
                                 0,          0,
                                 h,          t,
-                                1,          &obj);
+                                1,          obj);
 
     #pragma omp taskwait depend(depobj: obj)
     for(int i=0; i < N; i++){

--- a/tests/5.1/target/test_target_memcpy_async_depobj.c
+++ b/tests/5.1/target/test_target_memcpy_async_depobj.c
@@ -22,14 +22,14 @@ int errors, i;
 
 int test_target_memcpy_async_depobj() {
 
-    int h, t, i, x;
+    int h, t, i;
     errors = 0;
     int *mem;
     int *mem_dev_cpy;
     h = omp_get_initial_device();
     t = omp_get_default_device();
 
-    OMPVV_TEST_AND_SET_VERBOSE(errors, omp_get_num_devices() < 1 || t < 0);
+    OMPVV_TEST_AND_SET_VERBOSE(errors, omp_get_num_devices() < 1 || t < 0); //errors if device not available
 
     mem = (double *)malloc( sizeof(double)*N);
     mem_dev_cpy = (double *)omp_target_alloc( sizeof(double)*N, t);
@@ -38,23 +38,22 @@ int test_target_memcpy_async_depobj() {
 
     omp_depend_t obj;
 
-    #pragma omp depobj(obj) depend(inout: x)
-
-    /* dst src */
+    #pragma omp depobj(obj) depend(inout: mem_dev_cpy)
+    
+    /* copy to device memory */
     omp_target_memcpy_async(mem_dev_cpy, mem, sizeof(double)*N,
                                 0,          0,
                                 t,          h,
                                 1,          &obj);
 
     #pragma omp taskwait depend(depobj: obj)
-    #pragma omp target is_device_ptr(mem_dev_cpy) map(tofrom: x) device(t) depend(depobj: *obj)
+    #pragma omp target is_device_ptr(mem_dev_cpy) device(t) depend(depobj: obj)
     #pragma omp teams distribute parallel for
-    for(i = 0;i<N;i++){
+    for(i = 0; i < N; i++){
         mem_dev_cpy[i] = i*2; // initialize data
-        x = 5;
     }
-    OMPVV_TEST_AND_SET(errors, x!=5);
-    /* dst src */
+    
+    /* copy to host memory */
     omp_target_memcpy_async(mem, mem_dev_cpy, sizeof(double)*N,
                                 0,          0,
                                 h,          t,
@@ -64,8 +63,9 @@ int test_target_memcpy_async_depobj() {
     for(int i=0;i<N;i++){
         OMPVV_TEST_AND_SET(errors, mem_dev_cpy[i]!=i*2);
     }
+    // free resources
     omp_target_free(mem_dev_cpy, t);
-    #pragma omp depobj(obj) destroy // frees resource
+    #pragma omp depobj(obj) destroy 
     return errors;
 }
 

--- a/tests/5.1/target/test_target_memcpy_async_depobj.c
+++ b/tests/5.1/target/test_target_memcpy_async_depobj.c
@@ -44,7 +44,7 @@ int test_target_memcpy_async_depobj() {
     omp_target_memcpy_async(mem_dev_cpy, mem, sizeof(double)*N,
                                 0,          0,
                                 t,          h,
-                                1,          *obj);
+                                1,          &obj);
 
     #pragma omp taskwait depend(depobj: obj)
     #pragma omp target is_device_ptr(mem_dev_cpy) map(tofrom: x) device(t) depend(depobj: *obj)
@@ -58,7 +58,7 @@ int test_target_memcpy_async_depobj() {
     omp_target_memcpy_async(mem, mem_dev_cpy, sizeof(double)*N,
                                 0,          0,
                                 h,          t,
-                                1,          *obj);
+                                1,          &obj);
 
     #pragma omp taskwait depend(depobj: obj)
     for(int i=0;i<N;i++){


### PR DESCRIPTION
Test for [`omp_target_memcpy_async`](https://www.openmp.org/wp-content/uploads/OpenMP-API-Specification-5-1.pdf#page=444). Currently in progress.


I am new to using dependencies within OpenMP, and am not sure how a dependency would work with this construct. The data-attribute within `obj` will denote when memory is copied, but I am not sure specifically when this would occur.

My confusion comes from my understanding of dependencies. I know that when using `#pragma omptask depend`, for example, the task listed under this construct would limit other dependencies, but using _memcpy_ adds confusion to this.

I know I am being a bit vague, but any assistance or clarification would be greatly appreciated.

_Side note,_ this construct is not yet implemented in LLVM, unsure about GCC. 