### PR TITLE
omp_target_memcpy_rect_async test

### DIFF
--- a/tests/5.1/target/test_target_memcpy_async_depobj.c
+++ b/tests/5.1/target/test_target_memcpy_async_depobj.c
@@ -64,6 +64,7 @@ int test_target_memcpy_async_depobj() {
         OMPVV_TEST_AND_SET(errors, mem[i]!=i*2);
     }
     // free resources
+    free(mem);
     omp_target_free(mem_dev_cpy, t);
     #pragma omp depobj(obj) destroy
     return errors;

--- a/tests/5.1/target/test_target_memcpy_async_no_obj.c
+++ b/tests/5.1/target/test_target_memcpy_async_no_obj.c
@@ -55,10 +55,11 @@ int test_target_memcpy_async_no_obj() {
                                 0,          NULL);
 
     #pragma omp taskwait
-    
     for(i = 0; i < N; i++){
         OMPVV_TEST_AND_SET(errors, mem[i]!=i*2);
     }
+    // free resources
+    free(mem);
     omp_target_free(mem_dev_cpy, t);
     return errors;
 }

--- a/tests/5.1/target/test_target_memcpy_async_no_obj.c
+++ b/tests/5.1/target/test_target_memcpy_async_no_obj.c
@@ -45,7 +45,7 @@ int test_target_memcpy_async_no_obj() {
 
     #pragma omp target is_device_ptr(mem_dev_cpy) device(t)
     #pragma omp teams distribute parallel for
-    for(i = 0;i<N;i++){
+    for(i = 0; i < N; i++){
         mem_dev_cpy[i] = i*2; // initialize data on device
     }
     /* copy to host */
@@ -56,7 +56,7 @@ int test_target_memcpy_async_no_obj() {
 
     #pragma omp taskwait
     
-    for(int i=0;i<N;i++){
+    for(i = 0; i < N; i++){
         OMPVV_TEST_AND_SET(errors, mem[i]!=i*2);
     }
     omp_target_free(mem_dev_cpy, t);

--- a/tests/5.1/target/test_target_memcpy_rect_async_depobj.c
+++ b/tests/5.1/target/test_target_memcpy_rect_async_depobj.c
@@ -1,7 +1,7 @@
-//===--- test_target_memcpy_async_depobj.c ----------------------------===//
+//===--- test_target_memcpy_rect_async_depobj.c ----------------------------===//
 //
 //  Inspired from OpenMP 5.1 Examples Doc, 5.16.4 & 8.9
-//  This test utilizes the omp_target_memcpy_async construct to
+//  This test utilizes the omp_target_memcpy_rect_async construct to
 //  allocate memory on the device asynchronously. The construct
 //  uses 'obj' for dependency, so that memory is only copied once
 //  the variable listed in the depend clause is changed.
@@ -14,57 +14,72 @@
 #include "ompvv.h"
 #include <math.h>
 
-#define N 1024
+#define N 5
 
-int errors, i;
+int errors, i, j;
 
 int test_target_memcpy_async_depobj() {
 
-    int h, t, i;
+    int h, t;
     errors = 0;
-    double *mem;
-    double *mem_dev_cpy;
+    double *devRect;
     h = omp_get_initial_device();
     t = omp_get_default_device();
 
+    double* hostRect[N];
+    for(i = 0; i < N; i++){
+        hostRect[i] = (double *)malloc( sizeof(double)*N); 
+    } // 5x5 2D array
+    devRect = (double *)omp_target_alloc( sizeof(double)*N, t);
+    for(i = 0; i < N; i++){
+        devRect[i] = (double *)omp_target_alloc( sizeof(double)*N, t);
+    }
 
-    mem = (double *)malloc( sizeof(double)*N);
-    mem_dev_cpy = (double *)omp_target_alloc( sizeof(double)*N, t);
-
-    OMPVV_TEST_AND_SET_VERBOSE(errors, mem_dev_cpy == NULL);
+    OMPVV_TEST_AND_SET_VERBOSE(errors, devRect == NULL);
 
     for(i = 0; i < N; i++){
-        mem[i] = i;
+        for (j = 0; j < N; j++){
+            hostRect[i][j] = i;
+        }
     }
     omp_depend_t obj;
-    #pragma omp depobj(obj) depend(inout: mem_dev_cpy)
+    #pragma omp depobj(obj) depend(inout: devRect)
     omp_depend_t obj_arr[1] = {obj};
 
     /* copy to device memory */
-    omp_target_memcpy_async(mem_dev_cpy, mem, sizeof(double)*N,
+    omp_target_memcpy_rect_async(devRect, hostRect, 
+                                32 /*number of bits??*/, 2, 5, //5 by 5
                                 0,          0,
+                                sizeof(double)*N*N, sizeof(double)*N*N,
                                 t,          h,
                                 1,          obj_arr);
 
     #pragma omp taskwait depend(depobj: obj)
-    #pragma omp target is_device_ptr(mem_dev_cpy) device(t) depend(depobj: obj)
+    #pragma omp target is_device_ptr(devRect) device(t) depend(depobj: obj)
     {
         for(i = 0; i < N; i++){
-            mem_dev_cpy[i] = mem_dev_cpy[i]*2; // initialize data
+            for (j = 0; j < N; j++){
+                devRect[i][j] = devRect[i][j]*2; // initialize data
+            }
         }
     }
+
     /* copy to host memory */
-    omp_target_memcpy_async(mem, mem_dev_cpy, sizeof(double)*N,
+    omp_target_memcpy_rect_async(hostRect, devRect,
+                                32, 2, 5
                                 0,          0,
+                                sizeof(double)*N*N, sizeof(double)*N*N,
                                 h,          t,
                                 1,          obj_arr);
 
     #pragma omp taskwait depend(depobj: obj)
     for(i = 0; i < N; i++){
-        OMPVV_TEST_AND_SET(errors, mem[i]!=i*2);
+        for(j = 0; j < N; j++){
+            OMPVV_TEST_AND_SET(errors, hostRect[i][j]!=i*2);
+        }
     }
     // free resources
-    omp_target_free(mem_dev_cpy, t);
+    omp_target_free(devRect, t);
     #pragma omp depobj(obj) destroy
     return errors;
 }

--- a/tests/5.1/target/test_target_memcpy_rect_async_no_obj.c
+++ b/tests/5.1/target/test_target_memcpy_rect_async_no_obj.c
@@ -1,0 +1,86 @@
+//===--- test_target_memcpy_rect_async_no_obj.c ----------------------------===//
+//
+//  Inspired from OpenMP 5.1 Examples Doc, 5.16.4 & 8.9
+//  This test utilizes the omp_target_memcpy_rect_async construct to
+//  allocate 2D memory on the device asynchronously. The construct
+//  uses '0' for 'depobj_count', so that the clause is not dependent
+//  and memory is therefore copied synchronously.
+//
+////===----------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+#include <math.h>
+
+#define N 5
+#define M 10
+
+int errors, i, j;
+
+int test_target_memcpy_async_depobj() {
+
+    const size_t volume[2] = {5, 10};
+    const size_t offsets[2] = {0, 0};
+    const size_t dimensions[2] = {N, M};
+
+    int h, t;
+    errors = 0;
+    h = omp_get_initial_device();
+    t = omp_get_default_device();
+
+    double hostRect[N][M]; // 5x10 2D array
+    double *devRect = (double *)omp_target_alloc(sizeof(double)*N*M, t);
+
+    OMPVV_TEST_AND_SET_VERBOSE(errors, devRect == NULL);
+
+    for(i = 0; i < N; i++){             //each index is set to number of their row
+        for (j = 0; j < M; j++){
+            hostRect[i][j] = i + j;
+        }
+    }
+
+    /* copy to device memory */
+    omp_target_memcpy_rect_async(devRect, hostRect, 
+                                sizeof(double), 2, 
+                                volume, //5 by 10
+                                offsets,    offsets,
+                                dimensions, dimensions,
+                                t,          h,
+                                0,          NULL);  // no dependent objects, 'depobj_list' i.e. NULL is ignored
+
+    #pragma omp target is_device_ptr(devRect) device(t)
+    {
+        for(i = 0; i < N; i++){
+            for (j = 0; j < M; j++){
+                devRect[i*M + j] = devRect[i*M + j]*2; // initialize data
+            }
+        }
+    }
+
+    /* copy to host memory */
+    omp_target_memcpy_rect_async(hostRect, devRect,
+                                sizeof(double), 2,
+                                volume, //5 by 10
+                                offsets,          offsets,
+                                dimensions, dimensions,
+                                h,          t,
+                                0,          NULL);
+
+    for(i = 0; i < N; i++){
+        for(j = 0; j < N; j++){
+            OMPVV_TEST_AND_SET(errors, hostRect[i][j]!=(i+j)*2);
+        }
+    }
+    // free resources
+    omp_target_free(devRect, t);
+    return errors;
+}
+
+int main() {
+   errors = 0;
+   OMPVV_TEST_OFFLOADING;
+   OMPVV_TEST_AND_SET_VERBOSE(errors, test_target_memcpy_async_depobj() != 0);
+   OMPVV_REPORT_AND_RETURN(errors);
+}


### PR DESCRIPTION
https://www.openmp.org/wp-content/uploads/OpenMP-API-Specification-5-1.pdf#page=446

Unsure if my 2D arrays are allocated properly, and also unsure of what the "dst/src_dimensions" should be, as well as what volume should be. If it was a 3x5 array, then what would volume be? Seems it could only work for squres. 