### PR TITLE
omp_target_memcpy_async TEST with no dependent object

### DIFF
--- a/tests/5.1/target/test_target_memcpy_async_no_obj.c
+++ b/tests/5.1/target/test_target_memcpy_async_no_obj.c
@@ -1,0 +1,69 @@
+//===--- test_target_memcpy_async_no_obj.c ----------------------------===//
+//
+//  OpenMP API Version 5.1 Aug 2021
+//
+//  Inspired from OpenMP 5.1 Examples Doc, 5.16.4 & 8.9
+//  This test utilizes the omp_target_memcpy_async construct to
+//  allocate memory on the device asynchronously. The construct
+//  uses 0 for 'depobj_count', so that the clauses is not dependent
+//  and memory is therefore copied synchronously.
+//
+////===----------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+#include <math.h>
+
+#define N 1024
+
+int errors, i;
+
+int test_target_memcpy_async_no_obj() {
+
+    int h, t, i;
+    errors = 0;
+    double *mem;
+    double *mem_dev_cpy;
+    h = omp_get_initial_device();
+    t = omp_get_default_device();
+
+    OMPVV_TEST_AND_SET_VERBOSE(errors, omp_get_num_devices() < 1 || t < 0);
+
+    //allocate space on host & target
+    mem = (double *)malloc( sizeof(double)*N);
+    mem_dev_cpy = (double *)omp_target_alloc( sizeof(double)*N, t);
+
+    OMPVV_TEST_AND_SET_VERBOSE(errors, mem_dev_cpy == NULL);
+
+    /* copy to target */
+    omp_target_memcpy_async(mem_dev_cpy, mem, sizeof(double)*N,
+                                0,          0,
+                                t,          h,
+                                0,          0);
+
+    #pragma omp target is_device_ptr(mem_dev_cpy) device(t)
+    #pragma omp teams distribute parallel for
+    for(i = 0;i<N;i++){
+        mem_dev_cpy[i] = i*2; // initialize data on device
+    }
+    /* copy to host */
+    omp_target_memcpy_async(mem, mem_dev_cpy, sizeof(double)*N,
+                                0,          0,
+                                h,          t,
+                                0,          0);
+
+    for(int i=0;i<N;i++){
+        OMPVV_TEST_AND_SET(errors, mem[i]!=i*2);
+    }
+    omp_target_free(mem_dev_cpy, t);
+    return errors;
+}
+
+int main() {
+   errors = 0;
+   OMPVV_TEST_OFFLOADING;
+   OMPVV_TEST_AND_SET_VERBOSE(errors, test_target_memcpy_async_no_obj() != 0);
+   OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.1/target/test_target_memcpy_async_no_obj.c
+++ b/tests/5.1/target/test_target_memcpy_async_no_obj.c
@@ -5,7 +5,7 @@
 //  Inspired from OpenMP 5.1 Examples Doc, 5.16.4 & 8.9
 //  This test utilizes the omp_target_memcpy_async construct to
 //  allocate memory on the device asynchronously. The construct
-//  uses 0 for 'depobj_count', so that the clauses is not dependent
+//  uses 0 for 'depobj_count', so that the clause is not dependent
 //  and memory is therefore copied synchronously.
 //
 ////===----------------------------------------------------------------------===//

--- a/tests/5.1/target/test_target_memcpy_async_no_obj.c
+++ b/tests/5.1/target/test_target_memcpy_async_no_obj.c
@@ -52,7 +52,7 @@ int test_target_memcpy_async_no_obj() {
     omp_target_memcpy_async(mem, mem_dev_cpy, sizeof(double)*N,
                                 0,          0,
                                 h,          t,
-                                0,          0);
+                                0,          NULL);
 
     #pragma omp taskwait
     

--- a/tests/5.1/target/test_target_memcpy_async_no_obj.c
+++ b/tests/5.1/target/test_target_memcpy_async_no_obj.c
@@ -54,6 +54,8 @@ int test_target_memcpy_async_no_obj() {
                                 h,          t,
                                 0,          0);
 
+    #pragma omp taskwait
+    
     for(int i=0;i<N;i++){
         OMPVV_TEST_AND_SET(errors, mem[i]!=i*2);
     }

--- a/tests/5.1/target/test_target_memcpy_async_no_obj.c
+++ b/tests/5.1/target/test_target_memcpy_async_no_obj.c
@@ -41,7 +41,7 @@ int test_target_memcpy_async_no_obj() {
     omp_target_memcpy_async(mem_dev_cpy, mem, sizeof(double)*N,
                                 0,          0,
                                 t,          h,
-                                0,          0);
+                                0,          NULL);
 
     #pragma omp target is_device_ptr(mem_dev_cpy) device(t)
     #pragma omp teams distribute parallel for


### PR DESCRIPTION
Seperate test for omp_memcpy_async with 'depobj' of 0, where the [spec](https://www.openmp.org/wp-content/uploads/OpenMP-API-Specification-5-1.pdf#page=445) states:

> the generated target task is not a dependent task if the program passes in a count of zero for depobj_count. depojb_list is ignored if the value of depobj_count is zero.

Test passes on latest LLVM clang using omp_target_memcpy, since omp_target_memcpy_async is not yet supported.

I am going to leave up PR #493 for now, am waiting for further feedback on a use case/strategy for using dependency with this directive.
