### PR TITLE
Atomic Fail test

### DIFF
--- a/tests/5.1/atomic/test_atomic_fail_acquire.c
+++ b/tests/5.1/atomic/test_atomic_fail_acquire.c
@@ -1,6 +1,6 @@
-//===--- test_atomic_fail_acquire.c - test write release and read aquire--===//
+//===--- test_atomic_fail_acquire.c -----------------------------------------===//
 //
-// OpenMP API Version 5.0 Nov 2018
+// OpenMP API Version 5.1 Nov 2020
 //
 // Utilizes an atomic seq_cst w/ an atomic release to ensure the implicit
 // setting of x=10. Restrictions on atomic fail state they must be used

--- a/tests/5.1/atomic/test_atomic_fail_acquire.c
+++ b/tests/5.1/atomic/test_atomic_fail_acquire.c
@@ -1,0 +1,52 @@
+//===--- test_atomic_fail_acquire.c - test write release and read aquire--===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// Utilizes an atomic seq_cst w/ an atomic release to ensure the implicit
+// setting of x=10. Restrictions on atomic fail state they must be used
+// on an atomic compare.
+//
+////===----------------------------------------------------------------------===//
+#include <assert.h>
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+int test_atomic_fail_acquire() {
+  OMPVV_INFOMSG("test_atomic_fail_acquire");
+
+  int x = 0, y = 0;
+  int errors = 0;
+
+#pragma omp parallel num_threads(2)
+   {
+      int thrd = omp_get_thread_num();
+       if (thrd == 0) {
+          y = 1;
+          #pragma omp atomic write release // or seq_cst
+          x = 10;
+       } else {
+          int tmp = 0;
+          while (y != 5) {
+            #pragma omp atomic compare seq_cst fail(acquire)
+            if(y == 1){
+               y = 5;
+            }
+          }
+          OMPVV_TEST_AND_SET(errors, x != 10);
+          OMPVV_TEST_AND_SET(errors, y != 5);
+       }
+   }
+   return errors;
+}
+
+
+int main() {
+  int errors = 0;
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_atomic_fail_acquire());
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.1/atomic/test_atomic_fail_relaxed.c
+++ b/tests/5.1/atomic/test_atomic_fail_relaxed.c
@@ -1,6 +1,6 @@
-//===--- test_atomic_fail_relaxed.c - test write release and read aquire--===//
+//===--- test_atomic_fail_relaxed.c -----------------------------------------===//
 //
-// OpenMP API Version 5.0 Nov 2018
+// OpenMP API Version 5.1 Nov 2020
 //
 // Utilizes an compare w/ an atomic release to ensure the implicit
 // setting of x=10. Restrictions on atomic fail state they must be used

--- a/tests/5.1/atomic/test_atomic_fail_relaxed.c
+++ b/tests/5.1/atomic/test_atomic_fail_relaxed.c
@@ -1,0 +1,52 @@
+//===--- test_atomic_fail_relaxed.c - test write release and read aquire--===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// Utilizes an compare w/ an atomic release to ensure the implicit
+// setting of x=10. Restrictions on atomic fail state they must be used
+// on an atomic compare.
+//
+////===----------------------------------------------------------------------===//
+#include <assert.h>
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+int test_atomic_fail_relaxed() {
+  OMPVV_INFOMSG("test_atomic_fail_relaxed");
+
+  int x = 0, y = 0;
+  int errors = 0;
+
+#pragma omp parallel num_threads(2)
+   {
+      int thrd = omp_get_thread_num();
+       if (thrd == 0) {
+          y = 1;
+          #pragma omp atomic write release // or seq_cst
+          x = 10;
+       } else {
+          int tmp = 0;
+          while (y != 5) {
+            #pragma omp atomic compare fail(relaxed)
+            if(y == 1){
+               y = 5;
+            }
+          }
+          OMPVV_TEST_AND_SET(errors, x != 10);
+          OMPVV_TEST_AND_SET(errors, y != 5);
+       }
+   }
+   return errors;
+}
+
+
+int main() {
+  int errors = 0;
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_atomic_fail_relaxed());
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.1/atomic/test_atomic_fail_seq_cst.c
+++ b/tests/5.1/atomic/test_atomic_fail_seq_cst.c
@@ -1,0 +1,52 @@
+//===--- test_atomic_fail_seq_cst.c - test write release and read aquire--===//
+//
+// OpenMP API Version 5.0 Nov 2018
+//
+// Utilizes an atomic acquire w/ an atomic release to ensure the implicit
+// setting of x=10. Restrictions on atomic fail state they must be used
+// on an atomic compare.
+//
+////===----------------------------------------------------------------------===//
+#include <assert.h>
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+int test_atomic_fail_seq_cst() {
+  OMPVV_INFOMSG("test_atomic_fail_seq_cst");
+
+  int x = 0, y = 0;
+  int errors = 0;
+
+#pragma omp parallel num_threads(2)
+   {
+      int thrd = omp_get_thread_num();
+       if (thrd == 0) {
+          y = 1;
+          #pragma omp atomic write release // or seq_cst
+          x = 10;
+       } else {
+          int tmp = 0;
+          while (y != 5) {
+            #pragma omp atomic compare acquire fail(seq_cst)
+            if(y == 1){
+               y = 5;
+            }
+          }
+          OMPVV_TEST_AND_SET(errors, x != 10);
+          OMPVV_TEST_AND_SET(errors, y != 5);
+       }
+   }
+   return errors;
+}
+
+
+int main() {
+  int errors = 0;
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_atomic_fail_seq_cst());
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.1/atomic/test_atomic_fail_seq_cst.c
+++ b/tests/5.1/atomic/test_atomic_fail_seq_cst.c
@@ -1,6 +1,6 @@
-//===--- test_atomic_fail_seq_cst.c - test write release and read aquire--===//
+//===--- test_atomic_fail_seq_cst.c -----------------------------------------===//
 //
-// OpenMP API Version 5.0 Nov 2018
+// OpenMP API Version 5.1 Nov 2020
 //
 // Utilizes an atomic acquire w/ an atomic release to ensure the implicit
 // setting of x=10. Restrictions on atomic fail state they must be used


### PR DESCRIPTION
Tests pass on GCC 12.1.

Not really testing "fail clause", as much as ensuring it compiles, not sure of a method for testing them directly.