### PR TITLE
ompvv/ompvv.F90: Guard a PARAMETER by #ifdef

### DIFF
--- a/ompvv/ompvv.F90
+++ b/ompvv/ompvv.F90
@@ -305,8 +305,10 @@ OMPVV_MODULE_REQUIRES_LINE
       CHARACTER(len=*) :: fn
       CHARACTER(len=500) :: clean
       INTEGER :: ln
+#ifdef VERBOSE_MODE
       CHARACTER(len=*), PARAMETER :: msg = "This tests is running on a shared &
         & data environment between host and device. This may cause errors"
+#endif
 
       clean = TRIM(clean_fn(fn))
       ! Avoid unused variables warning


### PR DESCRIPTION
Silences "Unused parameter 'msg' declared" with unset VERBOSE_MODE in this always-included  file.

In gfortran, this warning only triggers with `-Wunused-parameter` (enabled by `-Wextra`) – if (and only if) VERBOSE_MODE is undefined. — However, since it is localized in ompvv/ompvv.F90, which is included in all Fortran test cases and is the only file where VERBOSE_MODE is processed, I think it still is sensible to silence this warning.