### PR TITLE
fix-test_target_simd_nontemporal.c: Fix directive

### DIFF
--- a/tests/5.0/target_simd/test_target_simd_nontemporal.c
+++ b/tests/5.0/target_simd/test_target_simd_nontemporal.c
@@ -27,7 +27,7 @@ int test_simd_nontemporal() {
       c[i] = 2 * i;
    }   
 
-   #pragma simd target nontemporal (a, b, c)
+   #pragma omp target simd nontemporal (a, b, c)
       for (i = 0; i < N; i += STRIDE_LEN) {
          a[i] = b[i] * c[i];
       }   


### PR DESCRIPTION
Change '#pragma simd target' to be '#pragma omp target simd'.

Rather obvious fix, once found.

@tmh97 @spophale @seyonglee @jrreap @AnonNick @krishols @mjcarr458 @nolanbaker31 – please review

_(It turned out that adding `-Werror=unknown-pragmas` to our internal testsuite was a good idea; I just have to see how to handle '#pragma ompx' once there is a testcase [→ Pull Request 602] ...)_