### PR TITLE
Issue 464: Avoid con't line issue in test_target_mapping_before_alloc.F90

### DIFF
--- a/tests/5.0/target/test_target_mapping_before_alloc.F90
+++ b/tests/5.0/target/test_target_mapping_before_alloc.F90
@@ -49,8 +49,7 @@ CONTAINS
 
     !$omp target map(alloc: scalar, a, test_struct) map(to: scalar, a, &
     !$omp& test_struct) map(tofrom: errors)
-    OMPVV_TEST_AND_SET_VERBOSE(errors, scalar .ne. 80 .OR. a(2) .ne. 2 .OR. test_struct%var .ne. 1 &
-         & .OR. test_struct%b(2) .ne. 2)
+    OMPVV_TEST_AND_SET_VERBOSE(errors, scalar .ne. 80 .OR. a(2) .ne. 2 .OR. test_struct%var .ne. 1 .OR. test_struct%b(2) .ne. 2)
     !$omp end target
 
     to_before_alloc = errors


### PR DESCRIPTION
Issue #464 

When expanding macros with the C preprocessor, linebreaks are removed. This causes for test_target_mapping_before_alloc.F90 a problem with a '&' (linebreak) '&' continuation, which then ends up being mid line, which is invalid Fortran.

As solution, the line break has been removed. This creates an overlong but Fortran compilers have an option to accept this. (F202x will permit longer than 132-characters free-source-form lines by default.) This solution is in line with the similar issue, fixed in Pull Req. 377 / commit 3586e45.

* tests/5.0/target/test_target_mapping_before_alloc.F90: Make the OMPVV_TEST_AND_SET_VERBOSE argument a single line and remove '&' continuation-line markers.

@spophale @tmh97 @seyonglee @nolanbaker31 @jrreap @mjcarr458 – please review.

***

Without, it fails with GCC/gfortran as:
```
   52 |     OMPVV_TEST_AND_SET_VERBOSE(errors, scalar .ne. 80 .OR. a(2) .ne. 2 .OR. test_struct%var .ne. 1 &
      |                                                                                                        1
Error: Syntax error in argument list at (1)
```
as the compiler sees the following input (cf. `cpp -I ompvv ...` or `gfortran -E ...`):
```F90
    errors = errors + test_and_set_verbose( scalar .ne. 80 .OR. a(2) .ne. 2 .OR. test_struct%var .ne. 1 &          & .OR. test_struct%b(2) .ne. 2, " scalar .ne. 80 .OR. a(2) .ne. 2 .OR. test_struct%var .ne. 1 &          & .OR. test_struct%b(2) .ne. 2", "tests/5.0/target/test_target_mapping_before_alloc.F90", 53)
```
and then chokes because of the mid-line:
```F90
... &          & ...
```