### PR TITLE
Added order unconstrained clause on parallel loop test

### DIFF
--- a/tests/5.1/order/test_loop_order_unconstrained.c
+++ b/tests/5.1/order/test_loop_order_unconstrained.c
@@ -1,0 +1,42 @@
+//===------------ test_loop_for_order_unconstrained.c -----------------------===//
+//
+// OpenMP API Version 5.1 Nov 2020
+//
+// This test checks that the order(unconstrained:concurrent) clause is 
+// properly handled. Since with unconstrained the values can be executed in any
+// order this test simply checks that the correct values have been calculated
+// for the array. In other words, that all iterations finish regardless of order.
+//
+////===----------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+int main() {
+	int errors = 0;
+	int x[N];
+
+	for (int i = 0; i < N; i++) {
+		x[i] = i;
+	}
+
+	OMPVV_TEST_OFFLOADING;
+
+	#pragma omp target map(tofrom: x)
+	{
+		#pragma omp parallel loop order(unconstrained:concurrent) 
+		for (int i = 0; i < N; i++) {
+			x[i] = x[i] + 2;	
+		}
+	}
+
+	for (int i = 0; i < N; i++) {
+    		OMPVV_TEST_AND_SET(errors, x[i] != i + 2);
+	}
+
+	OMPVV_REPORT_AND_RETURN(errors);
+}


### PR DESCRIPTION
Currently not implemented in LLVM. Not sure if GCC supports this yet either