### PR TITLE
tests/5.1/assume/test_assume_no_parallelism.c: Fix var scope issue

### DIFF
--- a/tests/5.1/assume/test_assume_holds.c
+++ b/tests/5.1/assume/test_assume_holds.c
@@ -19,9 +19,9 @@ int errors, i, N;
 
 int test_assume_holds() {
     N = 1024;
+    int arr[N];
     #pragma omp assume holds(N == 1024)
     {
-        int arr[N];
         for(i = 0; i < N; i++){
             arr[i] = i;
         }

--- a/tests/5.1/assume/test_assume_no_openmp_routines.c
+++ b/tests/5.1/assume/test_assume_no_openmp_routines.c
@@ -18,9 +18,9 @@
 int errors, i;
 
 int test_assume_no_openmp_routines() {
+    int arr[N];
     #pragma omp assume no_openmp_routines
     {
-        int arr[N];
         for(i = 0; i < N; i++){
             arr[i] = i;
         }

--- a/tests/5.1/assume/test_assume_no_parallelism.c
+++ b/tests/5.1/assume/test_assume_no_parallelism.c
@@ -18,10 +18,11 @@
 int errors, i;
 
 int test_assume_no_parallelism() {
+    int x;
+    int arr[N];
     #pragma omp assume no_parallelism
     {
-        int x = omp_get_thread_num(); // OMP runtime routine; should be 0
-        int arr[N];
+        x = omp_get_thread_num(); // OMP runtime routine; should be 0
         for(i = 0; i < N; i++){
             arr[i] = i + x;
         }


### PR DESCRIPTION
In my understanding, variables declare inside the curly braces of
```C
#pragma omp assume ...
   { ... }
```
are not visible outside. Hence, the 'arr' and 'x' need to be declared before the assume construct.

@mjcarr458 @spophale @nolanbaker31 @jrreap @krishols – please review.

_Side remark: While my older clang version errors out because of the unsupported 'assume' ("error: expected an OpenMP directive"), GCC only warns ("warning: ignoring ‘#pragma omp assume’ [-Wunknown-pragmas]")_