### PR TITLE
Initialize sum vars by 0

### DIFF
--- a/tests/5.0/task/test_task_in_reduction_dynamically_enclosed.c
+++ b/tests/5.0/task/test_task_in_reduction_dynamically_enclosed.c
@@ -18,7 +18,7 @@
 
 #define N 1024
 
-int sum;
+int sum = 0;
 
 void task_container(int i) {
 #pragma omp task in_reduction(+:sum)

--- a/tests/5.1/default/test_default_firstprivate_parallel.c
+++ b/tests/5.1/default/test_default_firstprivate_parallel.c
@@ -23,7 +23,7 @@ int errors, i;
 int test_default_firstprivate_parallel() {
   int scalar_var = 5;
   int arr[N];
-  int sum;
+  int sum = 0;
   for (int i=0; i<N; i++){
 	arr[i] = i;
 	sum += arr[i];
@@ -35,8 +35,8 @@ int test_default_firstprivate_parallel() {
 		arr[i] = i+2;
   	}	
   }
-  int newsum;
-  int wrongsum;
+  int newsum = 0;
+  int wrongsum = 0;
   for(int i=0; i<N; i++){
 	newsum += arr[i];
 	wrongsum += i+2;

--- a/tests/5.1/default/test_default_firstprivate_taskloop.c
+++ b/tests/5.1/default/test_default_firstprivate_taskloop.c
@@ -44,10 +44,10 @@ int test_default_firstprivate_taskloop() {
 	new_sum += arr[i];
 	wrong_sum += i + 3;
   	}
-  OMPVV_TEST_AND_SET(errors, scalar_var != 6);
+  OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_var != 6);
   OMPVV_INFOMSG_IF(scalar_var == 0, "Scalar was not initialized in parallel region & not updated");
   OMPVV_INFOMSG_IF(scalar_var >  6, "Scalar was not firstprivate, changes made in parallel affected original copy");
-  OMPVV_TEST_AND_SET(errors, sum != new_sum);
+  OMPVV_TEST_AND_SET_VERBOSE(errors, sum != new_sum);
   OMPVV_INFOMSG_IF(new_sum == 0, "Array was not initialized in parallel region properly");
   OMPVV_INFOMSG_IF(new_sum == wrong_sum, "Array was not first private, changes made in parallel affected original copy");
   return errors;

--- a/tests/5.1/default/test_task_default_firstprivate.c
+++ b/tests/5.1/default/test_task_default_firstprivate.c
@@ -35,15 +35,15 @@ int test_default_firstprivate_task(){
 			test_arr[i] = 1;
 		}
 	}
-	int new_sum;
-	int wrong_sum;
+	int new_sum = 0;
+	int wrong_sum = 0;
 	for (int i = 0; i<N; i++){
 		new_sum += test_arr[i];
 		wrong_sum += 1;
 	}
-	OMPVV_TEST_AND_SET(errors, test_num != 1);
+	OMPVV_TEST_AND_SET_VERBOSE(errors, test_num != 1);
 	OMPVV_INFOMSG_IF(test_num == 2, "Scalar was not firstprivate, changes made in task affected original copy");
-	OMPVV_TEST_AND_SET(errors, sum != new_sum);
+	OMPVV_TEST_AND_SET_VERBOSE(errors, sum != new_sum);
 	OMPVV_INFOMSG_IF(new_sum == wrong_sum, "Array was not first private, changes made in task affected original copy");
 	return errors;
 }

--- a/tests/5.1/strict/test_strict_grainsize.c
+++ b/tests/5.1/strict/test_strict_grainsize.c
@@ -31,7 +31,7 @@ int test_strict_grainsize() {
   for (int i = 0; i < N; i++) {
   	parallel_sum += arr[i];
   }
-  OMPVV_TEST_AND_SET(errors, parallel_sum != sum);
+  OMPVV_TEST_AND_SET_VERBOSE(errors, parallel_sum != sum);
   OMPVV_INFOMSG_IF(sum == 0, "Array was not initialized.");
   OMPVV_INFOMSG_IF(parallel_sum == 0, "Data sharing of parallel_sum was wrong.");
   OMPVV_INFOMSG_IF(parallel_sum == sum, "Test passed.");

--- a/tests/5.1/strict1/test_taskloop_strict_numtasks.c
+++ b/tests/5.1/strict1/test_taskloop_strict_numtasks.c
@@ -31,7 +31,7 @@ int test_taskloop_strict_numtasks() {
   for (int i = 0; i < N; i++) {
   	parallel_sum += arr[i];
   }
-  OMPVV_TEST_AND_SET(errors, parallel_sum != sum);
+  OMPVV_TEST_AND_SET_VERBOSE(errors, parallel_sum != sum);
   OMPVV_INFOMSG_IF(sum == 0, "Array was not initialized.");
   OMPVV_INFOMSG_IF(parallel_sum == 0, "Data sharing of parallel_sum was wrong.");
   OMPVV_INFOMSG_IF(parallel_sum == sum, "Test passed.");


### PR DESCRIPTION
* tests/5.0/task/test_task_in_reduction_dynamically_enclosed.c,
  tests/5.1/default/test_default_firstprivate_parallel.c,
  tests/5.1/default/test_task_default_firstprivate.c: Initialize
  sum variables by zero.
* tests/5.1/default/test_default_firstprivate_taskloop.c,
  tests/5.1/strict/test_strict_grainsize.c,
  tests/5.1/strict1/test_taskloop_strict_numtasks.c: Use
  OMPVV_TEST_AND_SET_VERBOSE instead of OMPVV_TEST_AND_SET.

_This is kind of a follow-up to #496's tests/5.1/default/test_default_firstprivate_parallel.c change, but for other files._

_Using OMPVV_TEST_AND_SET_VERBOSE helps to see if something else goes wrong instead of the sum == 0 or sum == wrong_sum issue (e.g. having an uninit variable as here) – or in the file in the other PR #496._

@spophale @tmh97 @nolanbaker31 @seyonglee – please have a look