### PR TITLE
Fix 5.1/target/test_target_is_accessible.c

### DIFF
--- a/tests/5.1/target/test_target_is_accessible.c
+++ b/tests/5.1/target/test_target_is_accessible.c
@@ -4,8 +4,8 @@
 //
 // This test checks that the omp_target_is_accessible device routine.
 // In this test the output of the target_is_accessible call should return
-// true because the storage indicated by the first and second arguements
-// is accessible by the targeted device. This test is closely adapdted
+// true because the storage indicated by the first and second arguments
+// is accessible by the targeted device. This test is closely adapted
 // from the 5.1 OpenMP example sheet.
 //-----------------------------------------------------------------------//
 
@@ -22,13 +22,13 @@ int check_device(){
 	const int buf_size = sizeof(int) * N;
 	const int dev = omp_get_default_device();
 
-	int *ptr = (int *) malloc(buf_size);
+	int *ptr = (int *) omp_target_malloc(buf_size, dev);
 
 	check_test = omp_target_is_accessible(ptr, buf_size, dev);
 	
-	free(ptr);
+	omp_target_free(omp_ptr, dev);
 	OMPVV_TEST_AND_SET_VERBOSE(errors, check_test != 1);
-	OMPVV_INFOMSG_IF(check_test == 0, "Omp_target_is_accessible is 0");
+	OMPVV_INFOMSG_IF(check_test == 0, "omp_target_is_accessible is 0");
 	OMPVV_ERROR_IF(check_test == 2, "omp_target_is_accessible did not return true or false");
 	return errors;
 }


### PR DESCRIPTION
* tests/5.1/target/test_target_is_accessible.c: Use omp_target_malloc instead of malloc to make it work also on systems that do not share memory between host and device.

While the testcase is based on the OpenMP example, the latter uses the following to make it work with both (unified) shared memory and unshared memory:
```C
#pragma omp metadirective \
            when(user={condition(accessible)}: target firstprivate(ptr) ) \
            otherwise( target map(ptr[:n]) )
```

@spophale @tmh97 @seyonglee @nolanbaker31 @jrreap @mjcarr458 – please review.