### PR TITLE
Fix mapping in target/test_target_defaultmap_to_from_tofrom.F90

### DIFF
--- a/tests/5.0/target/test_target_defaultmap_to_from_tofrom.F90
+++ b/tests/5.0/target/test_target_defaultmap_to_from_tofrom.F90
@@ -40,15 +40,16 @@ CONTAINS
 
 
     TYPE(structure) :: new_struct !aggregate
-    ALLOCATE(B(N))
+    ALLOCATE(B(N), ptr(N))
 
     scalar = 1
     new_struct%s = 1
 
     DO i = 1, N
-       A(i) = 0
-       B(i) = 0
-       new_struct%SA(i) = 0
+       A(i) = 1
+       B(i) = 1
+       ptr(i) = 1
+       new_struct%SA(i) = 1
     END DO
 
     errors = 0
@@ -59,17 +60,16 @@ CONTAINS
     B(1) = 5; B(2) = 5 ! allocatable array, default is tofrom
     ! aggregate structure, default is tofrom
     new_struct%s = 10; new_struct%SA(1) = 10; new_struct%SA(2) = 10
-    ptr => A
     ptr(51) = 70; ptr(52) = 71
     !$omp end target
 
     OMPVV_TEST_AND_SET_VERBOSE(errors, scalar /= 1)
-    OMPVV_TEST_AND_SET_VERBOSE(errors, A(1) /= 0 .OR. A(2) /= 0) 
-    OMPVV_TEST_AND_SET_VERBOSE(errors, A(51) /= 0 .OR. A(52) /= 0)
-    OMPVV_TEST_AND_SET_VERBOSE(errors, B(1) /= 0 .OR. B(2) /= 0) 
+    OMPVV_TEST_AND_SET_VERBOSE(errors, A(1) /= 1 .OR. A(2) /= 1)
+    OMPVV_TEST_AND_SET_VERBOSE(errors, ptr(51) /= 1 .OR. ptr(52) /= 1)
+    OMPVV_TEST_AND_SET_VERBOSE(errors, B(1) /= 1 .OR. B(2) /= 1)
     OMPVV_TEST_AND_SET_VERBOSE(errors, new_struct%s /= 1)
-    OMPVV_TEST_AND_SET_VERBOSE(errors, new_struct%SA(1) /= 0)
-    OMPVV_TEST_AND_SET_VERBOSE(errors, new_struct%SA(2) /= 0)
+    OMPVV_TEST_AND_SET_VERBOSE(errors, new_struct%SA(1) /= 1)
+    OMPVV_TEST_AND_SET_VERBOSE(errors, new_struct%SA(2) /= 1)
 
     defaultmap_with_to = errors
   END FUNCTION defaultmap_with_to
@@ -88,15 +88,16 @@ CONTAINS
 
 
     TYPE(structure) :: new_struct !aggregate
-    ALLOCATE(B(N))
+    ALLOCATE(B(N),ptr(N))
 
     scalar = 1
     new_struct%s = 1
 
     DO i = 1, N
-       A(i) = 0
-       B(i) = 0
-       new_struct%SA(i) = 0
+       A(i) = 1
+       B(i) = 1
+       ptr(i) = 1
+       new_struct%SA(i) = 1
     END DO
 
     errors = 0
@@ -107,13 +108,12 @@ CONTAINS
     B(1) = 5; B(2) = 5 ! allocatable array, default is tofrom
     ! aggregate structure, default is tofrom
     new_struct%s = 10; new_struct%SA(1) = 10; new_struct%SA(2) = 10
-    ptr => A
     ptr(51) = 50; ptr(52) = 51
     !$omp end target
 
     OMPVV_TEST_AND_SET_VERBOSE(errors, scalar /= 17)
     OMPVV_TEST_AND_SET_VERBOSE(errors, A(1) /= 5 .OR. A(2) /= 5) 
-    OMPVV_TEST_AND_SET_VERBOSE(errors, A(51) /= 50 .OR. A(52) /= 51)
+    OMPVV_TEST_AND_SET_VERBOSE(errors, ptr(51) /= 50 .OR. ptr(52) /= 51)
     OMPVV_TEST_AND_SET_VERBOSE(errors, B(1) /= 5 .OR. B(2) /= 5) 
     OMPVV_TEST_AND_SET_VERBOSE(errors, new_struct%s /= 10)
     OMPVV_TEST_AND_SET_VERBOSE(errors, new_struct%SA(1) /= 10)
@@ -136,38 +136,37 @@ CONTAINS
 
 
     TYPE(structure) :: new_struct !aggregate
-    ALLOCATE(B(N))
+    ALLOCATE(B(N),ptr(N))
 
-    ptr => null()
     scalar = 1
     new_struct%s = 1
 
     DO i = 1, N
-       A(i) = 0
-       B(i) = 0
-       new_struct%SA(i) = 0
+       A(i) = 1
+       B(i) = 1
+       ptr(i) = 1
+       new_struct%SA(i) = 1
     END DO
 
     errors = 0
 
     !$omp target defaultmap(tofrom)
-    scalar = 17 !scalar firstprivate, value not returned
-    A(1) = 5; A(2) = 5 ! aggregate array, default is tofrom
-    B(1) = 5; B(2) = 5 ! allocatable array, default is tofrom
+    scalar = scalar + 17 !scalar firstprivate, value not returned
+    A(1) = A(1) + 5; A(2) = A(2) + 5 ! aggregate array, default is tofrom
+    B(1) = B(1) + 5; B(2) = B(2) + 5 ! allocatable array, default is tofrom
     ! aggregate structure, default is tofrom
-    new_struct%s = 10; new_struct%SA(1) = 10; new_struct%SA(2) = 10
-    ptr => A
-    ptr(51) = 50; ptr(52) = 51
-    ptr => null()
+    new_struct%s = new_struct%s + 10;
+    new_struct%SA(1) = new_struct%SA(1) + 10; new_struct%SA(2) = new_struct%SA(2) + 10
+    ptr(51) = ptr(51) + 50; ptr(52) = ptr(52) + 51
     !$omp end target
 
-    OMPVV_TEST_AND_SET_VERBOSE(errors, scalar /= 17)
-    OMPVV_TEST_AND_SET_VERBOSE(errors, A(1) /= 5 .OR. A(2) /= 5) 
-    OMPVV_TEST_AND_SET_VERBOSE(errors, A(51) /= 50 .OR. A(52) /= 51)
-    OMPVV_TEST_AND_SET_VERBOSE(errors, B(1) /= 5 .OR. B(2) /= 5) 
-    OMPVV_TEST_AND_SET_VERBOSE(errors, new_struct%s /= 10)
-    OMPVV_TEST_AND_SET_VERBOSE(errors, new_struct%SA(1) /= 10)
-    OMPVV_TEST_AND_SET_VERBOSE(errors, new_struct%SA(2) /= 10)
+    OMPVV_TEST_AND_SET_VERBOSE(errors, scalar /= 18)
+    OMPVV_TEST_AND_SET_VERBOSE(errors, A(1) /= 6 .OR. A(2) /= 6)
+    OMPVV_TEST_AND_SET_VERBOSE(errors, ptr(51) /= 51 .OR. ptr(52) /= 52)
+    OMPVV_TEST_AND_SET_VERBOSE(errors, B(1) /= 6 .OR. B(2) /= 6)
+    OMPVV_TEST_AND_SET_VERBOSE(errors, new_struct%s /= 11)
+    OMPVV_TEST_AND_SET_VERBOSE(errors, new_struct%SA(1) /= 11)
+    OMPVV_TEST_AND_SET_VERBOSE(errors, new_struct%SA(2) /= 11)
 
     defaultmap_with_tofrom = errors
   END FUNCTION defaultmap_with_tofrom


### PR DESCRIPTION
This testcase did spurious fail on some host/gpu arch combinations when the Fortran pointer ptr wasn't nullified, either only for 'to' or for 'from'. This commit does:
* Actually map the pointer (i.e. apply 'defaultmap(to/from/fromto) also to category 'pointer') instead of just using it inside the target.
* Initialize all variables to /= 0 to make checking work more properly.
* For 'tofrom', actually use the passed value to distinguish 'from' from 'tofrom'.

Note: Regarding the pointer handling, see also the "restrictions to the target construct" (last three bullet points in OpenMP 5.1/5.2). In OpenMP 5.0, the third-last item describes this with looser words.

Namely, OpenMP 5.0 has, https://www.openmp.org/spec-html/5.0/openmpsu60.html#x86-2880002.12.5
>  * An attached pointer that is associated with a given pointer target must not become associated with a different pointer target in a target region.

And OpenMP 5.1 (likewise 5.2), https://www.openmp.org/spec-html/5.1/openmpsu68.html#Q1-96-392
>  * An attached pointer that is associated with a given pointer target must not become associated with a different pointer target in a target region.
> * [...] (4 other items)
> * If the association status of a list item with the POINTER attribute that appears in a map clause on the construct is associated upon entry to the target region, the list item must be associated with the same pointer target upon exit from the region.
> * If the association status of a list item with the POINTER attribute that appears in a map clause on the construct is disassociated upon entry to the target region, the list item must be disassociated upon exit from the region.
> * If the association status of a list item with the POINTER attribute that appears in a map clause on the construct is disassociated or undefined on entry to the target region and if the list item is associated with a pointer target inside the target region, the pointer association status must become disassociated before the end the region.

@spophale @nolanbaker31 @tmh97 @seyonglee @mjcarr458 @krishols @jrreap – please review.