### PR TITLE
add ompx F90 test code

### DIFF
--- a/tests/5.2/implementation_defined/test_ompx.F90
+++ b/tests/5.2/implementation_defined/test_ompx.F90
@@ -1,0 +1,41 @@
+!===-test_ompx.F90-===/
+!
+!
+! OpenMP API Version 5.2 July 2022
+!
+! Testing 'ompx' sentinel
+!
+! 'ompx' sentinel is reserved for
+! implementation-defined extensions to
+! fixed source form OpenMP directives.
+!===-------------------------------===//
+#include "ompvv.F90"
+
+#define N 1024
+PROGRAM test_ompx
+        use iso_fortran_env
+        use ompvv_lib
+        use omp_lib
+        implicit none
+
+        OMPVV_TEST_OFFLOADING
+
+        OMPVV_TEST_VERBOSE(test_fixed_ompx() .ne. 1)
+
+        OMPVV_REPORT_AND_RETURN()
+CONTAINS
+        INTEGER FUNCTION test_fixed_ompx() 
+                INTEGER :: i
+                INTEGER :: errors
+                INTEGER, DIMENSION(10) :: A
+                INTEGER, DIMENSION(10) :: B
+                INTEGER, DIMENSION(10) :: D
+                errors = 0
+                !$omp parallel num_threads(2)
+                !$ompx single
+                        errors = errors + 1
+                !$ompx end single
+                !$omp end parallel
+                test_fixed_ompx = errors
+        END FUNCTION test_fixed_ompx
+END PROGRAM test_ompx

--- a/tests/5.2/implementation_defined/test_ompx_free.F90
+++ b/tests/5.2/implementation_defined/test_ompx_free.F90
@@ -20,11 +20,11 @@ PROGRAM test_ompx
 
         OMPVV_TEST_OFFLOADING
 
-        OMPVV_TEST_VERBOSE(test_fixed_ompx() .ne. 2)
+        OMPVV_TEST_VERBOSE(test_free_ompx() .ne. 2)
 
         OMPVV_REPORT_AND_RETURN()
 CONTAINS
-        INTEGER FUNCTION test_fixed_ompx() 
+        INTEGER FUNCTION test_free_ompx() 
                 INTEGER :: i
                 INTEGER :: n
                 INTEGER :: errors
@@ -39,6 +39,6 @@ CONTAINS
                 do n = 1,2
                         errors = errors + ARR_ERR(n)
                 end do
-                test_fixed_ompx = errors
-        END FUNCTION test_fixed_ompx
+                test_free_ompx = errors
+        END FUNCTION test_free_ompx
 END PROGRAM test_ompx

--- a/tests/5.2/implementation_defined/test_ompx_free.F90
+++ b/tests/5.2/implementation_defined/test_ompx_free.F90
@@ -7,7 +7,7 @@
 !
 ! 'ompx' sentinel is reserved for
 ! implementation-defined extensions to
-! fixed source form OpenMP directives.
+! free source form OpenMP directives.
 !===-------------------------------===//
 #include "ompvv.F90"
 

--- a/tests/5.2/implementation_defined/test_ompx_free.F90
+++ b/tests/5.2/implementation_defined/test_ompx_free.F90
@@ -20,7 +20,7 @@ PROGRAM test_ompx
 
         OMPVV_TEST_OFFLOADING
 
-        OMPVV_TEST_VERBOSE(test_fixed_ompx() .ne. 1)
+        OMPVV_TEST_VERBOSE(test_fixed_ompx() .ne. 2)
 
         OMPVV_REPORT_AND_RETURN()
 CONTAINS
@@ -32,9 +32,8 @@ CONTAINS
                 INTEGER, DIMENSION(10) :: D
                 errors = 0
                 !$omp parallel num_threads(2)
-                !$ompx single
+                !$ompx test_nonexistant
                         errors = errors + 1
-                !$ompx end single
                 !$omp end parallel
                 test_fixed_ompx = errors
         END FUNCTION test_fixed_ompx

--- a/tests/5.2/implementation_defined/test_ompx_free.F90
+++ b/tests/5.2/implementation_defined/test_ompx_free.F90
@@ -26,15 +26,19 @@ PROGRAM test_ompx
 CONTAINS
         INTEGER FUNCTION test_fixed_ompx() 
                 INTEGER :: i
+                INTEGER :: n
                 INTEGER :: errors
-                INTEGER, DIMENSION(10) :: A
-                INTEGER, DIMENSION(10) :: B
-                INTEGER, DIMENSION(10) :: D
+                INTEGER, DIMENSION(2) :: ARR_ERR
                 errors = 0
-                !$omp parallel num_threads(2)
+                !$omp parallel shared(ARR_ERR) private(i)  num_threads(2)
                 !$ompx test_nonexistant
-                        errors = errors + 1
+                        i = omp_get_thread_num()
+                        i = i + 1
+                        ARR_ERR(i) = 1
                 !$omp end parallel
+                do n = 1,2
+                        errors = errors + ARR_ERR(n)
+                end do
                 test_fixed_ompx = errors
         END FUNCTION test_fixed_ompx
 END PROGRAM test_ompx


### PR DESCRIPTION
Preliminary test for ompx sentinel. 
Testing `ompx test_nonexistant`. Code performs as expected and seems to ignore `$!ompx`. 