### PR TITLE
Added order unconstrained clause on taskloop test

### DIFF
--- a/tests/5.1/order/test_taskloop_simd_order_unconstrained_device.c
+++ b/tests/5.1/order/test_taskloop_simd_order_unconstrained_device.c
@@ -1,11 +1,11 @@
-//===------------ test_target_taskloop_simd_order_reproducible_device.c ------===//
+//===------ test_target_taskloop_simd_order_unconstrained_concurrent.c ------===//
 //
 // OpenMP API Version 5.1 Nov 2020
 //
-// This test checks that the order(reproducible:unconstrained) clause is properly handled.
-// As per the definition the order in which they are executed does not matter. 
-// Instead focus on that the correct result is calculated, regardless of execution
-// order. 
+// This test checks that the order(reproducible:unconstrained) clause is 
+// properly handled. As per the definition the order in which they are executed 
+// does not matter. Instead focus on that the correct result is calculated, 
+// regardless of execution order. 
 //
 ////===----------------------------------------------------------------------===//
 

--- a/tests/5.1/order/test_taskloop_simd_order_unconstrained_device.c
+++ b/tests/5.1/order/test_taskloop_simd_order_unconstrained_device.c
@@ -49,7 +49,7 @@ int main() {
 
 	for (int i = 0; i < N; i++) {
     		OMPVV_TEST_AND_SET(errors, y[i] != i + 2);
-        OMPVV_TEST_AND_SET(errors, x[i] != i + 2)
+        	OMPVV_TEST_AND_SET(errors, x[i] != i + 2)
 	}
 
 	OMPVV_REPORT_AND_RETURN(errors);

--- a/tests/5.1/order/test_taskloop_simd_order_unconstrained_device.c
+++ b/tests/5.1/order/test_taskloop_simd_order_unconstrained_device.c
@@ -1,0 +1,56 @@
+//===------------ test_target_taskloop_simd_order_reproducible_device.c ------===//
+//
+// OpenMP API Version 5.1 Nov 2020
+//
+// This test checks that the order(reproducible:unconstrained) clause is properly handled.
+// As per the definition the order in which they are executed does not matter. 
+// Instead focus on that the correct result is calculated, regardless of execution
+// order. 
+//
+////===----------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 24
+
+int main() {
+	int errors = 0;
+	int x[N];
+	int y[N];
+
+	for (int i = 0; i < N; i++) {
+		x[i] = i;
+		y[i] = i;
+	}
+
+	OMPVV_TEST_OFFLOADING;
+
+	#pragma omp target map(tofrom: x,y)
+	{
+		#pragma omp parallel
+		{
+		   #pragma omp single
+		   #pragma omp taskloop simd order(reproducible:unconstrained)
+		   for (int i = 0; i < N; i++) {
+			   x[i] = x[i] + 2;	
+		   }
+
+		   #pragma omp single
+		   #pragma omp taskloop simd order(reproducible:unconstrained)
+		   for (int i = 0; i < N; i++) {
+			   y[i] = y[i] + 2;
+		   }
+		}
+
+	}
+
+	for (int i = 0; i < N; i++) {
+    		OMPVV_TEST_AND_SET(errors, y[i] != i + 2);
+        OMPVV_TEST_AND_SET(errors, x[i] != i + 2)
+	}
+
+	OMPVV_REPORT_AND_RETURN(errors);
+}


### PR DESCRIPTION
Final test in the order clause series, this one is a slight alteration to the previous order:reproducible clause. Instead this time execution order does not matter, simply that the correct result is ultimately returned.