### PR TITLE
Add new_test/test_requires_unified_shared_memory_static_is_device_ptr.F90

### DIFF
--- a/tests/5.0/requires/test_requires_unified_shared_memory_static_is_device_ptr.F90
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_static_is_device_ptr.F90
@@ -61,7 +61,7 @@ CONTAINS
   END SUBROUTINE test_is_device_ptr
 
   INTEGER FUNCTION unified_shared_memory_static_is_device_ptr()
-    INTEGER:: errors, i, ERR
+    INTEGER:: errors, i
     INTEGER, DIMENSION(N):: anArrayCopy
 
     OMPVV_INFOMSG("Unified shared memory testing - Static Array")

--- a/tests/5.0/requires/test_requires_unified_shared_memory_static_is_device_ptr.F90
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_static_is_device_ptr.F90
@@ -1,0 +1,84 @@
+!===--- test_requires_unified_shared_memory_static_is_device_ptr.F90 --------------===//
+!
+! OpenMP API Version 5.0 Nov 2018
+!
+! We request the use of unified_shared_memory in this program.
+! Checking for static arrays. The array is global and then accessed through 
+! a pointer from the host and the device.
+!
+! We use is_device_ptr to guarantee that the host pointer is used in the device.
+!
+!===------------------------------------------------------------------------------===//
+
+#define OMPVV_MODULE_REQUIRES_LINE !$omp requires unified_shared_memory
+#include "ompvv.F90"
+
+#define N 1024
+
+PROGRAM test_requires_unified_shared_memory_static_is_device_ptr
+   USE iso_fortran_env
+   USE ompvv_lib
+   USE omp_lib
+   implicit none
+   LOGICAL:: isOffloading
+   ! STATIC ARRAY
+   INTEGER, TARGET, DIMENSION(N):: anArray
+
+!$omp requires unified_shared_memory
+
+  OMPVV_TEST_AND_SET_OFFLOADING(isOffloading)
+
+  OMPVV_WARNING_IF(.NOT. isOffloading, "With no offloading, unified shared memory is guaranteed due to host execution")
+
+  OMPVV_TEST_VERBOSE(unified_shared_memory_static_is_device_ptr() .NE. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION unified_shared_memory_static_is_device_ptr()
+    INTEGER:: errors, i
+    INTEGER, DIMENSION(N):: anArrayCopy
+    INTEGER, POINTER:: aPtr(:)
+
+    OMPVV_INFOMSG("Unified shared memory testing - Static Array")
+
+    errors = 0
+    aPtr => anArray
+
+    DO i = 1, N
+      anArray(i) = i
+      anArrayCopy(i) = 0
+    END DO
+
+    ! Test for writes to this varriable from device
+    !$omp target is_device_ptr(aPtr) 
+    DO i = 1, N
+      aPtr(i) = aPtr(i) + 10
+    END DO
+    !$omp end target
+
+    ! Modify again on the host
+    DO i = 1, N
+      aPtr(i) = aPtr(i) + 10
+    END DO
+
+    ! Test for reads to this variable from device
+    !$omp target is_device_ptr(aPtr)
+    DO i = 1, N
+      anArrayCopy(i) = aPtr(i)
+    END DO
+    !$omp end target
+
+    DO i = 1, N
+      OMPVV_TEST_AND_SET_VERBOSE(errors, anArray(i) .NE. (i + 20))
+      OMPVV_TEST_AND_SET_VERBOSE(errors, anArrayCopy(i) .NE. (i + 20))
+      IF (errors .NE. 0) THEN
+        exit
+      END IF
+    END DO
+    
+    unified_shared_memory_static_is_device_ptr = errors
+  END FUNCTION unified_shared_memory_static_is_device_ptr
+END PROGRAM test_requires_unified_shared_memory_static_is_device_ptr
+      
+   

--- a/tests/5.0/requires/test_requires_unified_shared_memory_static_is_device_ptr.F90
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_static_is_device_ptr.F90
@@ -35,39 +35,45 @@ PROGRAM test_requires_unified_shared_memory_static_is_device_ptr
   OMPVV_REPORT_AND_RETURN()
 
 CONTAINS
+  SUBROUTINE test_is_device_ptr(anArrayDummy, anArrayCopyDummy)
+    INTEGER, DIMENSION(N):: anArrayDummy
+    INTEGER, DIMENSION(N):: anArrayCopyDummy
+    INTEGER:: i
+
+    ! Modify in the device
+    !$omp target is_device_ptr(anArrayDummy)
+    DO i = 1, N
+      anArrayDummy(i) = anArrayDummy(i) + 10
+    END DO
+    !$omp end target
+
+    ! Modify again on the host
+    DO i = 1, N
+      anArrayDummy(i) = anArrayDummy(i) + 10
+    END DO
+
+    ! Get the value the device is seeing
+    !$omp target is_device_ptr(anArrayDummy)
+    DO i = 1, N
+      anArrayCopyDummy(i) = anArrayDummy(i)
+    END DO
+    !$omp end target
+  END SUBROUTINE test_is_device_ptr
+
   INTEGER FUNCTION unified_shared_memory_static_is_device_ptr()
-    INTEGER:: errors, i
+    INTEGER:: errors, i, ERR
     INTEGER, DIMENSION(N):: anArrayCopy
-    INTEGER, POINTER:: aPtr(:)
 
     OMPVV_INFOMSG("Unified shared memory testing - Static Array")
 
     errors = 0
-    aPtr => anArray
 
     DO i = 1, N
       anArray(i) = i
       anArrayCopy(i) = 0
     END DO
 
-    ! Test for writes to this varriable from device
-    !$omp target is_device_ptr(aPtr) 
-    DO i = 1, N
-      aPtr(i) = aPtr(i) + 10
-    END DO
-    !$omp end target
-
-    ! Modify again on the host
-    DO i = 1, N
-      aPtr(i) = aPtr(i) + 10
-    END DO
-
-    ! Test for reads to this variable from device
-    !$omp target is_device_ptr(aPtr)
-    DO i = 1, N
-      anArrayCopy(i) = aPtr(i)
-    END DO
-    !$omp end target
+    CALL test_is_device_ptr(anArray, anArrayCopy)
 
     DO i = 1, N
       OMPVV_TEST_AND_SET_VERBOSE(errors, anArray(i) .NE. (i + 20))

--- a/tests/5.0/requires/test_requires_unified_shared_memory_static_is_device_ptr.c
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_static_is_device_ptr.c
@@ -2,11 +2,11 @@
 //
 // OpenMP API Version 5.0 Nov 2018
 //
-// We request the use of unified_shared_memory in this proogram.
+// We request the use of unified_shared_memory in this program.
 // Checking for static arrays. The array is global and then accessed through 
 // a pointer from the host and the device.
 //
-// We use is_device_ptr to guarantee that the host pointer is used in the device
+// We use is_device_ptr to guarantee that the host pointer is used in the device.
 //
 ////===----------------------------------------------------------------------===//
 #include <omp.h>
@@ -21,7 +21,7 @@
 // STATIC ARRAY 
 int anArray[N];
 
-int unified_shared_memory_static() {
+int unified_shared_memory_static_is_device_ptr() {
   OMPVV_INFOMSG("Unified shared memory testing - Static Array");
   int errors = 0;
   
@@ -65,7 +65,7 @@ int main() {
   OMPVV_TEST_AND_SET_OFFLOADING(isOffloading);
   OMPVV_WARNING_IF(!isOffloading, "With no offloading, unified shared memory is guaranteed due to host execution");
   int errors = 0;
-  OMPVV_TEST_AND_SET_VERBOSE(errors, unified_shared_memory_static());
+  OMPVV_TEST_AND_SET_VERBOSE(errors, unified_shared_memory_static_is_device_ptr());
 
   OMPVV_REPORT_AND_RETURN(errors);
 }


### PR DESCRIPTION


        - C test passed with LLVM 15.0.0-latest
        - C test failed with GCC 11.2.0
        - C test passed with XL 16.1.1-10 but on the host
        - C test failed with NVHPC 22.5 ("internal error: add_statement_list: struct_stmt_stack is empty")
        - Fortran test failed with GCC 11.2.0
        - Fortran test failed with XL 16.1.1-10
        - Fortran test passed with NVHPC 22.5