### PR TITLE
test_taskloop_strict_numtasks.c: Add missing 'reduction(+:'

### DIFF
--- a/tests/5.1/strict1/test_taskloop_strict_numtasks.c
+++ b/tests/5.1/strict1/test_taskloop_strict_numtasks.c
@@ -27,7 +27,7 @@ int test_taskloop_strict_numtasks() {
  }
 #pragma omp parallel num_threads(OMPVV_NUM_THREADS_HOST)
 #pragma omp single
-#pragma omp taskloop num_tasks(strict: 100)
+#pragma omp taskloop num_tasks(strict: 100) reduction(+: parallel_sum)
   for (int i = 0; i < N; i++) {
   	parallel_sum += arr[i];
   }


### PR DESCRIPTION
This commits adds a missing `reduction(+: parallel_sum)`. With the reduction clause, it passes with GCC 12.

(Test was added in #457 

@krishols @spophale @tmh97 @nolanbaker31 @mjcarr458 – please review.