### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -486,6 +486,8 @@ tidy: clean
 	- rm -rf $(RESULTS_JSON_OUTPUT_FILE)
 	- rm -rf $(RESULTS_CSV_OUTPUT_FILE)
 	- rm -rf ./*.exitstatus*
+	- rm -rf *.mod
+	- rm -rf slurm-*
 
 .PHONY: compilers
 compilers:


### PR DESCRIPTION
Often .mod files don't go in the "ompvv" directory. Quick fix to remove these w/ make tidy.

Also, using a slurm bash script creates a slurm-(numbers) file, so adding this to delete these as well.