### PR TITLE
test_requires_dynamic_allocators.c: Avoid I/O in target regions

### DIFF
--- a/tests/5.0/requires/test_requires_dynamic_allocators.c
+++ b/tests/5.0/requires/test_requires_dynamic_allocators.c
@@ -23,9 +23,10 @@
 #define N 1024
 
 int test_requires() {
+  int saved_x[N];
   int errors = 0;
 
-#pragma omp target map(from: errors)
+#pragma omp target map(from: saved_x)
   {
     int* x;
     omp_memspace_handle_t x_memspace = omp_default_mem_space;
@@ -40,11 +41,15 @@ int test_requires() {
     }
 
     for (int i = 0; i < N; i++) {
-      OMPVV_TEST_AND_SET_VERBOSE(errors, x[i] != i);
+      saved_x[i] = x[i];
     }
 
     omp_free(x, x_alloc);
     omp_destroy_allocator(x_alloc);
+  }
+
+  for (int i = 0; i < N; i++) {
+    OMPVV_TEST_AND_SET_VERBOSE(errors, saved_x[i] != i);
   }
 
   return errors;


### PR DESCRIPTION
Move the OMPVV_TEST_AND_SET_VERBOSE out of the target region as I/O is
not generally supported inside target regions and this testcase is
supposed to test another feature.

The issue only occurs when VERBOSE_MODE is set.

_I do note that GCC supports printf I/O in principle for C/C++ with nvptx + AMD GCN offloading and for Fortran with AMD GCN, but I think it still makes sense to avoid I/O in target regions._

_I wonder whether a C and a Fortran testcase should be added which does I/O in a target region on purpose._