### PR TITLE
Dispatch w/ novariants, nowait, nocontext & is_device_ptr clauses

### DIFF
--- a/tests/5.1/dispatch/test_dispatch_is_device_ptr.c
+++ b/tests/5.1/dispatch/test_dispatch_is_device_ptr.c
@@ -34,7 +34,7 @@ void add(int *arr){
 }
 
 void add_dev(int *arr){
-    #pragma omp target
+    #pragma omp target is_device_ptr(arr)
     for (int i = 0; i < N; i++){
         arr[i] = arr[i]+4; // Variant function adds 4 to array values
     }

--- a/tests/5.1/dispatch/test_dispatch_is_device_ptr.c
+++ b/tests/5.1/dispatch/test_dispatch_is_device_ptr.c
@@ -63,7 +63,6 @@ int test_wrapper() {
     for(i = 0; i < N; i++){
         OMPVV_TEST_AND_SET(errors, (arr[i] != i+4) && (arr[i] != i+2) );
     }
-    OMPVV_ERROR_IF(errors > 0, "Dispatch w/ novariants true is not working properly");
     OMPVV_INFOMSG_IF(errors > 0 || arr[0] == 2,
                    "Dispatch is either not working or was not considered"
                    " by the implementation as part of the context selector.");

--- a/tests/5.1/dispatch/test_dispatch_is_device_ptr.c
+++ b/tests/5.1/dispatch/test_dispatch_is_device_ptr.c
@@ -55,7 +55,7 @@ int test_wrapper() {
     #pragma omp dispatch is_device_ptr(arr)
         add(arr);
     
-    #pragma omp target
+    #pragma omp target map(tofrom: errors)
     for(i = 0; i < N; i++){
         OMPVV_TEST_AND_SET_VERBOSE(errors, arr[i] != i+4);
         if(i == 5) {

--- a/tests/5.1/dispatch/test_dispatch_is_device_ptr.c
+++ b/tests/5.1/dispatch/test_dispatch_is_device_ptr.c
@@ -25,10 +25,10 @@ int *arr;
 
 void add_dev(int *arr);
 
-#pragma omp declare variant(add_two) match(construct={dispatch}) // NOTE: necessary? append_params(interop: use_device_ptr)
+#pragma omp declare variant(add_dev) match(construct={dispatch}) 
 void add(int *arr){
     #pragma omp for
-    for (int i = 0; i < N; i++){ // Base function adds 1 to array values
+    for (int i = 0; i < N; i++){ // Base function adds 2 to array values
         arr[i] = arr[i]+2;
     }
 }
@@ -36,7 +36,7 @@ void add(int *arr){
 void add_dev(int *arr){
     #pragma omp target
     for (int i = 0; i < N; i++){
-        arr[i] = arr[i]+4; // Variant function adds 2 to array values
+        arr[i] = arr[i]+4; // Variant function adds 4 to array values
     }
 }
 
@@ -57,7 +57,7 @@ int test_wrapper() {
     
     #pragma omp target
     for(i = 0; i < N; i++){
-        OMPVV_TEST_AND_SET_VERBOSE(errors, arr[i] != i+1);
+        OMPVV_TEST_AND_SET_VERBOSE(errors, arr[i] != i+4);
         if(i == 5) {
             OMPVV_ERROR_IF(arr[i] == 5, "No function called or error in mapping");
             OMPVV_ERROR_IF(arr[i] == 7, "Non-target function was called");

--- a/tests/5.1/dispatch/test_dispatch_is_device_ptr.c
+++ b/tests/5.1/dispatch/test_dispatch_is_device_ptr.c
@@ -27,7 +27,7 @@ void add_dev(int *arr);
 
 #pragma omp declare variant(add_dev) match(construct={dispatch}) 
 void add(int *arr){
-    #pragma omp for
+    #pragma omp parallel for
     for (int i = 0; i < N; i++){ // Base function adds 2 to array values
         arr[i] = arr[i]+2;
     }
@@ -47,7 +47,7 @@ int test_wrapper() {
     arr = (int *)omp_target_alloc( sizeof(int)*N, t);
     #pragma omp target
     {
-        #pragma omp for
+        #pragma omp parallel for
         for(int i = 0; i < N; i++){
             arr[i] = i;
         }

--- a/tests/5.1/dispatch/test_dispatch_is_device_ptr.c
+++ b/tests/5.1/dispatch/test_dispatch_is_device_ptr.c
@@ -1,0 +1,74 @@
+//===---- test_dispatch_is_device_ptr.c -----------------------------------------===//
+// 
+// OpenMP API Version 5.1
+//
+// Uses dispatch construct as context for variant directive. Uses is_device_ptr
+// clause to ensure that the list item is in the device region.
+//
+// Inspired by "OpenMP 5.1 Features: The Dispatch Construct" video:
+// https://www.youtube.com/watch?v=ruugaX95gIs
+// 
+//===-------------------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include "ompvv.h"
+#include <stdbool.h>
+
+#define N 1024
+
+int errors;
+int i = 0;
+int *arr;
+
+void add_dev(int *arr);
+
+#pragma omp declare variant(add_two) match(construct={dispatch}) // NOTE: necessary? append_params(interop: use_device_ptr)
+void add(int *arr){
+    #pragma omp for
+    for (int i = 0; i < N; i++){ // Base function adds 1 to array values
+        arr[i] = arr[i]+2;
+    }
+}
+
+void add_dev(int *arr){
+    #pragma omp target
+    for (int i = 0; i < N; i++){
+        arr[i] = arr[i]+4; // Variant function adds 2 to array values
+    }
+}
+
+int test_wrapper() { 
+    int t;
+    errors = 0;
+    t = omp_get_default_device();
+    arr = (int *)omp_target_alloc( sizeof(int)*N, t);
+    #pragma omp target
+    {
+        #pragma omp for
+        for(int i = 0; i < N; i++){
+            arr[i] = i;
+        }
+    }
+    #pragma omp dispatch is_device_ptr(arr)
+        add(arr);
+    
+    #pragma omp target
+    for(i = 0; i < N; i++){
+        OMPVV_TEST_AND_SET_VERBOSE(errors, arr[i] != i+1);
+        if(i == 5) {
+            OMPVV_ERROR_IF(arr[i] == 5, "No function called or error in mapping");
+            OMPVV_ERROR_IF(arr[i] == 7, "Non-target function was called");
+        }
+    }
+    OMPVV_ERROR_IF(errors > 0, "Dispatch w/ novariants true is not working properly");
+    return errors;
+}
+
+int main () {
+   OMPVV_TEST_OFFLOADING;
+   OMPVV_TEST_AND_SET_VERBOSE(errors, test_wrapper());
+   OMPVV_REPORT_AND_RETURN(errors);
+}  

--- a/tests/5.1/dispatch/test_dispatch_is_device_ptr.c
+++ b/tests/5.1/dispatch/test_dispatch_is_device_ptr.c
@@ -57,7 +57,7 @@ int test_wrapper() {
     
     #pragma omp target map(tofrom: errors)
     for(i = 0; i < N; i++){
-        OMPVV_TEST_AND_SET_VERBOSE(errors, arr[i] != i+4);
+        OMPVV_TEST_AND_SET(errors, arr[i] != i+4);
         if(i == 5) {
             OMPVV_ERROR_IF(arr[i] == 5, "No function called or error in mapping");
             OMPVV_ERROR_IF(arr[i] == 7, "Non-target function was called");

--- a/tests/5.1/dispatch/test_dispatch_nocontext.c
+++ b/tests/5.1/dispatch/test_dispatch_nocontext.c
@@ -41,29 +41,29 @@ void add_two(int *arr){
 
 int test_wrapper() { 
    errors = 0;
-   bool use_context;
+   bool nocontext_arg;
    add(arr);
    for(i = 0; i < N; i++){
       OMPVV_TEST_AND_SET_VERBOSE(errors, arr[i] != i+1);
    } 
    OMPVV_ERROR_IF(errors > 0, "Base function is not working properly");
-   use_context = true;
-   #pragma omp dispatch nocontext(use_context)
+   nocontext_arg = true;
+   #pragma omp dispatch nocontext(nocontext_arg)
       add(arr);
    
    for(i = 0; i < N; i++){
       OMPVV_TEST_AND_SET_VERBOSE(errors, arr[i] != i+1);
    }
-   OMPVV_ERROR_IF(errors > 0, "Dispatch w/ novariants true is not working properly");
+   OMPVV_ERROR_IF(errors > 0, "Dispatch w/ nocontext true is not working properly");
 
-   use_context = false;
-   #pragma omp dispatch nocontext(use_context)
+   nocontext_arg = false;
+   #pragma omp dispatch nocontext(nocontext_arg)
       add(arr);
 
    for(i = 0; i < N; i++){
       OMPVV_TEST_AND_SET_VERBOSE(errors, arr[i] != i+2);
    }
-   OMPVV_ERROR_IF(errors > 0, "Dispatch w/ novariants false is not working properly");
+   OMPVV_ERROR_IF(errors > 0, "Dispatch w/ nocontext false is not working properly");
    return errors;
 }
 

--- a/tests/5.1/dispatch/test_dispatch_nocontext.c
+++ b/tests/5.1/dispatch/test_dispatch_nocontext.c
@@ -1,79 +1,86 @@
-//===---- test_dispatch_nocontext.c -----------------------------------------===//
-// 
+//===---- test_dispatch_nocontext.c ---------------------------------------===//
+//
+//
 // OpenMP API Version 5.1
 //
-// Uses dispatch construct as context for variant directive. Uses nocontext clause
-// which can determine whether dispatch is a viable construct for the variant directive.
-// When nocontext is true, then dispatch is not a viable construct and vice versa. 
+// Uses dispatch construct as context for variant directive. Uses nocontext
+// clause which can determine whether dispatch is a viable construct for the
+// variant directive. When nocontext is true, then dispatch is not a viable
+// construct and vice versa.
 //
 // Inspired by "OpenMP 5.1 Features: The Dispatch Construct" video:
 // https://www.youtube.com/watch?v=ruugaX95gIs
-// 
-//===-------------------------------------------------------------------------------===//
+//
+//===----------------------------------------------------------------------===//
 
+#include "ompvv.h"
+#include <math.h>
 #include <omp.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <math.h>
-#include "ompvv.h"
-#include <stdbool.h>
 
 #define N 1024
 
-int arr[N]; // implicit map array 
+int arr[N]; // implicit map array
 int errors;
 int i = 0;
 
 void add_two(int *arr);
 
-#pragma omp declare variant(add_two) match(construct={dispatch})
-void add(int *arr){
-   for (int i = 0; i < N; i++){ // Base function adds 1 to array values
-      arr[i] = i+1;
-   }
+#pragma omp declare variant(add_two) match(construct = {dispatch})
+void add(int *arr) {
+  for (int i = 0; i < N; i++) { // Base function adds 1 to array values
+    arr[i] = i + 1;
+  }
 }
 
-void add_two(int *arr){
-   for (int i = 0; i < N; i++){
-      arr[i] = i+2; // Variant function adds 2 to array values
-   }
+void add_two(int *arr) {
+  for (int i = 0; i < N; i++) {
+    arr[i] = i + 2; // Variant function adds 2 to array values
+  }
 }
 
-int test_wrapper() { 
-   errors = 0;
-   int err_ar[2] = {0, 0};
-   bool nocontext_arg;
-   add(arr);
-   for(i = 0; i < N; i++){
-      OMPVV_TEST_AND_SET(errors, arr[i] != i+1);
-   } 
-   OMPVV_ERROR_IF(errors > 0, "Base function is not working properly");
-   nocontext_arg = true;
-   #pragma omp dispatch nocontext(nocontext_arg)
-      add(arr);
-   
-   for(i = 0; i < N; i++){
-      OMPVV_TEST_AND_SET(err_ar[0], (arr[i] != i+1) || (arr[i] != i+2));
-   }
-   errors += err_ar[0];
-   OMPVV_ERROR_IF(errors > 0, "Dispatch w/ nocontext true is not working properly");
+int test_wrapper() {
+  errors = 0;
+  int err_ar[2] = {0, 0};
+  bool nocontext_arg;
+  add(arr);
+  for (i = 0; i < N; i++) {
+    OMPVV_TEST_AND_SET(errors, arr[i] != i + 1);
+  }
+  OMPVV_ERROR_IF(errors > 0, "Base function is not working properly");
+  nocontext_arg = true;
+  #pragma omp dispatch nocontext(nocontext_arg)
+  add(arr);
 
-   nocontext_arg = false;
-   #pragma omp dispatch nocontext(nocontext_arg)
-      add(arr);
+  for (i = 0; i < N; i++) {
+    OMPVV_TEST_AND_SET(err_ar[0], (arr[i] != i + 1));
+  }
+  errors += err_ar[0];
+  OMPVV_ERROR_IF(errors > 0,
+                 "Dispatch w/ nocontext true is not working properly");
 
-   for(i = 0; i < N; i++){
-      OMPVV_TEST_AND_SET(err_ar[1], (arr[i] != i+1) || (arr[i] != i+2));
-   }
-   errors += err_ar[1];
-   OMPVV_ERROR_IF(errors > 0, "Dispatch w/ nocontext false is not working properly");
-   OMPVV_WARNING_IF(errors > 0, "Dispatch is either not working or was not considered" 
-                    " by the implementation as part of the context selector.");
-   return errors;
+  nocontext_arg = false;
+  #pragma omp dispatch nocontext(nocontext_arg)
+  add(arr);
+
+  for (i = 0; i < N; i++) {
+    OMPVV_TEST_AND_SET(err_ar[1], (arr[i] != i + 1) && (arr[i] != i + 2));
+  }
+  // OMP 5.1, Pg54:6 -Whether the dispatch construct is added to the construct
+  // set is implementation defined.
+  errors += err_ar[1];
+  OMPVV_ERROR_IF(errors > 0,
+                 "Dispatch w/ nocontext false is not working properly");
+  OMPVV_INFOMSG_IF(errors > 0,
+                   "Dispatch is either not working or was not considered"
+                   " by the implementation as part of the context selector.");
+  return errors;
 }
 
-int main () {
-   OMPVV_TEST_OFFLOADING;
-   OMPVV_TEST_AND_SET_VERBOSE(errors, test_wrapper());
-   OMPVV_REPORT_AND_RETURN(errors);
-}  
+int main() {
+  OMPVV_TEST_OFFLOADING;
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_wrapper());
+  OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.1/dispatch/test_dispatch_nocontext.c
+++ b/tests/5.1/dispatch/test_dispatch_nocontext.c
@@ -73,7 +73,7 @@ int test_wrapper() {
   errors += err_ar[1];
   OMPVV_ERROR_IF(errors > 0,
                  "Dispatch w/ nocontext false is not working properly");
-  OMPVV_INFOMSG_IF(errors > 0,
+  OMPVV_INFOMSG_IF(errors > 0 || arr[0] == 1,
                    "Dispatch is either not working or was not considered"
                    " by the implementation as part of the context selector.");
   return errors;

--- a/tests/5.1/dispatch/test_dispatch_nocontext.c
+++ b/tests/5.1/dispatch/test_dispatch_nocontext.c
@@ -44,7 +44,7 @@ int test_wrapper() {
    bool nocontext_arg;
    add(arr);
    for(i = 0; i < N; i++){
-      OMPVV_TEST_AND_SET_VERBOSE(errors, arr[i] != i+1);
+      OMPVV_TEST_AND_SET(errors, arr[i] != i+1);
    } 
    OMPVV_ERROR_IF(errors > 0, "Base function is not working properly");
    nocontext_arg = true;
@@ -52,7 +52,7 @@ int test_wrapper() {
       add(arr);
    
    for(i = 0; i < N; i++){
-      OMPVV_TEST_AND_SET_VERBOSE(errors, arr[i] != i+1);
+      OMPVV_TEST_AND_SET(errors, arr[i] != i+1);
    }
    OMPVV_ERROR_IF(errors > 0, "Dispatch w/ nocontext true is not working properly");
 
@@ -61,7 +61,7 @@ int test_wrapper() {
       add(arr);
 
    for(i = 0; i < N; i++){
-      OMPVV_TEST_AND_SET_VERBOSE(errors, arr[i] != i+2);
+      OMPVV_TEST_AND_SET(errors, arr[i] != i+2);
    }
    OMPVV_ERROR_IF(errors > 0, "Dispatch w/ nocontext false is not working properly");
    return errors;

--- a/tests/5.1/dispatch/test_dispatch_nocontext.c
+++ b/tests/5.1/dispatch/test_dispatch_nocontext.c
@@ -41,6 +41,7 @@ void add_two(int *arr){
 
 int test_wrapper() { 
    errors = 0;
+   int err_ar[2] = {0, 0};
    bool nocontext_arg;
    add(arr);
    for(i = 0; i < N; i++){
@@ -52,8 +53,9 @@ int test_wrapper() {
       add(arr);
    
    for(i = 0; i < N; i++){
-      OMPVV_TEST_AND_SET(errors, arr[i] != i+1);
+      OMPVV_TEST_AND_SET(err_ar[0], (arr[i] != i+1) || (arr[i] != i+2));
    }
+   errors += err_ar[0];
    OMPVV_ERROR_IF(errors > 0, "Dispatch w/ nocontext true is not working properly");
 
    nocontext_arg = false;
@@ -61,9 +63,12 @@ int test_wrapper() {
       add(arr);
 
    for(i = 0; i < N; i++){
-      OMPVV_TEST_AND_SET(errors, arr[i] != i+2);
+      OMPVV_TEST_AND_SET(err_ar[1], (arr[i] != i+1) || (arr[i] != i+2));
    }
+   errors += err_ar[1];
    OMPVV_ERROR_IF(errors > 0, "Dispatch w/ nocontext false is not working properly");
+   OMPVV_WARNING_IF(errors > 0, "Dispatch is either not working or was not considered" 
+                    " by the implementation as part of the context selector.");
    return errors;
 }
 

--- a/tests/5.1/dispatch/test_dispatch_nocontext.c
+++ b/tests/5.1/dispatch/test_dispatch_nocontext.c
@@ -71,8 +71,6 @@ int test_wrapper() {
   // OMP 5.1, Pg54:6 -Whether the dispatch construct is added to the construct
   // set is implementation defined.
   errors += err_ar[1];
-  OMPVV_ERROR_IF(errors > 0,
-                 "Dispatch w/ nocontext false is not working properly");
   OMPVV_INFOMSG_IF(errors > 0 || arr[0] == 1,
                    "Dispatch is either not working or was not considered"
                    " by the implementation as part of the context selector.");

--- a/tests/5.1/dispatch/test_dispatch_nocontext.c
+++ b/tests/5.1/dispatch/test_dispatch_nocontext.c
@@ -54,16 +54,16 @@ int test_wrapper() {
    for(i = 0; i < N; i++){
       OMPVV_TEST_AND_SET_VERBOSE(errors, arr[i] != i+1);
    }
-   OMPVV_ERROR_IF(errors > 0, "Dispatch w/ novariants false is not working properly");
+   OMPVV_ERROR_IF(errors > 0, "Dispatch w/ novariants true is not working properly");
 
-   use_context = true;
+   use_context = false;
    #pragma omp dispatch nocontext(use_context)
       add(arr);
 
    for(i = 0; i < N; i++){
       OMPVV_TEST_AND_SET_VERBOSE(errors, arr[i] != i+2);
    }
-   OMPVV_ERROR_IF(errors > 0, "Dispatch w/ novariants true is not working properly");
+   OMPVV_ERROR_IF(errors > 0, "Dispatch w/ novariants false is not working properly");
    return errors;
 }
 

--- a/tests/5.1/dispatch/test_dispatch_nocontext.c
+++ b/tests/5.1/dispatch/test_dispatch_nocontext.c
@@ -1,0 +1,74 @@
+//===---- test_dispatch_nocontext.c -----------------------------------------===//
+// 
+// OpenMP API Version 5.1
+//
+// Uses dispatch construct as context for variant directive. Uses nocontext clause
+// which can determine whether dispatch is a viable construct for the variant directive.
+// When nocontext is true, then dispatch is not a viable construct and vice versa. 
+//
+// Inspired by "OpenMP 5.1 Features: The Dispatch Construct" video:
+// https://www.youtube.com/watch?v=ruugaX95gIs
+// 
+//===-------------------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include "ompvv.h"
+#include <stdbool.h>
+
+#define N 1024
+
+int arr[N]; // implicit map array 
+int errors;
+int i = 0;
+
+void add_two(int *arr);
+
+#pragma omp declare variant(add_two) match(construct={dispatch})
+void add(int *arr){
+   for (int i = 0; i < N; i++){ // Base function adds 1 to array values
+      arr[i] = i+1;
+   }
+}
+
+void add_two(int *arr){
+   for (int i = 0; i < N; i++){
+      arr[i] = i+2; // Variant function adds 2 to array values
+   }
+}
+
+int test_wrapper() { 
+   errors = 0;
+   bool use_context;
+   add(arr);
+   for(i = 0; i < N; i++){
+      OMPVV_TEST_AND_SET_VERBOSE(errors, arr[i] != i+1);
+   } 
+   OMPVV_ERROR_IF(errors > 0, "Base function is not working properly");
+   use_context = true;
+   #pragma omp dispatch nocontext(use_context)
+      add(arr);
+   
+   for(i = 0; i < N; i++){
+      OMPVV_TEST_AND_SET_VERBOSE(errors, arr[i] != i+1);
+   }
+   OMPVV_ERROR_IF(errors > 0, "Dispatch w/ novariants false is not working properly");
+
+   use_context = true;
+   #pragma omp dispatch nocontext(use_context)
+      add(arr);
+
+   for(i = 0; i < N; i++){
+      OMPVV_TEST_AND_SET_VERBOSE(errors, arr[i] != i+2);
+   }
+   OMPVV_ERROR_IF(errors > 0, "Dispatch w/ novariants true is not working properly");
+   return errors;
+}
+
+int main () {
+   OMPVV_TEST_OFFLOADING;
+   OMPVV_TEST_AND_SET_VERBOSE(errors, test_wrapper());
+   OMPVV_REPORT_AND_RETURN(errors);
+}  

--- a/tests/5.1/dispatch/test_dispatch_novariants.c
+++ b/tests/5.1/dispatch/test_dispatch_novariants.c
@@ -44,7 +44,7 @@ int test_wrapper() {
    bool novariant_arg;
    add(arr);
    for(i = 0; i < N; i++){
-      OMPVV_TEST_AND_SET_VERBOSE(errors, arr[i] != i+1);
+      OMPVV_TEST_AND_SET(errors, arr[i] != i+1);
    } 
    OMPVV_ERROR_IF(errors > 0, "Base function is not working properly");
    novariant_arg = true;
@@ -52,7 +52,7 @@ int test_wrapper() {
       add(arr);
    
    for(i = 0; i < N; i++){
-      OMPVV_TEST_AND_SET_VERBOSE(errors, arr[i] != i+1);
+      OMPVV_TEST_AND_SET(errors, arr[i] != i+1);
    }
    OMPVV_ERROR_IF(errors > 0, "Dispatch w/ novariants true is not working properly");
 
@@ -61,7 +61,7 @@ int test_wrapper() {
       add(arr);
 
    for(i = 0; i < N; i++){
-      OMPVV_TEST_AND_SET_VERBOSE(errors, arr[i] != i+2);
+      OMPVV_TEST_AND_SET(errors, arr[i] != i+2);
    }
    OMPVV_ERROR_IF(errors > 0, "Dispatch w/ novariants false is not working properly");
    return errors;

--- a/tests/5.1/dispatch/test_dispatch_novariants.c
+++ b/tests/5.1/dispatch/test_dispatch_novariants.c
@@ -56,7 +56,7 @@ int test_wrapper() {
    }
    OMPVV_ERROR_IF(errors > 0, "Dispatch w/ novariants true is not working properly");
 
-   novariant_arg = true;
+   novariant_arg = false;
    #pragma omp dispatch novariants(novariant_arg)
       add(arr);
 

--- a/tests/5.1/dispatch/test_dispatch_novariants.c
+++ b/tests/5.1/dispatch/test_dispatch_novariants.c
@@ -41,14 +41,14 @@ void add_two(int *arr){
 
 int test_wrapper() { 
    errors = 0;
-   bool use_variant;
+   bool novariant_arg;
    add(arr);
    for(i = 0; i < N; i++){
       OMPVV_TEST_AND_SET_VERBOSE(errors, arr[i] != i+1);
    } 
    OMPVV_ERROR_IF(errors > 0, "Base function is not working properly");
-   use_variant = true;
-   #pragma omp dispatch novariants(use_variant)
+   novariant_arg = true;
+   #pragma omp dispatch novariants(novariant_arg)
       add(arr);
    
    for(i = 0; i < N; i++){
@@ -56,8 +56,8 @@ int test_wrapper() {
    }
    OMPVV_ERROR_IF(errors > 0, "Dispatch w/ novariants true is not working properly");
 
-   use_variant = true;
-   #pragma omp dispatch novariants(use_variant)
+   novariant_arg = true;
+   #pragma omp dispatch novariants(novariant_arg)
       add(arr);
 
    for(i = 0; i < N; i++){

--- a/tests/5.1/dispatch/test_dispatch_novariants.c
+++ b/tests/5.1/dispatch/test_dispatch_novariants.c
@@ -69,7 +69,6 @@ int test_wrapper() {
    // set is implementation defined.
 
    errors += err_ar[1];
-   OMPVV_ERROR_IF(errors > 0, "Dispatch w/ novariants false is not working properly");
    OMPVV_INFOMSG_IF(errors > 0 || arr[0] == 1,
                    "Dispatch is either not working or was not considered"
                    " by the implementation as part of the context selector.");

--- a/tests/5.1/dispatch/test_dispatch_novariants.c
+++ b/tests/5.1/dispatch/test_dispatch_novariants.c
@@ -41,6 +41,7 @@ void add_two(int *arr){
 
 int test_wrapper() { 
    errors = 0;
+   int err_ar[2] = {0, 0};
    bool novariant_arg;
    add(arr);
    for(i = 0; i < N; i++){
@@ -52,8 +53,9 @@ int test_wrapper() {
       add(arr);
    
    for(i = 0; i < N; i++){
-      OMPVV_TEST_AND_SET(errors, arr[i] != i+1);
+      OMPVV_TEST_AND_SET(err_ar[0], (arr[i] != i + 1));
    }
+   errors += err_ar[0];
    OMPVV_ERROR_IF(errors > 0, "Dispatch w/ novariants true is not working properly");
 
    novariant_arg = false;
@@ -61,9 +63,16 @@ int test_wrapper() {
       add(arr);
 
    for(i = 0; i < N; i++){
-      OMPVV_TEST_AND_SET(errors, arr[i] != i+2);
+      OMPVV_TEST_AND_SET(err_ar[1], (arr[i] != i + 1) && (arr[i] != i + 2));
    }
+   // OMP 5.1, Pg54:6 -Whether the dispatch construct is added to the construct
+   // set is implementation defined.
+
+   errors += err_ar[1];
    OMPVV_ERROR_IF(errors > 0, "Dispatch w/ novariants false is not working properly");
+   OMPVV_INFOMSG_IF(errors > 0,
+                   "Dispatch is either not working or was not considered"
+                   " by the implementation as part of the context selector.");
    return errors;
 }
 

--- a/tests/5.1/dispatch/test_dispatch_novariants.c
+++ b/tests/5.1/dispatch/test_dispatch_novariants.c
@@ -1,0 +1,74 @@
+//===---- test_dispatch_novariants.c -----------------------------------------===//
+// 
+// OpenMP API Version 5.1
+//
+// Uses dispatch construct as context for variant directive. Uses novariants clause
+// which can determine whether the variant function will be used.
+// When novariants is true, then the variant cannot be used and vice versa. 
+//
+// Inspired by "OpenMP 5.1 Features: The Dispatch Construct" video:
+// https://www.youtube.com/watch?v=ruugaX95gIs
+// 
+//===-------------------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include "ompvv.h"
+#include <stdbool.h>
+
+#define N 1024
+
+int arr[N]; // implicit map array 
+int errors;
+int i = 0;
+
+void add_two(int *arr);
+
+#pragma omp declare variant(add_two) match(construct={dispatch})
+void add(int *arr){
+   for (int i = 0; i < N; i++){ // Base function adds 1 to array values
+      arr[i] = i+1;
+   }
+}
+
+void add_two(int *arr){
+   for (int i = 0; i < N; i++){
+      arr[i] = i+2; // Variant function adds 2 to array values
+   }
+}
+
+int test_wrapper() { 
+   errors = 0;
+   bool use_variant;
+   add(arr);
+   for(i = 0; i < N; i++){
+      OMPVV_TEST_AND_SET_VERBOSE(errors, arr[i] != i+1);
+   } 
+   OMPVV_ERROR_IF(errors > 0, "Base function is not working properly");
+   use_variant = true;
+   #pragma omp dispatch novariants(use_variant)
+      add(arr);
+   
+   for(i = 0; i < N; i++){
+      OMPVV_TEST_AND_SET_VERBOSE(errors, arr[i] != i+1);
+   }
+   OMPVV_ERROR_IF(errors > 0, "Dispatch w/ novariants true is not working properly");
+
+   use_variant = true;
+   #pragma omp dispatch novariants(use_variant)
+      add(arr);
+
+   for(i = 0; i < N; i++){
+      OMPVV_TEST_AND_SET_VERBOSE(errors, arr[i] != i+2);
+   }
+   OMPVV_ERROR_IF(errors > 0, "Dispatch w/ novariants false is not working properly");
+   return errors;
+}
+
+int main () {
+   OMPVV_TEST_OFFLOADING;
+   OMPVV_TEST_AND_SET_VERBOSE(errors, test_wrapper());
+   OMPVV_REPORT_AND_RETURN(errors);
+}  

--- a/tests/5.1/dispatch/test_dispatch_novariants.c
+++ b/tests/5.1/dispatch/test_dispatch_novariants.c
@@ -70,7 +70,7 @@ int test_wrapper() {
 
    errors += err_ar[1];
    OMPVV_ERROR_IF(errors > 0, "Dispatch w/ novariants false is not working properly");
-   OMPVV_INFOMSG_IF(errors > 0,
+   OMPVV_INFOMSG_IF(errors > 0 || arr[0] == 1,
                    "Dispatch is either not working or was not considered"
                    " by the implementation as part of the context selector.");
    return errors;

--- a/tests/5.1/dispatch/test_dispatch_nowait.c
+++ b/tests/5.1/dispatch/test_dispatch_nowait.c
@@ -48,10 +48,17 @@ int test_wrapper() {
    #pragma omp dispatch nowait
       add(arr);
 
+   #pragma omp barrier
    for(i = 0; i < N; i++){
       OMPVV_TEST_AND_SET(errors, arr[i] != i+2);
    }
+   // OMP 5.1, Pg54:6 -Whether the dispatch construct is added to the construct
+   // set is implementation defined.
+ 
    OMPVV_ERROR_IF(errors > 0, "Dispatch w/ nowait is not working properly");
+   OMPVV_INFOMSG_IF(errors > 0,
+                   "Dispatch is either not working or was not considered"
+                   " by the implementation as part of the context selector.");
    return errors;
 }
 

--- a/tests/5.1/dispatch/test_dispatch_nowait.c
+++ b/tests/5.1/dispatch/test_dispatch_nowait.c
@@ -56,7 +56,7 @@ int test_wrapper() {
    // set is implementation defined.
  
    OMPVV_ERROR_IF(errors > 0, "Dispatch w/ nowait is not working properly");
-   OMPVV_INFOMSG_IF(errors > 0,
+   OMPVV_INFOMSG_IF(errors > 0 || arr[0] == 1,
                    "Dispatch is either not working or was not considered"
                    " by the implementation as part of the context selector.");
    return errors;

--- a/tests/5.1/dispatch/test_dispatch_nowait.c
+++ b/tests/5.1/dispatch/test_dispatch_nowait.c
@@ -1,0 +1,62 @@
+//===---- test_dispatch_nowait.c -----------------------------------------===//
+// 
+// OpenMP API Version 5.1
+//
+// Uses dispatch construct as context for variant directive. Uses nowait clause
+// which adds nowait to the interoperability requirement set.
+//
+// Inspired by "OpenMP 5.1 Features: The Dispatch Construct" video:
+// https://www.youtube.com/watch?v=ruugaX95gIs
+// 
+//===-------------------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include "ompvv.h"
+
+#define N 1024
+
+int arr[N]; // implicit map array 
+int errors;
+int i = 0;
+
+void add_two(int *arr);
+
+#pragma omp declare variant(add_two) match(construct={dispatch})
+void add(int *arr){
+   for (int i = 0; i < N; i++){ // Base function adds 1 to array values
+      arr[i] = i+1;
+   }
+}
+
+void add_two(int *arr){
+   for (int i = 0; i < N; i++){
+      arr[i] = i+2; // Variant function adds 2 to array values
+   }
+}
+
+int test_wrapper() { 
+   errors = 0;
+   add(arr);
+   for(i = 0; i < N; i++){
+      OMPVV_TEST_AND_SET_VERBOSE(errors, arr[i] != i+1);
+   } 
+   OMPVV_ERROR_IF(errors > 0, "Base function is not working properly");
+
+   #pragma omp dispatch nowait
+      add(arr);
+
+   for(i = 0; i < N; i++){
+      OMPVV_TEST_AND_SET_VERBOSE(errors, arr[i] != i+2);
+   }
+   OMPVV_ERROR_IF(errors > 0, "Dispatch w/ nowait is not working properly");
+   return errors;
+}
+
+int main () {
+   OMPVV_TEST_OFFLOADING;
+   OMPVV_TEST_AND_SET_VERBOSE(errors, test_wrapper());
+   OMPVV_REPORT_AND_RETURN(errors);
+}  

--- a/tests/5.1/dispatch/test_dispatch_nowait.c
+++ b/tests/5.1/dispatch/test_dispatch_nowait.c
@@ -55,7 +55,6 @@ int test_wrapper() {
    // OMP 5.1, Pg54:6 -Whether the dispatch construct is added to the construct
    // set is implementation defined.
  
-   OMPVV_ERROR_IF(errors > 0, "Dispatch w/ nowait is not working properly");
    OMPVV_INFOMSG_IF(errors > 0 || arr[0] == 1,
                    "Dispatch is either not working or was not considered"
                    " by the implementation as part of the context selector.");

--- a/tests/5.1/dispatch/test_dispatch_nowait.c
+++ b/tests/5.1/dispatch/test_dispatch_nowait.c
@@ -41,7 +41,7 @@ int test_wrapper() {
    errors = 0;
    add(arr);
    for(i = 0; i < N; i++){
-      OMPVV_TEST_AND_SET_VERBOSE(errors, arr[i] != i+1);
+      OMPVV_TEST_AND_SET(errors, arr[i] != i+1);
    } 
    OMPVV_ERROR_IF(errors > 0, "Base function is not working properly");
 
@@ -49,7 +49,7 @@ int test_wrapper() {
       add(arr);
 
    for(i = 0; i < N; i++){
-      OMPVV_TEST_AND_SET_VERBOSE(errors, arr[i] != i+2);
+      OMPVV_TEST_AND_SET(errors, arr[i] != i+2);
    }
    OMPVV_ERROR_IF(errors > 0, "Dispatch w/ nowait is not working properly");
    return errors;


### PR DESCRIPTION
Getting the simpler clauses out of the way first for dispatch, still need device, depend & is_device_ptr clauses.

GCC 11.2 does not recognize directive, llvm just reports errors for `dispatch w/ ____ false is not working`
I'm not sure if I am using declare variant improperly (with the naming schemes, etc) or its not implemented properly.
