### PR TITLE
Fix test_target_teams_thread_limit.c

### DIFF
--- a/tests/5.1/teams/test_target_teams_thread_limit.c
+++ b/tests/5.1/teams/test_target_teams_thread_limit.c
@@ -26,31 +26,33 @@ int main() {
         int i;
 	int testing_thread_limit = OMPVV_NUM_THREADS_DEVICE/OMPVV_NUM_TEAMS_DEVICE;
 
+	if (testing_thread_limit == 1)
+	  testing_thread_limit = 2;
+
 	OMPVV_TEST_OFFLOADING;
       
 
-         for (i = 0; i<testing_thread_limit; i++){
+         for (i = 0; i<OMPVV_NUM_TEAMS_DEVICE; i++){
               errors[i] = 0;
          }
  
 	#pragma omp target map(tofrom:num_teams,errors) thread_limit(testing_thread_limit)
 	{
 		#pragma omp teams num_teams(OMPVV_NUM_TEAMS_DEVICE) 
-
 		{
+			#pragma omp parallel
+			{
+				if (omp_get_team_num() == 0 && omp_get_thread_num() == 0) {
+					num_teams = omp_get_num_teams();
+				}
 
-			if (omp_get_team_num() == 0 && omp_get_thread_num() == 0) {
-				num_teams = omp_get_num_teams();
-			}
-
-			if (omp_get_thread_num() == 0) {
+				if (omp_get_thread_num() == 0) {
 			
-			     if (omp_get_num_threads() > testing_thread_limit) {
-					errors[omp_get_team_num()] += 1;				
-			     }		
-			     
+					if (omp_get_num_threads() > testing_thread_limit) {
+						errors[omp_get_team_num()] += 1;
+					}
+				}
 			}
-
 		}
 
 	}


### PR DESCRIPTION
Follow up to Pull Request #458 (see discussion there).

* tests/5.1/teams/test_target_teams_thread_limit.c

Changes:
- `testing_thread_limit = OMPVV_NUM_THREADS_DEVICE/OMPVV_NUM_TEAMS_DEVICE;`
  is equivalent to `= 8 / 8 = 1`. If `testing_thread_limit` is 1, set it
  to 2 - also to silence the `testing_thread_limit == 1` warning.
- Loop over `OMPVV_NUM_TEAMS_DEVICE` not `testing_thread_limit` for
  `errors[i]` as it is set by teams not by thread.
- Wrap in `omp parallel` as `omp_get_thread_num`/`omp_get_num_threads` calls
  may not be strictly nested in `teams`.

@tmh97 @spophale @seyonglee @ nolanbaker31 @krishols @jrreap – please review.