### PR TITLE
Fix tests/5.0/parallel_for/test_parallel_for_allocate.F90

### DIFF
--- a/tests/5.0/parallel_for/test_parallel_for_allocate.F90
+++ b/tests/5.0/parallel_for/test_parallel_for_allocate.F90
@@ -48,6 +48,8 @@ CONTAINS
        END DO
     END DO
 
+    x_alloc = omp_init_allocator(x_memspace, size(x_traits), x_traits)
+
     !$omp parallel do allocate(x_alloc: x) private(x) &
     !$omp& shared(result_arr) num_threads(OMPVV_NUM_THREADS_HOST)
     DO i = 1, N


### PR DESCRIPTION
Call omp_init_allocator before using the allocator handle.

It is not quite clear why it tends not fail (at least for me)– probably the stack memory ends up as NULL – but it does not make sense to use an undefined allocator handle. Fixed by calling `omp_init_allocator` on it – the associated `omp_destroy_allocator` is already present (see line 78 (before) or line 80 (after this change)).

@spophale @nolanbaker31 @tmh97 @seyonglee @mjcarr458 @krishols @jrreap – please review.