### PR TITLE
Avoid stack allocation for test_requires_unified_shared_memory_heap*

### DIFF
--- a/tests/5.0/requires/test_requires_unified_shared_memory_heap.F90
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_heap.F90
@@ -32,13 +32,13 @@ CONTAINS
   INTEGER FUNCTION unified_shared_memory_heap()
     INTEGER:: errors, i
     INTEGER, ALLOCATABLE:: anArray(:)
-    INTEGER, DIMENSION(N):: anArrayCopy
+    INTEGER, ALLOCATABLE:: anArrayCopy(:)
 
     OMPVV_INFOMSG("Unified shared memory testing - Array on heap")
 
     errors = 0
 
-    ALLOCATE(anArray(N))
+    ALLOCATE(anArray(N), anArrayCopy(N))
 
     OMPVV_ERROR_IF(.NOT. ALLOCATED(anArray), "Memory was not properly allocated")
 
@@ -74,9 +74,7 @@ CONTAINS
       END IF
     END DO
     
-    DEALLOCATE(anArray)
+    DEALLOCATE(anArray, anArrayCopy)
     unified_shared_memory_heap = errors
   END FUNCTION unified_shared_memory_heap
 END PROGRAM test_requires_unified_shared_memory_heap
-      
-   

--- a/tests/5.0/requires/test_requires_unified_shared_memory_heap.c
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_heap.c
@@ -22,9 +22,10 @@ int unified_shared_memory_heap() {
   int errors = 0;
   
   int *anArray;
-  int anArrayCopy[N];
+  int *anArrayCopy;
 
   anArray = (int*)malloc(sizeof(int)*N);
+  anArrayCopy = (int*)malloc(sizeof(int)*N);
 
   for (int i = 0; i < N; i++) {
     anArray[i] = i;
@@ -57,6 +58,7 @@ int unified_shared_memory_heap() {
   }
 
   free(anArray);
+  free(anArrayCopy);
   return errors;
 }
 int main() {

--- a/tests/5.0/requires/test_requires_unified_shared_memory_heap_is_device_ptr.c
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_heap_is_device_ptr.c
@@ -22,9 +22,10 @@ int unified_shared_memory_heap() {
   int errors = 0;
   
   int *anArray;
-  int anArrayCopy[N];
+  int *anArrayCopy;
 
   anArray = (int*)malloc(sizeof(int)*N);
+  anArrayCopy = (int*)malloc(sizeof(int)*N);
 
   for (int i = 0; i < N; i++) {
     anArray[i] = i;
@@ -57,6 +58,7 @@ int unified_shared_memory_heap() {
   }
 
   free(anArray);
+  free(anArrayCopy);
   return errors;
 }
 int main() {

--- a/tests/5.0/requires/test_requires_unified_shared_memory_heap_map.F90
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_heap_map.F90
@@ -36,16 +36,16 @@ CONTAINS
   INTEGER FUNCTION unified_shared_memory_heap_map()
     INTEGER:: errors, i
     INTEGER, ALLOCATABLE:: anArray(:)
-    INTEGER, DIMENSION(N):: anArrayCopy
+    INTEGER, ALLOCATABLE:: anArrayCopy(:)
     INTEGER:: ERR
 
     OMPVV_INFOMSG("Unified shared memory testing - Array on heap")
 
     errors = 0
 
-    ALLOCATE(anArray(N), STAT=ERR)
+    ALLOCATE(anArray(N), anArrayCopy(N), STAT=ERR)
 
-    IF( .NOT. ALLOCATED(anArray) ) THEN
+    IF( ERR /= 0 ) THEN
       OMPVV_ERROR("Memory was not properly allocated")
       OMPVV_RETURN(ERR)
     END IF
@@ -82,7 +82,7 @@ CONTAINS
       END IF
     END DO
     
-    DEALLOCATE(anArray)
+    DEALLOCATE(anArray, anArrayCopy)
     unified_shared_memory_heap_map = errors
   END FUNCTION unified_shared_memory_heap_map
 END PROGRAM test_requires_unified_shared_memory_heap_map

--- a/tests/5.0/requires/test_requires_unified_shared_memory_heap_map.c
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_heap_map.c
@@ -23,9 +23,10 @@ int unified_shared_memory_heap_map() {
   int errors = 0;
   
   int *anArray;
-  int anArrayCopy[N];
+  int *anArrayCopy;
 
   anArray = (int*)malloc(sizeof(int)*N);
+  anArrayCopy = (int*)malloc(sizeof(int)*N);
   if( anArray == NULL ) {
     OMPVV_ERROR("Memory was not properly allocated");
     OMPVV_RETURN(1);
@@ -62,6 +63,7 @@ int unified_shared_memory_heap_map() {
   }
 
   free(anArray);
+  free(anArrayCopy);
   return errors;
 }
 int main() {


### PR DESCRIPTION
Some (pseuo)USM implementations allocate memory in a special memory section that permits either direct memory access (DMA) from the device or on-access migration. In that case, stack and static memory may or may not be accessible.

This pull request changes the test_requires_unified_shared_memory_heap{,_map,_is_device_ptr}.{c,F90} testcases such that only heap memory is used on the device. The existing test_unified_shared_memory*.* testcases handle the other variants.

@nolanbaker31 @spophale @jrreap @krishols @mjcarr458 – please review

_This is a consistency fix – permitting a partial pass with pseudo USM. For full USM, kernel + hardware support is required to access all memory. I some (but not all) post-Pascal Nvidia cards permit to access all memory and, if I understood it correctly_ (big “if”), _AMD cards since VEGA support accessing all memory in principle, but effectively, only gfx90a (MI 200 series) permits fast access and has proper._