### PR TITLE
Fortran: Make standard conform, avoid conversion warnings

### DIFF
--- a/tests/4.5/target/test_target_defaultmap.F90
+++ b/tests/4.5/target/test_target_defaultmap.F90
@@ -22,16 +22,35 @@
 
 
         CONTAINS 
+          LOGICAL FUNCTION same_val_real32 (x, y) RESULT(res)
+            REAL(kind = real32) :: x, y
+            res = abs(x-y) < min(abs(x) + abs(y), huge(x)) * epsilon(x)
+          END FUNCTION
+          LOGICAL FUNCTION same_val_real64 (x, y) RESULT(res)
+            REAL(kind = real64) :: x, y
+            res = abs(x-y) < min(abs(x) + abs(y), huge(x)) * epsilon(x)
+          END FUNCTION
+          LOGICAL FUNCTION same_val_cmplx (x, y) RESULT(res)
+            COMPLEX :: x, y
+            REAL :: rx, ry
+            REAL :: ix, iy
+            rx = real(x)
+            ry = real(y)
+            ix = aimag(x)
+            iy = aimag(y)
+            res = (abs(rx-ry) < min(abs(rx) + abs(ry), huge(rx)) * epsilon(rx) &
+                   .and. abs(ix-iy) < min(abs(ix) + abs(iy), huge(ix)) * epsilon(ix))
+          END FUNCTION
           INTEGER FUNCTION test_defaultmap_on()
             INTEGER :: errors_bf, errors_af
           
             ! we try with all the scalars
-            BYTE :: scalar_byte
-            INTEGER(kind = 2) :: scalar_short
-            INTEGER(kind = 4) :: scalar_int
-            INTEGER(kind = 8) :: scalar_long_int
-            REAL(kind = 4) :: scalar_float 
-            REAL(kind = 8) :: scalar_double 
+            INTEGER(kind = int8) :: scalar_byte
+            INTEGER(kind = int16) :: scalar_short
+            INTEGER(kind = int32) :: scalar_int
+            INTEGER(kind = int64) :: scalar_long_int
+            REAL(kind = real32) :: scalar_float
+            REAL(kind = real64) :: scalar_double
             LOGICAL :: scalar_logical
             LOGICAL(kind = 4) :: scalar_logical_kind4
             LOGICAL(kind = 8) :: scalar_logical_kind8
@@ -44,8 +63,8 @@
             scalar_short = 23
             scalar_int = 56
             scalar_long_int = 90000
-            scalar_float  = 4.5e+3
-            scalar_double  = 4.9e+10
+            scalar_float = 4.5e+3_real32
+            scalar_double = 4.9e+10_real64
             scalar_logical = .true.
             scalar_logical_kind4 = .true.
             scalar_logical_kind8 = .true.
@@ -57,8 +76,8 @@
               scalar_short = 83
               scalar_int = 49
               scalar_long_int = 12345
-              scalar_float  = 3.0e+5
-              scalar_double  = 9.5e+9
+              scalar_float = 3.0e+5_real32
+              scalar_double = 9.5e+9_real64
               scalar_logical = .false.
               scalar_logical_kind4 = .false.
               scalar_logical_kind8 = .false.
@@ -69,12 +88,12 @@
             OMPVV_TEST_VERBOSE(scalar_short /= 83)
             OMPVV_TEST_VERBOSE(scalar_int /= 49)
             OMPVV_TEST_VERBOSE(scalar_long_int /= 12345)
-            OMPVV_TEST_VERBOSE(scalar_float  /= 3.0e+5)
-            OMPVV_TEST_VERBOSE(scalar_double  /= 9.5e+9)
+            OMPVV_TEST_VERBOSE(.NOT. same_val_real32(scalar_float, 3.0e+5_real32))
+            OMPVV_TEST_VERBOSE(.NOT. same_val_real64(scalar_double, 9.5e+9_real64))
             OMPVV_TEST_VERBOSE(scalar_logical .NEQV. .false.)
             OMPVV_TEST_VERBOSE(scalar_logical_kind4 .NEQV. .false.)
             OMPVV_TEST_VERBOSE(LOGICAL(scalar_logical_kind8 .NEQV. .false., kind = 4))
-            OMPVV_TEST_VERBOSE(scalar_complex /= (5, 5))
+            OMPVV_TEST_VERBOSE(.NOT. same_val_cmplx(scalar_complex, (5, 5)))
 
             OMPVV_GET_ERRORS(errors_af)
             test_defaultmap_on = errors_bf - errors_af
@@ -87,12 +106,12 @@
             LOGICAL:: firstprivateCheck(10)
             
             ! we try with all the scalars
-            BYTE :: scalar_byte
-            INTEGER(kind = 2) :: scalar_short
-            INTEGER(kind = 4) :: scalar_int
-            INTEGER(kind = 8) :: scalar_long_int
-            REAL(kind = 4) :: scalar_float 
-            REAL(kind = 8) :: scalar_double 
+            INTEGER(kind = int8) :: scalar_byte
+            INTEGER(kind = int16) :: scalar_short
+            INTEGER(kind = int32) :: scalar_int
+            INTEGER(kind = int64) :: scalar_long_int
+            REAL(kind = real32) :: scalar_float
+            REAL(kind = real64) :: scalar_double
             LOGICAL :: scalar_logical
             LOGICAL(kind = 4) :: scalar_logical_kind4
             LOGICAL(kind = 8) :: scalar_logical_kind8
@@ -105,8 +124,8 @@
             scalar_short = 23
             scalar_int = 56
             scalar_long_int = 90000
-            scalar_float  = 4.5e+3
-            scalar_double  = 4.9e+10
+            scalar_float = 4.5e+3_real32
+            scalar_double = 4.9e+10_real64
             scalar_logical = .true.
             scalar_logical_kind4 = .true.
             scalar_logical_kind8 = .true.
@@ -119,20 +138,20 @@
               firstprivateCheck(2)  = scalar_short == 23
               firstprivateCheck(3)  = scalar_int == 56
               firstprivateCheck(4)  = scalar_long_int == 90000
-              firstprivateCheck(5)  = scalar_float  == 4.5e+3
-              firstprivateCheck(6)  = scalar_double  == 4.9e+10
+              firstprivateCheck(5)  = same_val_real32(scalar_float, 4.5e+3_real32)
+              firstprivateCheck(6)  = same_val_real64(scalar_double, 4.9e+10_real64)
               firstprivateCheck(7)  = scalar_logical .EQV. .true.
               firstprivateCheck(8)  = scalar_logical_kind4 .EQV. .true.
               firstprivateCheck(9)  = scalar_logical_kind8 .EQV. .true.
-              firstprivateCheck(10) = scalar_complex == (1, 1)
+              firstprivateCheck(10) = same_val_cmplx (scalar_complex, (1, 1))
 
               ! Attempting value change
               scalar_byte = 80
               scalar_short = 83
               scalar_int = 49
               scalar_long_int = 12345
-              scalar_float  = 3.0e+5
-              scalar_double  = 9.5e+9
+              scalar_float  = 3.0e+5_real32
+              scalar_double  = 9.5e+9_real64
               scalar_logical = .false.
               scalar_logical_kind4 = .false.
               scalar_logical_kind8 = .false.
@@ -152,12 +171,12 @@
             OMPVV_TEST_VERBOSE(scalar_short /= 23)
             OMPVV_TEST_VERBOSE(scalar_int /= 56)
             OMPVV_TEST_VERBOSE(scalar_long_int /= 90000)
-            OMPVV_TEST_VERBOSE(scalar_float  /= 4.5e+3)
-            OMPVV_TEST_VERBOSE(scalar_double  /= 4.9e+10)
+            OMPVV_TEST_VERBOSE(.NOT. same_val_real32(scalar_float, 4.5e+3_real32))
+            OMPVV_TEST_VERBOSE(.NOT. same_val_real64(scalar_double, 4.9e+10_real64))
             OMPVV_TEST_VERBOSE(scalar_logical .NEQV. .true.)
             OMPVV_TEST_VERBOSE(scalar_logical_kind4 .NEQV. .true.)
             OMPVV_TEST_VERBOSE(LOGICAL(scalar_logical_kind8 .NEQV. .true., kind = 4))
-            OMPVV_TEST_VERBOSE(scalar_complex /= (1, 1))
+            OMPVV_TEST_VERBOSE(.NOT. same_val_cmplx (scalar_complex, (1, 1)))
 
             OMPVV_GET_ERRORS(errors_af)
             test_defaultmap_off = errors_bf - errors_af

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_defaultmap.F90
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_defaultmap.F90
@@ -38,23 +38,23 @@ PROGRAM test_target_teams_distribute_defaultmap
 CONTAINS
   INTEGER FUNCTION test_defaultmap_on()
     INTEGER :: errors, x
-    BYTE :: scalar_byte
-    INTEGER(kind = 2) :: scalar_short
-    INTEGER(kind = 4) :: scalar_int
-    INTEGER(kind = 8) :: scalar_long_int
-    REAL(kind = 4) :: scalar_float
-    REAL(kind = 8) :: scalar_double
+    INTEGER(kind = int8) :: scalar_byte
+    INTEGER(kind = int16) :: scalar_short
+    INTEGER(kind = int32) :: scalar_int
+    INTEGER(kind = int64) :: scalar_long_int
+    REAL(kind = real32) :: scalar_float
+    REAL(kind = real64) :: scalar_double
     LOGICAL :: scalar_logical
     LOGICAL(kind = 4) :: scalar_logical_kind4
     LOGICAL(kind = 8) :: scalar_logical_kind8
     COMPLEX :: scalar_complex
 
-    BYTE,DIMENSION(N) :: byte_array
-    INTEGER(kind = 2),DIMENSION(N) :: short_array
-    INTEGER(kind = 4),DIMENSION(N) :: int_array
-    INTEGER(kind = 8),DIMENSION(N) :: long_int_array
-    REAL(kind = 4),DIMENSION(N) :: float_array
-    REAL(kind = 8),DIMENSION(N) :: double_array
+    INTEGER(kind = int8),DIMENSION(N) :: byte_array
+    INTEGER(kind = int16),DIMENSION(N) :: short_array
+    INTEGER(kind = int32),DIMENSION(N) :: int_array
+    INTEGER(kind = int64),DIMENSION(N) :: long_int_array
+    REAL(kind = real32),DIMENSION(N) :: float_array
+    REAL(kind = real64),DIMENSION(N) :: double_array
     LOGICAL,DIMENSION(N) :: logical_array
     LOGICAL(kind = 4),DIMENSION(N) :: logical_kind4_array
     LOGICAL(kind = 8),DIMENSION(N) :: logical_kind8_array
@@ -104,7 +104,7 @@ CONTAINS
        OMPVV_TEST_AND_SET_VERBOSE(errors, logical_kind4_array(x) .neqv. scalar_logical_kind4)
        OMPVV_TEST_AND_SET_VERBOSE(errors, LOGICAL(logical_kind8_array(x) .neqv. scalar_logical_kind8, 4))
        OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(REAL(complex_array(x)) - REAL(scalar_complex)) .gt. .00001)
-       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(IMAG(complex_array(x)) - IMAG(scalar_complex)) .gt. .00001)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(AIMAG(complex_array(x)) - AIMAG(scalar_complex)) .gt. .00001)
     END DO
 
     !$omp target teams distribute defaultmap(tofrom: scalar)
@@ -114,8 +114,8 @@ CONTAINS
           scalar_short = 83
           scalar_int = 49
           scalar_long_int = 12345
-          scalar_float  = 11.2
-          scalar_double  = 9.5
+          scalar_float  = 11.2_real32
+          scalar_double  = 9.5_real64
           scalar_logical = .false.
           scalar_logical_kind4 = .false.
           scalar_logical_kind8 = .false.
@@ -128,36 +128,37 @@ CONTAINS
     OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_short .ne. 83)
     OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_int .ne. 49)
     OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_long_int .ne. 12345)
-    OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(scalar_float - 11.2) .gt. .00001)
-    OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(scalar_double - 9.5) .gt. .0000000001)
+    OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(scalar_float - 11.2_real32) .gt. .00001)
+    OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(scalar_double - 9.5_real64) .gt. .0000000001)
     OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_logical .neqv. .false.)
     OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_logical_kind4 .neqv. .false.)
     OMPVV_TEST_AND_SET_VERBOSE(errors, LOGICAL(scalar_logical_kind8 .neqv. .false., 4))
     OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(REAL(scalar_complex) - 5) .gt. .00001)
-    OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(IMAG(scalar_complex) - 5) .gt. .00001)
+    OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(AIMAG(scalar_complex) - 5) .gt. .00001)
 
     test_defaultmap_on = errors
   END FUNCTION test_defaultmap_on
 
   INTEGER FUNCTION test_defaultmap_off()
-    INTEGER :: errors, x, y
-    BYTE :: scalar_byte, scalar_byte_copy
-    INTEGER(kind = 2) :: scalar_short, scalar_short_copy
-    INTEGER(kind = 4) :: scalar_int, scalar_int_copy
-    INTEGER(kind = 8) :: scalar_long_int, scalar_long_int_copy
-    REAL(kind = 4) :: scalar_float, scalar_float_copy
-    REAL(kind = 8) :: scalar_double, scalar_double_copy
+    INTEGER :: errors, x
+    INTEGER(kind = int64) :: y
+    INTEGER(kind = int8) :: scalar_byte, scalar_byte_copy
+    INTEGER(kind = int16) :: scalar_short, scalar_short_copy
+    INTEGER(kind = int32) :: scalar_int, scalar_int_copy
+    INTEGER(kind = int64) :: scalar_long_int, scalar_long_int_copy
+    REAL(kind = real32) :: scalar_float, scalar_float_copy
+    REAL(kind = real64) :: scalar_double, scalar_double_copy
     LOGICAL :: scalar_logical, scalar_logical_copy
     LOGICAL(kind = 4) :: scalar_logical_kind4, scalar_logical_kind4_copy
     LOGICAL(kind = 8) :: scalar_logical_kind8, scalar_logical_kind8_copy
     COMPLEX :: scalar_complex, scalar_complex_copy
 
-    BYTE,DIMENSION(N) :: byte_array_a, byte_array_b
-    INTEGER(kind = 2),DIMENSION(N) :: short_array_a, short_array_b
-    INTEGER(kind = 4),DIMENSION(N) :: int_array_a, int_array_b
-    INTEGER(kind = 8),DIMENSION(N) :: long_int_array_a, long_int_array_b
-    REAL(kind = 4),DIMENSION(N) :: float_array_a, float_array_b
-    REAL(kind = 8),DIMENSION(N) :: double_array_a, double_array_b
+    INTEGER(kind = int8),DIMENSION(N) :: byte_array_a, byte_array_b
+    INTEGER(kind = int16),DIMENSION(N) :: short_array_a, short_array_b
+    INTEGER(kind = int32),DIMENSION(N) :: int_array_a, int_array_b
+    INTEGER(kind = int64),DIMENSION(N) :: long_int_array_a, long_int_array_b
+    REAL(kind = real32),DIMENSION(N) :: float_array_a, float_array_b
+    REAL(kind = real64),DIMENSION(N) :: double_array_a, double_array_b
     LOGICAL,DIMENSION(N, 16) :: logical_array_a
     LOGICAL,DIMENSION(N) :: logical_array_b
     LOGICAL(kind = 4),DIMENSION(N, 16) :: logical_kind4_array_a
@@ -170,8 +171,8 @@ CONTAINS
     scalar_short = 23
     scalar_int = 56
     scalar_long_int = 90000
-    scalar_float = 4.5
-    scalar_double = 4.9
+    scalar_float = 4.5_real32
+    scalar_double = 4.9_real64
     scalar_logical = .TRUE.
     scalar_logical_kind4 = .TRUE.
     scalar_logical_kind8 = .TRUE.
@@ -182,8 +183,8 @@ CONTAINS
        short_array_a(x) = 50
        int_array_a(x) = 70
        long_int_array_a(x) = 150
-       float_array_a(x) = 15.5
-       double_array_a(x) = 52.45
+       float_array_a(x) = 15.5_real32
+       double_array_a(x) = 52.45_real64
        DO y = 1, 16
           logical_array_a(x, y) = .TRUE.
           logical_kind4_array_a(x, y) = .TRUE.
@@ -208,37 +209,37 @@ CONTAINS
     DO x = 1, N
        scalar_byte = 0
        DO y = 1, byte_array_a(x)
-          scalar_byte = scalar_byte + 1
+          scalar_byte = scalar_byte + 1_int8
        END DO
        byte_array_b(x) = scalar_byte
 
        scalar_short = 0
        DO y = 1, short_array_a(x)
-          scalar_short = scalar_short + 1
+          scalar_short = scalar_short + 1_int16
        END DO
        short_array_b(x) = scalar_short
 
        scalar_int = 0
        DO y = 1, int_array_a(x)
-          scalar_int = scalar_int + 1
+          scalar_int = scalar_int + 1_int32
        END DO
        int_array_b(x) = scalar_int
 
        scalar_long_int = 0
        DO y = 1, long_int_array_a(x)
-          scalar_long_int = scalar_long_int + 1
+          scalar_long_int = scalar_long_int + 1_int64
        END DO
        long_int_array_b(x) = scalar_long_int
 
        scalar_float = 0
        DO y = 1, INT(float_array_a(x))
-          scalar_float = scalar_float + .7
+          scalar_float = scalar_float + .7_real32
        END DO
        float_array_b(x) = scalar_float
 
        scalar_double = 0
        DO y = 1, INT(double_array_a(x))
-          scalar_double = scalar_double + .7
+          scalar_double = scalar_double + .7_real64
        END DO
        double_array_b(x) = scalar_double
 
@@ -276,8 +277,8 @@ CONTAINS
        OMPVV_TEST_AND_SET_VERBOSE(errors, short_array_a(x) .ne. short_array_b(x))
        OMPVV_TEST_AND_SET_VERBOSE(errors, int_array_a(x) .ne. int_array_b(x))
        OMPVV_TEST_AND_SET_VERBOSE(errors, long_int_array_a(x) .ne. long_int_array_b(x))
-       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS((INT(float_array_a(x)) * .7) - float_array_b(x)) .gt. .00001)
-       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS((INT(double_array_a(x)) * .7) - double_array_b(x)) .gt. .00001)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS((INT(float_array_a(x)) * .7_real32) - float_array_b(x)) .gt. .00001_real32)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS((INT(double_array_a(x)) * .7_real64) - double_array_b(x)) .gt. .00001_real64)
        OMPVV_TEST_AND_SET_VERBOSE(errors, logical_array_b(x) .neqv. .FALSE.)
        OMPVV_TEST_AND_SET_VERBOSE(errors, logical_kind4_array_b(x) .neqv. .FALSE.)
        OMPVV_TEST_AND_SET_VERBOSE(errors, LOGICAL(logical_kind8_array_b(x) .neqv. .FALSE., 4))
@@ -289,8 +290,8 @@ CONTAINS
     scalar_short = 23
     scalar_int = 56
     scalar_long_int = 90000
-    scalar_float = 4.5
-    scalar_double = 4.9
+    scalar_float = 4.5_real32
+    scalar_double = 4.9_real64
     scalar_logical = .TRUE.
     scalar_logical_kind4 = .TRUE.
     scalar_logical_kind8 = .TRUE.
@@ -344,8 +345,8 @@ CONTAINS
        OMPVV_TEST_AND_SET_VERBOSE(errors, short_array_a(x) .ne. scalar_short_copy)
        OMPVV_TEST_AND_SET_VERBOSE(errors, int_array_a(x) .ne. scalar_int_copy)
        OMPVV_TEST_AND_SET_VERBOSE(errors, long_int_array_a(x) .ne. scalar_long_int_copy)
-       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(float_array_a(x) - scalar_float_copy) .gt. .000001)
-       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(double_array_a(x) - scalar_double_copy) .gt. .0000000001)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(float_array_a(x) - scalar_float_copy) .gt. .000001_real32)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(double_array_a(x) - scalar_double_copy) .gt. .0000000001_real64)
        OMPVV_TEST_AND_SET_VERBOSE(errors, logical_array_b(x) .neqv. scalar_logical_copy)
        OMPVV_TEST_AND_SET_VERBOSE(errors, logical_kind4_array_b(x) .neqv. scalar_logical_kind4_copy)
        OMPVV_TEST_AND_SET_VERBOSE(errors, LOGICAL(logical_kind8_array_b(x) .neqv. scalar_logical_kind8_copy, 4))
@@ -357,13 +358,13 @@ CONTAINS
        OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_short .ne. scalar_short_copy)
        OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_int .ne. scalar_int_copy)
        OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_long_int .ne. scalar_long_int_copy)
-       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(scalar_float - scalar_float_copy) .gt. .000001)
-       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(scalar_double - scalar_double_copy) .gt. .0000000001)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(scalar_float - scalar_float_copy) .gt. .000001_real32)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(scalar_double - scalar_double_copy) .gt. .0000000001_real64)
        OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_logical .neqv. scalar_logical_copy)
        OMPVV_TEST_AND_SET_VERBOSE(errors, scalar_logical_kind4 .neqv. scalar_logical_kind4_copy)
        OMPVV_TEST_AND_SET_VERBOSE(errors, LOGICAL(scalar_logical_kind8 .neqv. scalar_logical_kind8_copy, 4))
        OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(REAL(scalar_complex) - REAL(scalar_complex_copy)) .gt. .000001)
-       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(IMAG(scalar_complex) - IMAG(scalar_complex_copy)) .gt. .000001)
+       OMPVV_TEST_AND_SET_VERBOSE(errors, ABS(AIMAG(scalar_complex) - AIMAG(scalar_complex_copy)) .gt. .000001)
     END IF
     test_defaultmap_off = errors
   END FUNCTION test_defaultmap_off


### PR DESCRIPTION
* BYTE is a vendor extension, use kind = INT8 instead.
* Replace numerical kind values by INT{16,32,64} and REAL{32,64}
* Add '_kind' suffix to floating point constants to avoid rounding
  issues; append _kind to some integer constants to avoid semi-bogus
  conversion warnings
* Make one loop variable larger (int64) to avoid potentially overflowing
  warning
* Use AIMAG instead IMAG as the latter is a vendor extension
* Do epsilon-based same-value comparisons for REAL/COMPLEX

Follow up to Pull Request #499.

Note: The code still uses numerical constants for `LOGICAL`. While expected that that `INT_KINDS` and `LOGICAL_KINDS` are identical and have identical storage size for the same kind value, the Fortran standard does not guarantee this.
If needed, one solution would be to use LOGICAL_KINDS(1) and LOGICAL(size(LOGICAL_KINDS)) to use the largest/smallest logical kind.