### PR TITLE
test_parallel_for_reduction_task_device.c: Fix directive

### DIFF
--- a/tests/5.0/task/test_parallel_for_reduction_task_device.c
+++ b/tests/5.0/task/test_parallel_for_reduction_task_device.c
@@ -30,7 +30,7 @@ int test_parallel_for_reduction_task() {
     z[i] = 2*(i + 1);
   }
 
-#pragma target map(tofrom: sum, y, z, num_threads)
+#pragma omp target map(tofrom: sum, y, z, num_threads)
   {
 #pragma omp parallel for reduction(task, +: sum) num_threads(OMPVV_NUM_THREADS_DEVICE) shared(y, z, num_threads)
     for (int i = 0; i < N; i++) {


### PR DESCRIPTION
Change 'target map' to 'omp target map'.

Rather obvious fix, once found.

@tmh97 @spophale @seyonglee @jrreap @AnonNick @krishols @mjcarr458 @nolanbaker31 – please review

_I had combined this PR with PR 612 if I had seen it earlier that both had the same issue; to keep a sensible subject line, I did not add the commit to the other PR._