### PR TITLE
ompvv/ompvv.h: Parenthesize error condition in OMPVV_REPORT+OMPVV_RETURN

### DIFF
--- a/ompvv/ompvv.h
+++ b/ompvv/ompvv.h
@@ -80,14 +80,14 @@ _Pragma("omp target map (from: _ompvv_isOffloadingOn)") \
 #define OMPVV_REPORT(err) { \
   OMPVV_INFOMSG("The value of " #err " is %d.", err); \
   if (_ompvv_isOffloadingOn == -1) \
-    printf("[OMPVV_RESULT: %s] Test %s.\n", __FILENAME__, (err == 0)? "passed":"failed"); \
+    printf("[OMPVV_RESULT: %s] Test %s.\n", __FILENAME__, ((err) == 0)? "passed":"failed"); \
   else \
-    printf("[OMPVV_RESULT: %s] Test %s on the %s.\n", __FILENAME__, (err == 0)? "passed":"failed", (_ompvv_isOffloadingOn)? "device" : "host"); \
+    printf("[OMPVV_RESULT: %s] Test %s on the %s.\n", __FILENAME__, ((err) == 0)? "passed":"failed", (_ompvv_isOffloadingOn)? "device" : "host"); \
 }
 
 // Macro for correct exit code
 #define OMPVV_RETURN(err) { \
-  return (err == 0) ? EXIT_SUCCESS : EXIT_FAILURE; \
+  return ((err) == 0) ? EXIT_SUCCESS : EXIT_FAILURE; \
 }
 
 // Macro for report and exit


### PR DESCRIPTION
Silences:
```
warning: suggest parentheses around comparison in operand of ‘==’ [-Wparentheses]
  143 |     OMPVV_REPORT_AND_RETURN(error_sum != 0.0);
ompvv/ompvv.h:90:11: note: in definition of macro ‘OMPVV_RETURN’
   90 |   return (err == 0) ? EXIT_SUCCESS : EXIT_FAILURE; \
```
@mjcarr458 @spophale @nolanbaker31 @jrreap @krishols – please review.