### PR TITLE
Fix test_metadirective_nothing.c

### DIFF
--- a/tests/5.1/metadirective/test_metadirective_nothing.c
+++ b/tests/5.1/metadirective/test_metadirective_nothing.c
@@ -35,11 +35,9 @@ int metadirectiveOnDevice() {
          when( device={arch("nvptx")}: nothing) \
          when( implementation={vendor(amd)}: nothing ) \
          default( parallel for)
-         {
             for (int i = 0; i < N; i++) {
                A[i] += omp_in_parallel();
             }
-         }
    }
 
    for (int i = 0; i < N; i++) {
@@ -67,12 +65,9 @@ int metadirectiveOnHost() {
      when( device={arch("nvptx")}: parallel for) \
      when( implementation={vendor(amd)}: parallel for ) \
      default( nothing )
-     {
         for (int i = 0; i < N; i++) {
            A[i] += omp_in_parallel();
         }
-     }
-
 
   OMPVV_WARNING_IF(A[0] == 1, "Even though no devices were available the test recognized kind/arch equal to nohost or nvptx or amd");
   


### PR DESCRIPTION
After a loop-associated construct, a loop-nest must follow. In C/C++, that's 'for' and not a '{' ... '}' block with a contained 'for'. The metadirective uses besides 'nothing': 'parallel for'. This is a combined/composite construct with a worksharing-loop, which is loop-associated construct.

@nolanbaker31 @spophale @jrreap @krishols @mjcarr458  – please review

See also OpenMP 5.1:
* https://www.openmp.org/spec-html/5.1/openmpsu73.html (2.16.1  Parallel Worksharing-Loop Construct) 
* https://www.openmp.org/spec-html/5.1/openmpsu45.html ("loop-nest — One of the following:")