### PR TITLE
Dispatch Depend test

### DIFF
--- a/tests/5.1/dispatch/test_dispatch_depend.c
+++ b/tests/5.1/dispatch/test_dispatch_depend.c
@@ -25,7 +25,7 @@ int a = 0;
 
 void add_a(int *arr);
 
-#pragma omp declare variant(add_two) match(construct={dispatch})
+#pragma omp declare variant(add_a) match(construct={dispatch})
 void add(int *arr){
     for (int i = 0; i < N; i++){ // Base function adds 1 to array values
         arr[i] = i+1;

--- a/tests/5.1/dispatch/test_dispatch_depend.c
+++ b/tests/5.1/dispatch/test_dispatch_depend.c
@@ -21,7 +21,7 @@
 int arr[N]; // implicit map array 
 int errors;
 int i = 0;
-int a;
+int a = 0;
 
 void add_two(int *arr);
 
@@ -30,15 +30,14 @@ void add(int *arr){
     for (int i = 0; i < N; i++){ // Base function adds 1 to array values
         arr[i] = i+1;
     }
-    #pragma omp task depend(out: a)
-        a = 3;
+    a = 3;
 }
 
 void add_two(int *arr){
     OMPVV_TEST_AND_SET_VERBOSE(errors, a != 3);
     OMPVV_ERROR_IF(errors > 0, "Depend clause on dispatch directive not working properly");
     for (int i = 0; i < N; i++){
-        arr[i] = i+2; // Variant function adds 2 to array values
+        arr[i] = i+a; // Variant function adds 2 to array values
     }
 }
 
@@ -54,7 +53,7 @@ int test_wrapper() {
         add(arr);
 
     for(i = 0; i < N; i++){
-        OMPVV_TEST_AND_SET_VERBOSE(errors, arr[i] != i+2);
+        OMPVV_TEST_AND_SET_VERBOSE(errors, arr[i] != i+3);
     }
     OMPVV_ERROR_IF(errors > 0, "Dispatch w/ depend is not working properly");
     return errors;
@@ -64,4 +63,4 @@ int main () {
     OMPVV_TEST_OFFLOADING;
     OMPVV_TEST_AND_SET_VERBOSE(errors, test_wrapper());
     OMPVV_REPORT_AND_RETURN(errors);
-}  
+}

--- a/tests/5.1/dispatch/test_dispatch_depend.c
+++ b/tests/5.1/dispatch/test_dispatch_depend.c
@@ -23,7 +23,7 @@ int errors;
 int i = 0;
 int a = 0;
 
-void add_two(int *arr);
+void add_a(int *arr);
 
 #pragma omp declare variant(add_two) match(construct={dispatch})
 void add(int *arr){
@@ -33,7 +33,7 @@ void add(int *arr){
     a = 3;
 }
 
-void add_two(int *arr){
+void add_a(int *arr){
     OMPVV_TEST_AND_SET(errors, a != 3);
     OMPVV_ERROR_IF(errors > 0, "Depend clause on dispatch directive not working properly");
     for (int i = 0; i < N; i++){
@@ -61,7 +61,7 @@ int test_wrapper() {
     for(i = 0; i < N; i++){
         OMPVV_TEST_AND_SET(errors, arr[i] != i+1 && arr[i] != i+3);
     }
-    OMPVV_ERROR_IF(errors > 0, "Dispatch w/ depend is not working properly");
+
     OMPVV_INFOMSG_IF(errors > 0 || arr[0] == 1,
                    "Dispatch is either not working or was not considered"
                    " by the implementation as part of the context selector.");

--- a/tests/5.1/dispatch/test_dispatch_depend.c
+++ b/tests/5.1/dispatch/test_dispatch_depend.c
@@ -62,7 +62,7 @@ int test_wrapper() {
         OMPVV_TEST_AND_SET(errors, arr[i] != i+1 && arr[i] != i+3);
     }
     OMPVV_ERROR_IF(errors > 0, "Dispatch w/ depend is not working properly");
-    OMPVV_INFOMSG_IF(errors > 0,
+    OMPVV_INFOMSG_IF(errors > 0 || arr[0] == 1,
                    "Dispatch is either not working or was not considered"
                    " by the implementation as part of the context selector.");
     return errors;

--- a/tests/5.1/dispatch/test_dispatch_depend.c
+++ b/tests/5.1/dispatch/test_dispatch_depend.c
@@ -37,7 +37,7 @@ void add_two(int *arr){
     OMPVV_TEST_AND_SET_VERBOSE(errors, a != 3);
     OMPVV_ERROR_IF(errors > 0, "Depend clause on dispatch directive not working properly");
     for (int i = 0; i < N; i++){
-        arr[i] = i+a; // Variant function adds 2 to array values
+        arr[i] = i+a; // Variant function adds 3 to array values
     }
 }
 

--- a/tests/5.1/dispatch/test_dispatch_depend.c
+++ b/tests/5.1/dispatch/test_dispatch_depend.c
@@ -1,0 +1,67 @@
+//===---- test_dispatch_depend.c -----------------------------------------===//
+// 
+// OpenMP API Version 5.1
+//
+// Uses dispatch construct as context for variant directive. Uses depend clause
+// which adds depend property to the interoperability requirement set.
+//
+// Inspired by "OpenMP 5.1 Features: The Dispatch Construct" video:
+// https://www.youtube.com/watch?v=ruugaX95gIs
+// 
+//===-------------------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include "ompvv.h"
+
+#define N 1024
+
+int arr[N]; // implicit map array 
+int errors;
+int i = 0;
+int a;
+
+void add_two(int *arr);
+
+#pragma omp declare variant(add_two) match(construct={dispatch})
+void add(int *arr){
+    for (int i = 0; i < N; i++){ // Base function adds 1 to array values
+        arr[i] = i+1;
+    }
+    #pragma omp task depend(out: a)
+        a = 3;
+}
+
+void add_two(int *arr){
+    OMPVV_TEST_AND_SET_VERBOSE(errors, a != 3);
+    OMPVV_ERROR_IF(errors > 0, "Depend clause on dispatch directive not working properly");
+    for (int i = 0; i < N; i++){
+        arr[i] = i+2; // Variant function adds 2 to array values
+    }
+}
+
+int test_wrapper() { 
+    errors = 0;
+    add(arr);
+    for(i = 0; i < N; i++){
+        OMPVV_TEST_AND_SET_VERBOSE(errors, arr[i] != i+1);
+    } 
+    OMPVV_ERROR_IF(errors > 0, "Base function is not working properly");
+
+    #pragma omp dispatch depend(in: a)
+        add(arr);
+
+    for(i = 0; i < N; i++){
+        OMPVV_TEST_AND_SET_VERBOSE(errors, arr[i] != i+2);
+    }
+    OMPVV_ERROR_IF(errors > 0, "Dispatch w/ depend is not working properly");
+    return errors;
+}
+
+int main () {
+    OMPVV_TEST_OFFLOADING;
+    OMPVV_TEST_AND_SET_VERBOSE(errors, test_wrapper());
+    OMPVV_REPORT_AND_RETURN(errors);
+}  


### PR DESCRIPTION
Compiles with LLVM 16.0.0, but gives 2048 errors. I don't believe the variant function is ever being reached.

I am not sure if my use of **depend** is extensive enough
I am also not sure if I am using variants properly... OpenMP 5.1 examples doc uses it similarly to the way I am doing in this test: https://www.openmp.org/wp-content/uploads/openmp-examples-5.1.pdf#page=458

`void p_vxv(int *v1,int *v2,int *v3,int n);
void t_vxv(int *v1,int *v2,int *v3,int n);

#pragma omp declare variant( p_vxv ) match( construct={parallel} )
#pragma omp declare variant( t_vxv ) match( construct={target} )
void vxv(int *v1,int *v2,int *v3,int n) // base function
{
for (int i= 0; i< n; i++) v3[i] = v1[i] * v2[i];
 }

void p_vxv(int *v1,int *v2,int *v3,int n) // function variant
{
 #pragma omp for
for (int i= 0; i< n; i++) v3[i] = v1[i] * v2[i]*3;
}

#pragma omp declare target
void t_vxv(int *v1,int *v2,int *v3,int n) // function variant
{
 #pragma omp distribute simd
 for (int i= 0; i< n; i++) v3[i] = v1[i] * v2[i]*2;
}
#pragma omp end declare target`