### PR TITLE
Target_Device context selector

### DIFF
--- a/tests/5.1/metadirective/test_metadirective_target_device.c
+++ b/tests/5.1/metadirective/test_metadirective_target_device.c
@@ -26,7 +26,7 @@ int test_metadirective_target_device() {
    {
       #pragma omp parallel num_threads(4)
       {
-      // We expect at least one of these when conditons to eval to true, thus having the nothing directive utilized
+      // Except that one of these are true, so the array should be set to masked thread num (0)
       #pragma omp metadirective \
          when( target_device={kind(nohost)}: masked ) \
          when( target_device={arch("nvptx")}: masked ) \

--- a/tests/5.1/metadirective/test_metadirective_target_device.c
+++ b/tests/5.1/metadirective/test_metadirective_target_device.c
@@ -1,0 +1,63 @@
+//===--------------------- test_metadirective_target_device.c ---------------------===//
+//
+// OpenMP API Version 5.1 Nov 2020
+// 
+// Tests that target_device is recognized & will work properly when matching an nvidia
+// GPU.
+//
+////===---------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+int test_metadirective_target_device() {
+   int errors = 0;
+   int A[N];
+
+   for (int i = 0; i < N; i++) {
+      A[i] = 1;
+   }
+
+   #pragma omp target map(tofrom: A)
+   {
+      #pragma omp parallel num_threads(4)
+      {
+      // We expect at least one of these when conditons to eval to true, thus having the nothing directive utilized
+      #pragma omp metadirective \
+         when( target_device={kind(nohost)}: masked ) \
+         when( target_device={arch("nvptx")}: masked ) \
+         when( implementation={vendor(amd)}: masked ) \
+         default( for)
+            for (int i = 0; i < N; i++) {
+               A[i] = omp_get_thread_num();
+            }
+      }
+   }
+
+   for (int i = 0; i < N; i++) {
+      OMPVV_TEST_AND_SET(errors, A[i] != 0);
+   }
+
+   OMPVV_INFOMSG("Test ran with a number of available devices greater than 0");
+
+   return errors;
+}
+
+int main () {
+  int errors = 0;
+  OMPVV_TEST_OFFLOADING;
+
+  if (omp_get_num_devices() > 0) {
+    errors = test_metadirective_target_device();
+  } else {
+    OMPVV_INFOMSG("Cannot test target_device without a target device!")
+  }
+
+  OMPVV_REPORT_AND_RETURN(errors);
+
+  return 0;
+}

--- a/tests/5.1/metadirective/test_metadirective_target_device.c
+++ b/tests/5.1/metadirective/test_metadirective_target_device.c
@@ -28,9 +28,10 @@ int test_metadirective_target_device() {
       {
       // Except that one of these are true, so the array should be set to masked thread num (0)
       #pragma omp metadirective \
-         when( target_device={kind(nohost)}: masked ) \
          when( target_device={arch("nvptx")}: masked ) \
          when( implementation={vendor(amd)}: masked ) \
+         when (implementation={vendor(nvidia)}: masked) \
+         when( target_device={kind(nohost)}: masked ) \
          default( for)
             for (int i = 0; i < N; i++) {
                A[i] = omp_get_thread_num();


### PR DESCRIPTION
Not sure what I would use for AMD arch.
Fails on GCC 12.2.1 w/ message:

`internal compiler error: Segmentation fault
   34 |          default( for)
      |                   ^~~
0x109cace3 crash_signal
	/autofs/nccs-svm1_proj/stf010/elwasif/gccbuild/src/gcc/gcc/toplev.cc:322
0x10805c0b omp_dynamic_cond
	/autofs/nccs-svm1_proj/stf010/elwasif/gccbuild/src/gcc/gcc/omp-general.cc:2093
0x1080b4a3 omp_dynamic_selector_p`

Fails on LLVM w/ message: 
`'target_device' is not a valid context set in a `declare variant``