### PR TITLE
ompt_state_wait_barrier_teams test

### DIFF
--- a/tests/5.1/ompt/test_ompt_state_wait_barrier_teams.c
+++ b/tests/5.1/ompt/test_ompt_state_wait_barrier_teams.c
@@ -1,0 +1,31 @@
+//-----------------test_ompt_state_wait_barrier_teams-----------------------
+//
+// OpenMP API Version 5.1 Oct 2022
+//
+// This test is designed to test the ompt_state_t barrier teams member
+// field. The test will access the ompt_state_wait_barrier_teams to ensure 
+// it is being properly set.
+// 
+// ------------------------------------------------------------------------
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <omp-tools.h>
+#include "ompvv.h"
+
+int test_case(){
+	int errors = 0;
+	int test_val = 0;
+	test_val = ompt_state_wait_barrier_teams;
+	OMPVV_TEST_AND_SET_VERBOSE(errors, test_val != 22);
+	OMPVV_INFOMSG_IF(test_val == 0, "local test variable was not overwritten");
+	return errors;
+}
+
+int main() {
+	int errors = 0;
+	OMPVV_TEST_OFFLOADING;
+	OMPVV_TEST_AND_SET_VERBOSE(errors, test_case() != 0);
+	OMPVV_REPORT_AND_RETURN(errors);
+}


### PR DESCRIPTION
Currently calls and checks the value of ompt_state_wait_barrier_teams enum. Should this test be adapted to check for a thread in that state or is that unnecessary complexity?