### PR TITLE
Issue 571: Fix race in 5.1/masked/test_masked

### DIFF
--- a/tests/5.1/masked/test_masked.F90
+++ b/tests/5.1/masked/test_masked.F90
@@ -26,16 +26,21 @@ CONTAINS
     INTEGER:: errors = 0
     INTEGER:: total = 10
     INTEGER:: ct = 0
-    INTEGER:: threads
+    INTEGER:: threads, tot
 
     OMPVV_INFOMSG("test_masked")
     threads = OMPVV_NUM_THREADS_HOST
 
     !$omp parallel num_threads(threads)
-    DO WHILE (total>0)
+    DO WHILE (.true.)
+      !$omp atomic read
+      tot = total
+      if (tot <= 0) &
+        exit
       !$omp masked
         OMPVV_TEST_AND_SET_VERBOSE(errors, omp_get_thread_num() .ne. 0) ! primary thread
         ct = ct + 1
+        !omp atomic
         total = total - 1
       !$omp end masked
     END DO

--- a/tests/5.1/masked/test_masked.c
+++ b/tests/5.1/masked/test_masked.c
@@ -22,11 +22,17 @@ int test_masked() {
   int threads = OMPVV_NUM_THREADS_HOST;
 
 #pragma omp parallel num_threads(threads)
-while(total > 0){
+while(1){
+  int tot;
+  #pragma omp atomic read
+  tot = total;
+  if (tot <= 0)
+    break;
   #pragma omp masked
   {
     OMPVV_TEST_AND_SET_VERBOSE(errors, omp_get_thread_num() != 0); // primary thread
     ct++;
+    #pragma omp atomic
     total = total-1;
   }
 }

--- a/tests/5.1/masked/test_masked_filter.F90
+++ b/tests/5.1/masked/test_masked_filter.F90
@@ -26,16 +26,20 @@ CONTAINS
     INTEGER:: errors = 0
     INTEGER:: total = 10
     INTEGER:: ct = 0
-    INTEGER:: threads
+    INTEGER:: threads, tot
 
     OMPVV_INFOMSG("test_masked")
     threads = OMPVV_NUM_THREADS_HOST
-
-    !$omp parallel num_threads(threads)
-    DO WHILE (total>0)
+    !$omp parallel num_threads(threads) private(tot)
+    DO WHILE (.true.)
+      !$omp atomic read
+      tot = total
+      if (tot <= 0) &
+        exit
       !$omp masked filter(3)
         OMPVV_TEST_AND_SET_VERBOSE(errors, omp_get_thread_num() .ne. 3) ! primary thread
         ct = ct + 1
+        !omp atomic
         total = total - 1
       !$omp end masked
     END DO

--- a/tests/5.1/masked/test_masked_filter.c
+++ b/tests/5.1/masked/test_masked_filter.c
@@ -22,11 +22,17 @@ int test_masked_filter() {
   int threads = OMPVV_NUM_THREADS_HOST;
 
 #pragma omp parallel num_threads(threads)
-while(total > 0){
+while(1){
+  int tot;
+  #pragma omp atomic read
+  tot = total;
+  if (tot <= 0)
+    break;
   #pragma omp masked filter(3)
   {
     OMPVV_TEST_AND_SET_VERBOSE(errors, omp_get_thread_num() != 3); // filter thread 3
     ct++;
+    #pragma omp atomic
     total = total-1;
   }
 }


### PR DESCRIPTION
Issue #571

This was a data race; 'total' var is shared: 'total' is decremented inside of the masked region (i.e. by one thread) but tested by all threads – before this commit – without any kind of synchronization in between.

Solution: read and decrement 'total' atomically.

* tests/5.1/masked/test_masked.F90: Atomically read/decrement 'total'.
* tests/5.1/masked/test_masked.c: Likewise.
* tests/5.1/masked/test_masked_filter.F90: Likewise.
* tests/5.1/masked/test_masked_filter.c: Likewise.

@spophale @tmh97 @seyonglee @nolanbaker31 @jrreap @mjcarr458 – please review.