### PR TITLE
fix_issue/test_declare_variant.F90

### DIFF
--- a/tests/5.0/declare_variant/test_declare_variant.F90
+++ b/tests/5.0/declare_variant/test_declare_variant.F90
@@ -43,6 +43,7 @@ CONTAINS
   SUBROUTINE t_fn(arr)
     INTEGER,INTENT(inout) :: arr(N)
     INTEGER :: i
+    !$omp declare target
 
     !$omp distribute simd
     DO i = 1, N


### PR DESCRIPTION
- Added a missing declare target directive to the SUBROUTINE t_fn(arr) in the Fortran version.
- This bug is similar to issue #595 

	- NVHPC 22.5: Both C and Fortran tests failed.
        - LLVM 15.0.0: C test passed.
        - GCC 12.1.1: Both C and Fortran tests passed.
        - XL 16.1.1-10: Both C and Fortran tests failed.