### PR TITLE
Fix tests using fprintf in GPU target region

### DIFF
--- a/tests/5.0/target_requires/test_target_requires_atomic_default_mem_order_acq_rel.c
+++ b/tests/5.0/target_requires/test_target_requires_atomic_default_mem_order_acq_rel.c
@@ -41,7 +41,7 @@ int test_target_requires_atomic_acq_rel() {
           OMPVV_TEST_AND_SET(errors, x != 10);
        }
    }
-   OMPVV_ERROR_IF(errors > 0; "Requires atomic_default_mem_order(acq_rel) test failed");
+   OMPVV_ERROR_IF(errors > 0, "Requires atomic_default_mem_order(acq_rel) test failed");
    return errors;
 }
 

--- a/tests/5.0/target_requires/test_target_requires_atomic_default_mem_order_acq_rel.c
+++ b/tests/5.0/target_requires/test_target_requires_atomic_default_mem_order_acq_rel.c
@@ -38,9 +38,10 @@ int test_target_requires_atomic_acq_rel() {
             #pragma omp atomic read 
             tmp = y;
           }
-          OMPVV_TEST_AND_SET_VERBOSE(errors, x != 10);
+          OMPVV_TEST_AND_SET(errors, x != 10);
        }
    }
+   OMPVV_ERROR_IF(errors > 0; "Requires atomic_default_mem_order(acq_rel) test failed");
    return errors;
 }
 

--- a/tests/5.0/target_requires/test_target_requires_atomic_default_mem_order_relaxed.c
+++ b/tests/5.0/target_requires/test_target_requires_atomic_default_mem_order_relaxed.c
@@ -41,9 +41,10 @@ int test_target_requires_atomic_relaxed() {
             tmp = y;
           }
           #pragma omp flush
-          OMPVV_TEST_AND_SET_VERBOSE(errors, x != 10);
+          OMPVV_TEST_AND_SET(errors, x != 10);
        }
    }
+   OMPVV_ERROR_IF(errors > 0, "Requires atomic_default_mem_order(relaxed) test failed");
    return errors;
 }
 

--- a/tests/5.0/target_requires/test_target_requires_atomic_default_mem_order_seq_cst.c
+++ b/tests/5.0/target_requires/test_target_requires_atomic_default_mem_order_seq_cst.c
@@ -42,6 +42,7 @@ int test_target_atomic_seq_cst() {
           OMPVV_TEST_AND_SET_VERBOSE(errors, x != 10);
        }
    }
+   OMPVV_ERROR_IF(errors > 0, "Requires atomic_default_mem_order(seq_cst) test failed");
    return errors;
 }
 

--- a/tests/5.0/target_requires/test_target_requires_atomic_default_mem_order_seq_cst.c
+++ b/tests/5.0/target_requires/test_target_requires_atomic_default_mem_order_seq_cst.c
@@ -39,7 +39,7 @@ int test_target_atomic_seq_cst() {
             #pragma omp atomic read 
             tmp = y;
           }
-          OMPVV_TEST_AND_SET_VERBOSE(errors, x != 10);
+          OMPVV_TEST_AND_SET(errors, x != 10);
        }
    }
    OMPVV_ERROR_IF(errors > 0, "Requires atomic_default_mem_order(seq_cst) test failed");


### PR DESCRIPTION
Addresses issue #565 of tests using fprintf (which is part of OMPVV_TEST_AND_SET_VERBOSE) in target regions.