### PR TITLE
Issue 545: 4.5/target/test_target_defaultmap.F90 avoid OMP5.0-isms

### DIFF
--- a/tests/4.5/target/test_target_defaultmap.F90
+++ b/tests/4.5/target/test_target_defaultmap.F90
@@ -9,7 +9,8 @@
 #include "ompvv.F90" 
 
       PROGRAM test_target_defaultmap
-        USE iso_fortran_env
+        USE iso_c_binding
+        ! Assume c_float=32bit, c_double=64bit;
         USE ompvv_lib
         USE omp_lib
         implicit none
@@ -23,14 +24,17 @@
 
         CONTAINS 
           LOGICAL FUNCTION same_val_real32 (x, y) RESULT(res)
-            REAL(kind = real32) :: x, y
+            !$omp declare target
+            REAL(kind = c_float) :: x, y
             res = abs(x-y) < min(abs(x) + abs(y), huge(x)) * epsilon(x)
           END FUNCTION
           LOGICAL FUNCTION same_val_real64 (x, y) RESULT(res)
-            REAL(kind = real64) :: x, y
+            !$omp declare target
+            REAL(kind = c_double) :: x, y
             res = abs(x-y) < min(abs(x) + abs(y), huge(x)) * epsilon(x)
           END FUNCTION
           LOGICAL FUNCTION same_val_cmplx (x, y) RESULT(res)
+            !$omp declare target
             COMPLEX :: x, y
             REAL :: rx, ry
             REAL :: ix, iy
@@ -45,12 +49,12 @@
             INTEGER :: errors_bf, errors_af
           
             ! we try with all the scalars
-            INTEGER(kind = int8) :: scalar_byte
-            INTEGER(kind = int16) :: scalar_short
-            INTEGER(kind = int32) :: scalar_int
-            INTEGER(kind = int64) :: scalar_long_int
-            REAL(kind = real32) :: scalar_float
-            REAL(kind = real64) :: scalar_double
+            INTEGER(kind = c_int8_t) :: scalar_byte
+            INTEGER(kind = c_int16_t) :: scalar_short
+            INTEGER(kind = c_int32_t) :: scalar_int
+            INTEGER(kind = c_int64_t) :: scalar_long_int
+            REAL(kind = c_float) :: scalar_float
+            REAL(kind = c_double) :: scalar_double
             LOGICAL :: scalar_logical
             LOGICAL(kind = 4) :: scalar_logical_kind4
             LOGICAL(kind = 8) :: scalar_logical_kind8
@@ -63,8 +67,8 @@
             scalar_short = 23
             scalar_int = 56
             scalar_long_int = 90000
-            scalar_float = 4.5e+3_real32
-            scalar_double = 4.9e+10_real64
+            scalar_float = 4.5e+3_c_float
+            scalar_double = 4.9e+10_c_double
             scalar_logical = .true.
             scalar_logical_kind4 = .true.
             scalar_logical_kind8 = .true.
@@ -76,8 +80,8 @@
               scalar_short = 83
               scalar_int = 49
               scalar_long_int = 12345
-              scalar_float = 3.0e+5_real32
-              scalar_double = 9.5e+9_real64
+              scalar_float = 3.0e+5_c_float
+              scalar_double = 9.5e+9_c_double
               scalar_logical = .false.
               scalar_logical_kind4 = .false.
               scalar_logical_kind8 = .false.
@@ -88,8 +92,8 @@
             OMPVV_TEST_VERBOSE(scalar_short /= 83)
             OMPVV_TEST_VERBOSE(scalar_int /= 49)
             OMPVV_TEST_VERBOSE(scalar_long_int /= 12345)
-            OMPVV_TEST_VERBOSE(.NOT. same_val_real32(scalar_float, 3.0e+5_real32))
-            OMPVV_TEST_VERBOSE(.NOT. same_val_real64(scalar_double, 9.5e+9_real64))
+            OMPVV_TEST_VERBOSE(.NOT. same_val_real32(scalar_float, 3.0e+5_c_float))
+            OMPVV_TEST_VERBOSE(.NOT. same_val_real64(scalar_double, 9.5e+9_c_double))
             OMPVV_TEST_VERBOSE(scalar_logical .NEQV. .false.)
             OMPVV_TEST_VERBOSE(scalar_logical_kind4 .NEQV. .false.)
             OMPVV_TEST_VERBOSE(LOGICAL(scalar_logical_kind8 .NEQV. .false., kind = 4))
@@ -106,12 +110,12 @@
             LOGICAL:: firstprivateCheck(10)
             
             ! we try with all the scalars
-            INTEGER(kind = int8) :: scalar_byte
-            INTEGER(kind = int16) :: scalar_short
-            INTEGER(kind = int32) :: scalar_int
-            INTEGER(kind = int64) :: scalar_long_int
-            REAL(kind = real32) :: scalar_float
-            REAL(kind = real64) :: scalar_double
+            INTEGER(kind = c_int8_t) :: scalar_byte
+            INTEGER(kind = c_int16_t) :: scalar_short
+            INTEGER(kind = c_int32_t) :: scalar_int
+            INTEGER(kind = c_int64_t) :: scalar_long_int
+            REAL(kind = c_float) :: scalar_float
+            REAL(kind = c_double) :: scalar_double
             LOGICAL :: scalar_logical
             LOGICAL(kind = 4) :: scalar_logical_kind4
             LOGICAL(kind = 8) :: scalar_logical_kind8
@@ -124,8 +128,8 @@
             scalar_short = 23
             scalar_int = 56
             scalar_long_int = 90000
-            scalar_float = 4.5e+3_real32
-            scalar_double = 4.9e+10_real64
+            scalar_float = 4.5e+3_c_float
+            scalar_double = 4.9e+10_c_double
             scalar_logical = .true.
             scalar_logical_kind4 = .true.
             scalar_logical_kind8 = .true.
@@ -138,8 +142,8 @@
               firstprivateCheck(2)  = scalar_short == 23
               firstprivateCheck(3)  = scalar_int == 56
               firstprivateCheck(4)  = scalar_long_int == 90000
-              firstprivateCheck(5)  = same_val_real32(scalar_float, 4.5e+3_real32)
-              firstprivateCheck(6)  = same_val_real64(scalar_double, 4.9e+10_real64)
+              firstprivateCheck(5)  = same_val_real32(scalar_float, 4.5e+3_c_float)
+              firstprivateCheck(6)  = same_val_real64(scalar_double, 4.9e+10_c_double)
               firstprivateCheck(7)  = scalar_logical .EQV. .true.
               firstprivateCheck(8)  = scalar_logical_kind4 .EQV. .true.
               firstprivateCheck(9)  = scalar_logical_kind8 .EQV. .true.
@@ -150,8 +154,8 @@
               scalar_short = 83
               scalar_int = 49
               scalar_long_int = 12345
-              scalar_float  = 3.0e+5_real32
-              scalar_double  = 9.5e+9_real64
+              scalar_float  = 3.0e+5_c_float
+              scalar_double  = 9.5e+9_c_double
               scalar_logical = .false.
               scalar_logical_kind4 = .false.
               scalar_logical_kind8 = .false.
@@ -171,8 +175,8 @@
             OMPVV_TEST_VERBOSE(scalar_short /= 23)
             OMPVV_TEST_VERBOSE(scalar_int /= 56)
             OMPVV_TEST_VERBOSE(scalar_long_int /= 90000)
-            OMPVV_TEST_VERBOSE(.NOT. same_val_real32(scalar_float, 4.5e+3_real32))
-            OMPVV_TEST_VERBOSE(.NOT. same_val_real64(scalar_double, 4.9e+10_real64))
+            OMPVV_TEST_VERBOSE(.NOT. same_val_real32(scalar_float, 4.5e+3_c_float))
+            OMPVV_TEST_VERBOSE(.NOT. same_val_real64(scalar_double, 4.9e+10_c_double))
             OMPVV_TEST_VERBOSE(scalar_logical .NEQV. .true.)
             OMPVV_TEST_VERBOSE(scalar_logical_kind4 .NEQV. .true.)
             OMPVV_TEST_VERBOSE(LOGICAL(scalar_logical_kind8 .NEQV. .true., kind = 4))


### PR DESCRIPTION
Issue #545 

OpenMP 4.5 does not automatically add 'declare target', contrary to OpenMP 5.0. Thus, add it explicitly.

Likewise, the base-language version of OpenMP 4.5 is Fortran 2003. Thus, remove ISO_FORTRAN_ENV parameters added in Fortran 2008 and replace intXX and realXX by ISO_C_BINDING's c_int..._t and c_float/c_double.
