### PR TITLE
Test Depend inoutset

### DIFF
--- a/tests/5.1/depend/test_depend_inoutset.c
+++ b/tests/5.1/depend/test_depend_inoutset.c
@@ -20,6 +20,9 @@
 int errors;
 int arr[N];
 int depend_inoutset(){
+  for(int i = 0; i < N; i++){
+    arr[i] = 0;
+  }
   #pragma omp parallel
   #pragma omp single
   {

--- a/tests/5.1/depend/test_depend_inoutset.c
+++ b/tests/5.1/depend/test_depend_inoutset.c
@@ -13,32 +13,36 @@
 #include "ompvv.h"
 #include <math.h>
 
-int errors;
+#define N 1024
 
+int errors;
+int arr[N];
 int depend_inoutset(){
-    #pragma omp parallel
-#pragma omp single
+  #pragma omp parallel
+  #pragma omp single
   {
-#pragma omp task depend(out: c)
-   c = 1; /* Task T1 */
- #pragma omp task depend(out: a)
-   a = 2; /* Task T2 */
- #pragma omp task depend(out: b)
-   b = 3; /* Task T3 */
- #pragma omp task depend(in: a) depend(inoutset: c)
-   c += a; /* Task T4 */
- #pragma omp task depend(in: b) depend(inoutset: c)
-   c += b; /* Task T5 */
- #pragma omp task depend(in: c)
-   d = c; /* Task T6 */
+    for(int i = 0; i < N; i++){
+      #pragma omp task depend(out: arr[i])
+      arr[i] = i + 1;
+    }
+    for(int i = 0; i < N; i++){
+      #pragma omp task depend(inoutset: arr[i])
+      arr[i] = arr[i] + 2;
+    }
+    for(int i = 0; i < N; i++){
+      #pragma omp task depend(inoutset: arr[i])
+      arr[i] = arr[i] + 3;
+    }
   }
-  OMPVV_TEST_AND_SET_VERBOSE(errors, d != 6);
+  for(int i = 0; i < N; i++){
+    OMPVV_TEST_AND_SET_VERBOSE(errors, arr[i] != i + 6);
+  }
   return errors;
 }
 
 int main() {
    errors = 0;
    OMPVV_TEST_OFFLOADING;
-   OMPVV_TEST_AND_SET_VERBOSE(errors, test_depend_intouset() != 0);
+   OMPVV_TEST_AND_SET_VERBOSE(errors, depend_inoutset() != 0);
    OMPVV_REPORT_AND_RETURN(errors);
 }

--- a/tests/5.1/depend/test_depend_inoutset.c
+++ b/tests/5.1/depend/test_depend_inoutset.c
@@ -38,6 +38,7 @@ int depend_inoutset(){
     OMPVV_TEST_AND_SET_VERBOSE(errors, arr[i] != i + 6);
   }
   return errors;
+
 }
 
 int main() {
@@ -45,4 +46,5 @@ int main() {
    OMPVV_TEST_OFFLOADING;
    OMPVV_TEST_AND_SET_VERBOSE(errors, depend_inoutset() != 0);
    OMPVV_REPORT_AND_RETURN(errors);
+   
 }

--- a/tests/5.1/depend/test_depend_inoutset.c
+++ b/tests/5.1/depend/test_depend_inoutset.c
@@ -2,8 +2,10 @@
 //
 //  OpenMP API Version 5.1 Aug 2021
 //
-//  This test verifies the use of inoutset in depend clause.
-//  Task T4 & T5 both rely on the use of c, and should run in any order.
+//  This test verifies the use of inoutset in depend clause. The 'mutexinoutset'
+//  clause is mutually exclusive when running, meaning that the tasks must be
+//  seperate from one another. Inoutset, on the other hand, is not mutually
+//  exclusive with itself. 
 //
 ////===----------------------------------------------------------------------===//
 

--- a/tests/5.1/depend/test_depend_inoutset.c
+++ b/tests/5.1/depend/test_depend_inoutset.c
@@ -1,0 +1,44 @@
+//===--- test_depend_inoutset.c ----------------------------===//
+//
+//  OpenMP API Version 5.1 Aug 2021
+//
+//  This test verifies the use of inoutset in depend clause.
+//  Task T4 & T5 both rely on the use of c, and should run in any order.
+//
+////===----------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+#include <math.h>
+
+int errors;
+
+int depend_inoutset(){
+    #pragma omp parallel
+#pragma omp single
+  {
+#pragma omp task depend(out: c)
+   c = 1; /* Task T1 */
+ #pragma omp task depend(out: a)
+   a = 2; /* Task T2 */
+ #pragma omp task depend(out: b)
+   b = 3; /* Task T3 */
+ #pragma omp task depend(in: a) depend(inoutset: c)
+   c += a; /* Task T4 */
+ #pragma omp task depend(in: b) depend(inoutset: c)
+   c += b; /* Task T5 */
+ #pragma omp task depend(in: c)
+   d = c; /* Task T6 */
+  }
+  OMPVV_TEST_AND_SET_VERBOSE(errors, d != 6);
+  return errors;
+}
+
+int main() {
+   errors = 0;
+   OMPVV_TEST_OFFLOADING;
+   OMPVV_TEST_AND_SET_VERBOSE(errors, test_depend_intouset() != 0);
+   OMPVV_REPORT_AND_RETURN(errors);
+}


### PR DESCRIPTION
Confused as to the difference between this & mutexinoutset introduced in 5.0. It is clear that the spec states that mutexinoutset dependencies are mutually exclusive, and doesn't state this for outset, but the behavior/use of using inoutset is unclear to me.

Test based on 5.0/task/test_task_depend_mutexinoutset.c test