### PR TITLE
Fix test_target_teams_distribute_parallel_for_devices.F90

### DIFF
--- a/tests/4.5/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_devices.F90
+++ b/tests/4.5/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_devices.F90
@@ -26,13 +26,14 @@ PROGRAM test_target_teams_distribute_parallel_for_devices
 
 CONTAINS
    INTEGER FUNCTION target_teams_distribute_parallel_for_devices()
-      INTEGER :: num_dev, errors, i, dev
+      INTEGER :: num_dev, errors, i, dev, dev2, initial_dev
       INTEGER, DIMENSION(N) :: a
       LOGICAL, DIMENSION(0:N) :: isHost
       CHARACTER(len=400) :: numDeviceMsg, hostOrDevMsg
 
       errors = 0
 
+      initial_dev = omp_get_initial_device()
       num_dev = omp_get_num_devices()
       OMPVV_WARNING_IF(num_dev .le. 1, "Testing devices clause without multiple devices")
 
@@ -44,15 +45,27 @@ CONTAINS
       END DO
 
       DO dev = 0, num_dev
+         ! Include the initial device in the tests - but honor that before
+         ! OpenMP < 5.1, num_dev might not be a valid device number
+         IF (i == num_dev) THEN
+           dev2 = initial_dev
+         ELSE
+           dev2 = dev
+         END IF
          ! This testcase assumes that 'map' actually places 'a' into device memory
          ! and is not a no op - not even with (unified) shared memory.
-         !$omp target enter data map(to: a) device(dev)
+         !$omp target enter data map(to: a) device(dev2)
       END DO
 
       DO dev = 0, num_dev
-      ! The implicit 'map(tofrom: a)' does not imply an update of 'a' as 'a'
-      ! is already present on the device.
-      !$omp target teams distribute parallel do device(dev) map(tofrom: isHost)
+         IF (dev == num_dev) THEN
+           dev2 = initial_dev
+         ELSE
+           dev2 = dev
+         END IF
+         ! The implicit 'map(tofrom: a)' does not imply an update of 'a' as 'a'
+         ! is already present on the device.
+         !$omp target teams distribute parallel do device(dev2) map(tofrom: isHost)
             DO i = 1, N
                IF ((omp_get_team_num() .eq. 0) .and. (omp_get_thread_num() .eq. 0)) THEN
                   isHost(dev) = omp_is_initial_device()
@@ -64,7 +77,12 @@ CONTAINS
       ! Check the host value (dev == num_dev) first in order to avoid that it
       ! gets overridden by the device-memory versions (dev = 0 ... num_dev - 1)
       DO dev = num_dev, 0, -1
-         !$omp target exit data map(from: a) device(dev)
+         IF (dev == num_dev) THEN
+           dev2 = initial_dev
+         ELSE
+           dev2 = dev
+         END IF
+         !$omp target exit data map(from: a) device(dev2)
          IF (isHost(dev) .eqv. .true.) THEN 
             WRITE(hostOrDevMsg, *) "Device", dev, "ran on the host"
          END IF


### PR DESCRIPTION
* Actually do something useful for the first device (device number: 0)
* Start with checking in reverse device-number order in order to not override the host value before having checked it.
* Add comments that this testcase assumes that 'map' is no no-op.

_The loop-walking change makes use of the knowledge that `omp_get_num_devices()` is the device number for the host/initial device. (In newer specs:_ a number _as another one is `omp_initial_device == -1`.)_

@tmh97 @nolanbaker31 @spophale – please review.