### PR TITLE
fix_issue_595/test_declare_mapper_target_struct.F90

### DIFF
--- a/tests/5.0/declare_mapper/test_declare_mapper_target_struct.F90
+++ b/tests/5.0/declare_mapper/test_declare_mapper_target_struct.F90
@@ -68,5 +68,7 @@ SUBROUTINE init(s)
     use my_struct
     type(newvec) :: s
 
+    !$omp declare target
+
     s%data = [(i, i = 1, s%len)]
 END SUBROUTINE


### PR DESCRIPTION
Fix issue #595 by adding a missing declare target directive to the SUBROUTINE init(s) in the Fortran version.
    - NVHPC 22.5: C test failed but Fortran test passed.
    - LLVM 15.0.0: C test passed.
    - GCC 12.1.1: Both C and Fortran tests failed.
    - XL 16.1.1-10: C test passed but ran on host. Fortran test failed.

Related OpenMP spec rules:
- OpenMP V5.0, Section 2.12.5 target Construct, page 173, line 1~3:
    - If a function (C, C++, Fortran) or subroutine (Fortran) is referenced in a target construct then that function or subroutine is treated as if its name had appeared in a to clause on a declare target directive.
- OpenMP V5.0, Section 2.12.7 declare target Directve, page 182, line 10~11:
    - If a function appears in a to clause in the same translation unit in which the definition of the function occurs then a device-specific version of the function is created.
- OpenMP V5.0, Section 2.12.7 declare target Directve, page 184, line 7~8:
    - Any declare target directive with clauses must appear in a specification part of a subroutine subprogram, function subprogram, program or module.