### PR TITLE
New test/test requires unified shared memory static.f90

### DIFF
--- a/tests/5.0/requires/test_requires_unified_shared_memory_static.F90
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_static.F90
@@ -41,7 +41,7 @@ CONTAINS
     INTEGER, DIMENSION(N):: anArrayCopy
     INTEGER, POINTER:: aPtr(:)
 
-    OMPVV_INFOMSG("Unified shared memory testing - Array on stack")
+    OMPVV_INFOMSG("Unified shared memory testing - Static Array")
 
     errors = 0
     aPtr => anArray

--- a/tests/5.0/requires/test_requires_unified_shared_memory_static.F90
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_static.F90
@@ -1,0 +1,85 @@
+!===--- test_requires_unified_shared_memory_static.F90 --------------------------===//
+!
+! OpenMP API Version 5.0 Nov 2018
+!
+! We request the use of unified_shared_memory in this program.
+! Checking for static arrays. The array is global and then accessed through 
+! a pointer from the host and the device.
+!
+! We use default mapping of the pointer, which should result in mapping of a zero
+! lenght array.
+!
+!===------------------------------------------------------------------------------===//
+
+#define OMPVV_MODULE_REQUIRES_LINE !$omp requires unified_shared_memory
+#include "ompvv.F90"
+
+#define N 1024
+
+PROGRAM test_requires_unified_shared_memory_static
+   USE iso_fortran_env
+   USE ompvv_lib
+   USE omp_lib
+   implicit none
+   LOGICAL:: isOffloading
+   ! STATIC ARRAY
+   INTEGER, TARGET, DIMENSION(N):: anArray
+
+!$omp requires unified_shared_memory
+
+  OMPVV_TEST_AND_SET_OFFLOADING(isOffloading)
+
+  OMPVV_WARNING_IF(.NOT. isOffloading, "With no offloading, unified shared memory is guaranteed due to host execution")
+
+  OMPVV_TEST_VERBOSE(unified_shared_memory_static() .NE. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION unified_shared_memory_static()
+    INTEGER:: errors, i
+    INTEGER, DIMENSION(N):: anArrayCopy
+    INTEGER, POINTER:: aPtr(:)
+
+    OMPVV_INFOMSG("Unified shared memory testing - Array on stack")
+
+    errors = 0
+    aPtr => anArray
+
+    DO i = 1, N
+      anArray(i) = i
+      anArrayCopy(i) = 0
+    END DO
+
+    ! Test for writes to this varriable from device
+    !$omp target 
+    DO i = 1, N
+      aPtr(i) = aPtr(i) + 10
+    END DO
+    !$omp end target
+
+    ! Modify again on the host
+    DO i = 1, N
+      aPtr(i) = aPtr(i) + 10
+    END DO
+
+    ! Test for reads to this variable from device
+    !$omp target 
+    DO i = 1, N
+      anArrayCopy(i) = aPtr(i)
+    END DO
+    !$omp end target
+
+    DO i = 1, N
+      OMPVV_TEST_AND_SET_VERBOSE(errors, anArray(i) .NE. (i + 20))
+      OMPVV_TEST_AND_SET_VERBOSE(errors, anArrayCopy(i) .NE. (i + 20))
+      IF (errors .NE. 0) THEN
+        exit
+      END IF
+    END DO
+    
+    unified_shared_memory_static = errors
+  END FUNCTION unified_shared_memory_static
+END PROGRAM test_requires_unified_shared_memory_static
+      
+   

--- a/tests/5.0/requires/test_requires_unified_shared_memory_static.c
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_static.c
@@ -2,12 +2,12 @@
 //
 // OpenMP API Version 5.0 Nov 2018
 //
-// We request the use of unified_shared_memory in this proogram.
+// We request the use of unified_shared_memory in this program.
 // Checking for static arrays. The array is global and then accessed through 
 // a pointer from the host and the device.
 //
 // We use default mapping of the pointer, which should result in mapping of a zero
-// lenght array
+// lenght array.
 //
 ////===----------------------------------------------------------------------===//
 #include <omp.h>


### PR DESCRIPTION
        - C test passed with XL 16.1.1-10 but on the host
        - C test failed with NVHPC 21.11 and 22.5 ("internal error: add_statement_list: struct_stmt_stack is empty")
        - C test passed with LLVM 15.0.0-latest
        - C test failed with GCC 11.2.0
        - Fortran test failed with XL 16.1.1-10
        - Fortran test passed with NVHPC 21.11 and 22.5
        - Fortran test failed with GCC 11.2.0