### PR TITLE
Add new_test/test_requires_reverse_offload.F90

### DIFF
--- a/tests/5.0/requires/test_requires_reverse_offload.F90
+++ b/tests/5.0/requires/test_requires_reverse_offload.F90
@@ -39,7 +39,7 @@ PROGRAM test_requires_reverse_offload
      A(i) = i
   END DO
 
-  OMPVV_WARNING_IF(device_num .le. 0, "Cannot properly properly test reverse offload if no devices are available")
+  OMPVV_WARNING_IF(device_num .le. 0, "Cannot properly test reverse offload if no devices are available")
   OMPVV_TEST_AND_SET_SHARED_ENVIRONMENT(is_shared_env)
   OMPVV_WARNING_IF(is_shared_env, "[WARNING] May not be able to detect errors if the target system supports shared memory.")
 

--- a/tests/5.0/requires/test_requires_reverse_offload.F90
+++ b/tests/5.0/requires/test_requires_reverse_offload.F90
@@ -1,0 +1,61 @@
+!===--- test_requires_reverse_offload.F90 -------------------------------===//
+!
+! OpenMP API Version 5.0 Nov 2018
+!
+! This test checks to see that the reverse_offload clause on a requires directive 
+! is supported, and if so, the function host_function() will made available as a 
+! procedure only on the host. By specificying the 'ancestor' modifier with device 
+! number of 1, we are indicating to compiler that execution is to be performed on
+! the immediate parent, the host. The omp declare target statement ensures that the
+! host_function will only be available on host.  
+!
+! Based on OpenMP 5.0 Example: target_reverse_offload.7.c
+! 
+!//===----------------------------------------------------------------------===//
+#define OMPVV_MODULE_REQUIRES_LINE !$omp requires reverse_offload
+#include "ompvv.F90"
+
+#define N 1024
+
+PROGRAM test_requires_reverse_offload
+  !$omp requires reverse_offload
+  USE iso_fortran_env
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+
+  INTEGER, DIMENSION(N) :: A
+  LOGICAL :: isOffloading
+  INTEGER :: device_num, i
+  INTEGER :: is_shared_env
+
+  OMPVV_TEST_AND_SET_OFFLOADING(isOffloading)
+
+  OMPVV_WARNING_IF(.not. isOffloading, "Without offloading enabled, host execution is already guaranteed")
+
+  device_num = omp_get_num_devices()
+
+  DO i = 1, N
+     A(i) = i
+  END DO
+
+  OMPVV_WARNING_IF(device_num .le. 0, "Cannot properly properly test reverse offload if no devices are available")
+  OMPVV_TEST_AND_SET_SHARED_ENVIRONMENT(is_shared_env)
+  OMPVV_WARNING_IF(is_shared_env .ne. 0, "[WARNING] May not be able to detect errors if the target system supports shared memory.")
+
+  !$omp target enter data map(to: A)
+
+  IF (device_num .gt. 0) THEN
+    !$omp target device(ancestor: 1) map(always, to: A)
+    DO i = 1, N
+       A(i) = 2*i
+    END DO
+    !$omp end target
+  END IF
+
+  DO i = 1, N
+     OMPVV_TEST(A[i] .ne. 2*i)
+  END DO
+
+  OMPVV_REPORT_AND_RETURN()
+END PROGRAM test_requires_reverse_offload

--- a/tests/5.0/requires/test_requires_reverse_offload.F90
+++ b/tests/5.0/requires/test_requires_reverse_offload.F90
@@ -54,7 +54,7 @@ PROGRAM test_requires_reverse_offload
   END IF
 
   DO i = 1, N
-     OMPVV_TEST(A[i] .ne. 2*i)
+     OMPVV_TEST(A(i) .ne. 2*i)
   END DO
 
   OMPVV_REPORT_AND_RETURN()

--- a/tests/5.0/requires/test_requires_reverse_offload.F90
+++ b/tests/5.0/requires/test_requires_reverse_offload.F90
@@ -27,7 +27,7 @@ PROGRAM test_requires_reverse_offload
   INTEGER, DIMENSION(N) :: A
   LOGICAL :: isOffloading
   INTEGER :: device_num, i
-  INTEGER :: is_shared_env
+  LOGICAL :: is_shared_env
 
   OMPVV_TEST_AND_SET_OFFLOADING(isOffloading)
 
@@ -41,7 +41,7 @@ PROGRAM test_requires_reverse_offload
 
   OMPVV_WARNING_IF(device_num .le. 0, "Cannot properly properly test reverse offload if no devices are available")
   OMPVV_TEST_AND_SET_SHARED_ENVIRONMENT(is_shared_env)
-  OMPVV_WARNING_IF(is_shared_env .ne. 0, "[WARNING] May not be able to detect errors if the target system supports shared memory.")
+  OMPVV_WARNING_IF(is_shared_env, "[WARNING] May not be able to detect errors if the target system supports shared memory.")
 
   !$omp target enter data map(to: A)
 

--- a/tests/5.0/requires/test_requires_reverse_offload.F90
+++ b/tests/5.0/requires/test_requires_reverse_offload.F90
@@ -45,13 +45,13 @@ PROGRAM test_requires_reverse_offload
 
   !$omp target enter data map(to: A)
 
-  IF (device_num .gt. 0) THEN
+  !$omp target   ! Run on the default device, which is the host for device_num = 0
     !$omp target device(ancestor: 1) map(always, to: A)
     DO i = 1, N
        A(i) = 2*i
     END DO
     !$omp end target
-  END IF
+  !$omp end target
 
   DO i = 1, N
      OMPVV_TEST(A(i) .ne. 2*i)

--- a/tests/5.0/requires/test_requires_reverse_offload.c
+++ b/tests/5.0/requires/test_requires_reverse_offload.c
@@ -27,12 +27,13 @@ int main()
     int isOffloading;
     int errors;
     int device_num;
+    int is_shared_env = 0;
 
     errors = 0;
    
     OMPVV_TEST_AND_SET_OFFLOADING(isOffloading);
 
-    OMPVV_WARNING_IF(!isOffloading, "Without offloading enabled, host execution is already guaranteed")
+    OMPVV_WARNING_IF(!isOffloading, "Without offloading enabled, host execution is already guaranteed");
 
     device_num = omp_get_num_devices();
 
@@ -41,6 +42,8 @@ int main()
     }
 
     OMPVV_WARNING_IF(device_num <= 0, "Cannot properly properly test reverse offload if no devices are available");
+    OMPVV_TEST_AND_SET_SHARED_ENVIRONMENT(is_shared_env);
+    OMPVV_WARNING_IF(is_shared_env != 0, "[WARNING] May not be able to detect errors if the target system supports shared memory.")
     
     #pragma omp target enter data map(to: A) 
 

--- a/tests/5.0/requires/test_requires_reverse_offload.c
+++ b/tests/5.0/requires/test_requires_reverse_offload.c
@@ -41,7 +41,7 @@ int main()
         A[i] = i;
     }
 
-    OMPVV_WARNING_IF(device_num <= 0, "Cannot properly properly test reverse offload if no devices are available");
+    OMPVV_WARNING_IF(device_num <= 0, "Cannot properly test reverse offload if no devices are available");
     OMPVV_TEST_AND_SET_SHARED_ENVIRONMENT(is_shared_env);
     OMPVV_WARNING_IF(is_shared_env != 0, "[WARNING] May not be able to detect errors if the target system supports shared memory.")
     

--- a/tests/5.0/requires/test_requires_reverse_offload.c
+++ b/tests/5.0/requires/test_requires_reverse_offload.c
@@ -25,7 +25,7 @@ int main()
 {
     int A[N];	
     int isOffloading;
-    int errors;
+    int errors, errors2;
     int device_num;
     int is_shared_env = 0;
 
@@ -44,16 +44,24 @@ int main()
     OMPVV_WARNING_IF(device_num <= 0, "Cannot properly test reverse offload if no devices are available");
     OMPVV_TEST_AND_SET_SHARED_ENVIRONMENT(is_shared_env);
     OMPVV_WARNING_IF(is_shared_env != 0, "[WARNING] May not be able to detect errors if the target system supports shared memory.")
-    
-    #pragma omp target enter data map(to: A) 
 
-    #pragma omp target // Run on the default device, which is the host for device_num = 0
+    errors2 = 0;
+    
+    #pragma omp target map(tofrom: errors2) map(to:A, is_shared_env) // Run on the default device, which is the host for device_num = 0
     {
        #pragma omp target device(ancestor:1) map(always, to: A)
        for (int j = 0; j < N; j++) {
           A[j] = 2*j;
        } 
+       if( (omp_is_initial_device() == 0) && (is_shared_env == 0) ) {
+          for (int i = 0; i < N; i++) {
+             if( A[i] != i) { errors2 = errors2 + 1; }
+          }
+       }   
+
     }
+
+    OMPVV_TEST_AND_SET_VERBOSE(errors, errors2 != 0);
     
     for (int i = 0; i < N; i++) {
        OMPVV_TEST_AND_SET(errors, A[i] != 2*i);

--- a/tests/5.0/requires/test_requires_reverse_offload.c
+++ b/tests/5.0/requires/test_requires_reverse_offload.c
@@ -47,7 +47,8 @@ int main()
     
     #pragma omp target enter data map(to: A) 
 
-    if (device_num > 0) {
+    #pragma omp target // Run on the default device, which is the host for device_num = 0
+    {
        #pragma omp target device(ancestor:1) map(always, to: A)
        for (int j = 0; j < N; j++) {
           A[j] = 2*j;


### PR DESCRIPTION
Update both C and Fortran versions to print a warning if the test cannot detect errors because the target system supports a shared memory.
    - LLVM 15.0.0: C test failed.
    - GCC 12.1.1: Both C and Fortran tests failed.
    - XL 16.1.1-10: Both C and Fortran tests failed.
    - NVHPC 22.5: Both C and Fortran tests failed.