### PR TITLE
test_target_defaultmap_*: Various fixes

### DIFF
--- a/tests/5.0/target/test_target_defaultmap_default.F90
+++ b/tests/5.0/target/test_target_defaultmap_default.F90
@@ -46,6 +46,7 @@ CONTAINS
     TYPE(structure) :: new_struct !aggregate
     ALLOCATE(B(N))
 
+    ptr => null()
     scalar = 1
     new_struct%s = 1
 
@@ -65,6 +66,7 @@ CONTAINS
     new_struct%s = 10; new_struct%SA(1) = 10; new_struct%SA(2) = 10
     ptr => A
     ptr(51) = 50; ptr(52) = 51
+    ptr => null()
     !$omp end target
 
     OMPVV_TEST_AND_SET_VERBOSE(errors, scalar /= 1)

--- a/tests/5.0/target/test_target_defaultmap_firstprivate.F90
+++ b/tests/5.0/target/test_target_defaultmap_firstprivate.F90
@@ -41,6 +41,7 @@ CONTAINS
     TYPE(structure) :: new_struct !aggregate
     ALLOCATE(B(N))
 
+    ptr => null()
     scalar = 1
     new_struct%s = 1
 
@@ -66,7 +67,7 @@ CONTAINS
     OMPVV_TEST_AND_SET_VERBOSE(errors, A(1) /= 0 .OR. A(2) /= 0) 
     OMPVV_TEST_AND_SET_VERBOSE(errors, A(51) /= 0 .OR. A(52) /= 0)
     OMPVV_TEST_AND_SET_VERBOSE(errors, B(1) /= 0 .OR. B(2) /= 0) 
-    OMPVV_TEST_AND_SET_VERBOSE(errors, new_struct%s /= 0)
+    OMPVV_TEST_AND_SET_VERBOSE(errors, new_struct%s /= 1)
     OMPVV_TEST_AND_SET_VERBOSE(errors, new_struct%SA(1) /= 0)
     OMPVV_TEST_AND_SET_VERBOSE(errors, new_struct%SA(2) /= 0)
 

--- a/tests/5.0/target/test_target_defaultmap_none.F90
+++ b/tests/5.0/target/test_target_defaultmap_none.F90
@@ -42,6 +42,7 @@ CONTAINS
     TYPE(structure) :: new_struct !aggregate
     ALLOCATE(B(N))
 
+    ptr => null()
     scalar = 1
     new_struct%s = 1
 
@@ -61,6 +62,7 @@ CONTAINS
     new_struct%s = 10; new_struct%SA(1) = 10; new_struct%SA(2) = 10
     ptr => A
     ptr(51) = 50; ptr(52) = 51
+    ptr => null()
     !$omp end target
 
     OMPVV_TEST_AND_SET_VERBOSE(errors, scalar /= 17)
@@ -80,6 +82,7 @@ CONTAINS
     new_struct%SA(2) = new_struct%SA(2) + 10
     ptr => A
     ptr(51) = ptr(51) + 10; ptr(52) = ptr(52) + 10
+    ptr => null()
     !$omp end target
 
     OMPVV_TEST_AND_SET_VERBOSE(errors, scalar /= 17)

--- a/tests/5.0/target/test_target_defaultmap_to_from_tofrom.F90
+++ b/tests/5.0/target/test_target_defaultmap_to_from_tofrom.F90
@@ -67,7 +67,7 @@ CONTAINS
     OMPVV_TEST_AND_SET_VERBOSE(errors, A(1) /= 0 .OR. A(2) /= 0) 
     OMPVV_TEST_AND_SET_VERBOSE(errors, A(51) /= 0 .OR. A(52) /= 0)
     OMPVV_TEST_AND_SET_VERBOSE(errors, B(1) /= 0 .OR. B(2) /= 0) 
-    OMPVV_TEST_AND_SET_VERBOSE(errors, new_struct%s /= 0)
+    OMPVV_TEST_AND_SET_VERBOSE(errors, new_struct%s /= 1)
     OMPVV_TEST_AND_SET_VERBOSE(errors, new_struct%SA(1) /= 0)
     OMPVV_TEST_AND_SET_VERBOSE(errors, new_struct%SA(2) /= 0)
 
@@ -138,6 +138,7 @@ CONTAINS
     TYPE(structure) :: new_struct !aggregate
     ALLOCATE(B(N))
 
+    ptr => null()
     scalar = 1
     new_struct%s = 1
 
@@ -157,6 +158,7 @@ CONTAINS
     new_struct%s = 10; new_struct%SA(1) = 10; new_struct%SA(2) = 10
     ptr => A
     ptr(51) = 50; ptr(52) = 51
+    ptr => null()
     !$omp end target
 
     OMPVV_TEST_AND_SET_VERBOSE(errors, scalar /= 17)

--- a/tests/5.1/default/test_default_firstprivate_parallel.c
+++ b/tests/5.1/default/test_default_firstprivate_parallel.c
@@ -23,7 +23,7 @@ int errors, i;
 int test_default_firstprivate_parallel() {
   int scalar_var = 5;
   int arr[N];
-  int sum;
+  int sum = 0;
   for (int i=0; i<N; i++){
 	arr[i] = i;
 	sum += arr[i];
@@ -35,16 +35,16 @@ int test_default_firstprivate_parallel() {
 		arr[i] = i+2;
   	}	
   }
-  int newsum;
-  int wrongsum;
+  int newsum = 0;
+  int wrongsum = 0;
   for(int i=0; i<N; i++){
 	newsum += arr[i];
 	wrongsum += i+2;
   }
-  OMPVV_TEST_AND_SET(errors, scalar_var != 5);
+  OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_var != 5);
   OMPVV_INFOMSG_IF(scalar_var == 0, "Scalar was not initialized in parallel region & not updated");
   OMPVV_INFOMSG_IF(scalar_var == 15, "Scalar was not firstprivate, changes made in parallel affected original copy");
-  OMPVV_TEST_AND_SET(errors, sum != newsum);
+  OMPVV_TEST_AND_SET_VERBOSE(errors, sum != newsum);
   OMPVV_INFOMSG_IF(newsum == 0, "Array was not initialized in parallel region properly");
   OMPVV_INFOMSG_IF(newsum == wrongsum, "Array was not first private, changes made in parallel affected original copy");
   return errors;


### PR DESCRIPTION
* tests/5.1/default/test_default_firstprivate_parallel.c: Use
  OMPVV_TEST_AND_SET_VERBOSE (not OMPVV_TEST_AND_SET) to get a better
  diagnostic. Initialize sum variables with 0.

* tests/5.0/target/test_target_defaultmap_*.F90: Fix expected value
  for new_struct%s. Initialize ptr to NULL before the target region
  to avoid mapping uninit memory + at the end of the region to
  have the initial value.

**Namely:**

* The nonintialized sum variable did cause sporadic fails. And as the value was none of the expected wrong values, no VERBOSE_MODE did not show anything helpful; thus, I use OMPVV_TEST_AND_SET_VERBOSE.
* The contrary to the arrays, scalars were set before the target region to '1' and not to '0'. Thus, new_struct%s should check for the value '1'.
* Pointers: Contrary to C, Fortran POINTER variables are mapped - thus, for `tests/5.0/target/test_target_defaultmap_none.F90`, which uses an explicit `map(tofrom: ..., ptr)`, it failed here as some random memory was attempted to get mapped. — I have now nullified all 'ptr' on the host.
* For Fortran POINTER, there is a restriction in "**target** Construct" which requires that the pointer association of a mapped pointer is the same on exit of target region as it was when entering it. _(5.1+5.2 have a clearer wording, 5.0 also has it but a bit murky.)_ — Thus, I just set it to NULL at the end of the region, except with `firstprivate` (i.e. not for test_target_defaultmap_firstprivate.F90 at the end of the target region)

@spophale @tmh97 @nolanbaker31 @seyonglee – please have a look

_**GCC 12:** With those patches, only test_target_defaultmap_firstprivate.F90 fails as it does not properly map allocatables with firstprivate, cf. https://gcc.gnu.org/PR104949_