### PR TITLE
Remove unused vars: target_defaultmap.F90, printf_in_target_region.c

### DIFF
--- a/tests/4.5/target/test_target_defaultmap.F90
+++ b/tests/4.5/target/test_target_defaultmap.F90
@@ -105,7 +105,6 @@
 
           INTEGER FUNCTION test_defaultmap_off()
             INTEGER :: errors_bf, errors_af, i, tmp1 = 0, tmp2 = 0
-            CHARACTER(len=400) :: longMessage
             CHARACTER(len=100) :: shortMessage
             LOGICAL:: firstprivateCheck(10)
             

--- a/tests/5.2/misc/test_printf_in_target_region.c
+++ b/tests/5.2/misc/test_printf_in_target_region.c
@@ -29,8 +29,6 @@ int main () {
    long int long_one = 194834345;
    unsigned long int unsigned_long = 1777444;
    long long int long_long = 282828293898;
-   unsigned char unsigned_char = 200;
-
 
    #pragma omp target map(tofrom: integer, floater, doubler, single_char, shortie, unsigned_shortie, long_one, unsigned_long, long_long) 
    {


### PR DESCRIPTION
* tests/5.2/misc/test_printf_in_target_region.c: Remove 'unsigned_char' as %c test already exists (and using it with %c
  might have encoding issues as 200 not part of ASCII/single-byte UTF-8) and using '%u' is already covered by 'short'.
* tests/4.5/target/test_target_defaultmap.F90: Remove 'longMessage'  as it is unused.

Crossref:
* test_printf_in_target_region.c was added via Pull Request #555
* test_target_defaultmap.F90 lost the use of longMessage in #44 _(some later commits fixed other issues, but not this unused warning)_

@spophale @tmh97 @seyonglee @nolanbaker31 @jrreap @mjcarr458 – please review.