### PR TITLE
Add new_test/test_requires_unified_shared_memory_stack_is_device_ptr.F90

### DIFF
--- a/tests/5.0/requires/test_requires_unified_shared_memory_stack_is_device_ptr.F90
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_stack_is_device_ptr.F90
@@ -1,0 +1,83 @@
+!===--- test_requires_unified_shared_memory_stack_is_device_ptr.F90 --------------------------===//
+!
+! OpenMP API Version 5.0 Nov 2018
+!
+! Testing memory access from host and device to a variable allocated in the stack
+! The variable is accessed through a pointer to guarantee that there is no default
+! mapping tofrom: of the stack array
+!
+! We use the is_device_ptr to guarantee using the host pointer is used in the device
+!
+!===------------------------------------------------------------------------------===//
+
+#define OMPVV_MODULE_REQUIRES_LINE !$omp requires unified_shared_memory
+#include "ompvv.F90"
+
+#define N 1024
+
+PROGRAM test_requires_unified_shared_memory_stack_is_device_ptr
+   USE iso_fortran_env
+   USE ompvv_lib
+   USE omp_lib
+   implicit none
+   LOGICAL:: isOffloading
+
+!$omp requires unified_shared_memory
+
+  OMPVV_TEST_AND_SET_OFFLOADING(isOffloading)
+
+  OMPVV_WARNING_IF(.NOT. isOffloading, "With no offloading, unified shared memory is guaranteed due to host execution")
+
+  OMPVV_TEST_VERBOSE(unified_shared_memory_stack_is_device_ptr() .NE. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION unified_shared_memory_stack_is_device_ptr()
+    INTEGER:: errors, i
+    INTEGER, TARGET, DIMENSION(N):: anArray
+    INTEGER, DIMENSION(N):: anArrayCopy
+    INTEGER, POINTER:: aPtr(:)
+
+    OMPVV_INFOMSG("Unified shared memory testing - Array on stack")
+
+    errors = 0
+    aPtr => anArray
+
+    DO i = 1, N
+      anArray(i) = i
+      anArrayCopy(i) = 0
+    END DO
+
+    ! Test for writes to this varriable from device
+    !$omp target is_device_ptr(aPtr)
+    DO i = 1, N
+      aPtr(i) = aPtr(i) + 10
+    END DO
+    !$omp end target
+
+    ! Modify again on the host
+    DO i = 1, N
+      aPtr(i) = aPtr(i) + 10
+    END DO
+
+    ! Test for reads to this variable from device
+    !$omp target is_device_ptr(aPtr)
+    DO i = 1, N
+      anArrayCopy(i) = aPtr(i)
+    END DO
+    !$omp end target
+
+    DO i = 1, N
+      OMPVV_TEST_AND_SET_VERBOSE(errors, anArray(i) .NE. (i + 20))
+      OMPVV_TEST_AND_SET_VERBOSE(errors, anArrayCopy(i) .NE. (i + 20))
+      IF (errors .NE. 0) THEN
+        exit
+      END IF
+    END DO
+    
+    unified_shared_memory_stack_is_device_ptr = errors
+  END FUNCTION unified_shared_memory_stack_is_device_ptr
+END PROGRAM test_requires_unified_shared_memory_stack_is_device_ptr
+      
+   

--- a/tests/5.0/requires/test_requires_unified_shared_memory_stack_is_device_ptr.c
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_stack_is_device_ptr.c
@@ -18,7 +18,7 @@
 
 #pragma omp requires unified_shared_memory
 
-int unified_shared_memory_stack() {
+int unified_shared_memory_stack_is_device_ptr() {
   OMPVV_INFOMSG("Unified shared memory testing - Array on stack");
   int errors = 0;
   
@@ -63,7 +63,7 @@ int main() {
   OMPVV_TEST_AND_SET_OFFLOADING(isOffloading);
   OMPVV_WARNING_IF(!isOffloading, "With no offloading, unified shared memory is guaranteed due to host execution");
   int errors = 0;
-  OMPVV_TEST_AND_SET_VERBOSE(errors, unified_shared_memory_stack());
+  OMPVV_TEST_AND_SET_VERBOSE(errors, unified_shared_memory_stack_is_device_ptr());
 
   OMPVV_REPORT_AND_RETURN(errors);
 }


### PR DESCRIPTION
        - C test passed with NVHPC 22.5
        - C test passed with LLVM 15.0.0-latest
        - C test failed with GCC 11.2.0
        - C test passed with XL 16.1.1-10 but on the host
        - Fortran test passed with NVHPC 22.5
        - Fortran test failed with GCC 11.2.0
        - Fortran test failed with XL 16.1.1-10