### PR TITLE
Fix tests/5.1/scope/test_scope_private_construct.c

### DIFF
--- a/tests/5.1/scope/test_scope_private_construct.c
+++ b/tests/5.1/scope/test_scope_private_construct.c
@@ -17,7 +17,7 @@
 int test_scope(){
 	int errors = 0;
 	int test_int = 1;
-	#pragma omp task shared(test_int)
+	#pragma omp parallel shared(test_int)
 	{
 		#pragma omp scope private(test_int)
 		{


### PR DESCRIPTION
This is a follow up to Pull Request #576. It changes the enclosing 'task' to 'parallel' to avoid running into the following restriction for 'scope':

"A **scope** region may not be closely nested inside a worksharing, **loop**, **task**, **taskloop**, **critical**, **ordered**, **atomic**, or **masked** region."

_(GCC actually does diagnose this and fails to compile.)_
* * *
Unchanged – but could be changed:
* There is undefined behavior for the "test_int+=1" code, which should not matter in practice but compilers may warn for those.
 _(GCC with -Wall: "warning: ‘test_int’ is used uninitialized")_

An alternative would be either "firstprivate" or a plain assignment instead of an increment of the value. — Not touch so far by this pull request.
* * *
@mjcarr458 @spophale @nolanbaker31 @jrreap @krishols – please review.