### PR TITLE
Add a new test (test/5.0/loop/test_loop_bind_device.F90)

### DIFF
--- a/tests/5.0/loop/test_loop_bind_device.F90
+++ b/tests/5.0/loop/test_loop_bind_device.F90
@@ -1,0 +1,246 @@
+!===--- test_loop_bind_device.F90 ------------------------------------------===//
+!
+! OpenMP API Version 5.0 Nov 2018
+!
+! This test checks the loop directive with the bind(binding) clause. The bind
+! clause indicates that the loop construct should apply in the context of the
+! given binding, one of teams, parallel, or thread. Each of these bindings
+! is tested in an appropriate context and the correctness of results of
+! array operations in the nested loop is checked. This test checks these
+! directives in a target context.
+!
+!//===----------------------------------------------------------------------===//
+
+#include "ompvv.F90"
+
+#define N 32
+
+PROGRAM test_loop_bind_device
+  USE iso_fortran_env
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+
+  OMPVV_TEST_VERBOSE(test_bind_teams() .NE. 0)
+  OMPVV_TEST_VERBOSE(test_bind_parallel() .NE. 0)
+  OMPVV_TEST_VERBOSE(test_bind_thread_teams() .NE. 0)
+  OMPVV_TEST_VERBOSE(test_bind_thread_parallel() .NE. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION test_bind_teams()
+    INTEGER,DIMENSION(N,N):: x
+    INTEGER,DIMENSION(N):: y
+    INTEGER,DIMENSION(N):: z
+    INTEGER:: errors, num_teams, i, j
+
+    OMPVV_INFOMSG("test_loop_bind_teams")
+
+    errors = 0
+    num_teams = -1
+
+    DO i = 1, N
+       DO j = 1, N
+          x(j,i) = 1
+       END DO
+       y(i) = i
+       z(i) = 2*i
+    END DO
+
+    !$omp target teams num_teams(OMPVV_NUM_TEAMS_DEVICE) thread_limit(OMPVV_NUM_THREADS_HOST) map(tofrom: x, y, z, num_teams)
+    !$omp loop bind(teams)
+    DO i = 1, N
+       DO j = 1, N
+          x(j,i) = x(j,i) + y(i)*z(i)
+       END DO
+    END DO
+    !$omp end loop
+    !$omp parallel if(.FALSE.)
+    IF ( omp_get_team_num() .EQ. 0 ) THEN
+       num_teams = omp_get_num_teams()
+    END IF
+    !$omp end parallel
+    !$omp end target teams
+
+    DO i = 1, N
+       DO j = 1, N
+          OMPVV_TEST_AND_SET_VERBOSE(errors, x(j,i) .NE. (1 + y(i)*z(i)))
+       END DO
+    END DO
+
+    OMPVV_WARNING_IF(num_teams .EQ. 1, "Test ran with one team, so parallelism of loop construct with bind(teams) can't be guaranteed.")
+    OMPVV_TEST_AND_SET_VERBOSE(errors, num_teams .LT. 1)
+    OMPVV_ERROR_IF(num_teams .LT. 1, "omp_get_num_teams() returned an invalid number of teams.")
+
+    test_bind_teams = errors
+  END FUNCTION test_bind_teams
+
+  INTEGER FUNCTION test_bind_parallel()
+    INTEGER,DIMENSION(N,N):: x
+    INTEGER,DIMENSION(N):: y
+    INTEGER,DIMENSION(N):: z
+    INTEGER:: errors, num_threads, i, j
+
+    OMPVV_INFOMSG("test_loop_bind_parallel")
+
+    errors = 0
+    num_threads = -1
+
+    DO i = 1, N
+       DO j = 1, N
+          x(j,i) = 1
+       END DO
+       y(i) = i
+       z(i) = 2*i
+    END DO
+
+    !$omp target parallel num_threads(OMPVV_NUM_THREADS_HOST) map(tofrom: x, y, z, num_threads)
+    !$omp loop bind(parallel)
+    DO i = 1, N
+       DO j = 1, N
+          x(j,i) = x(j,i) + y(i)*z(i)
+       END DO
+    END DO
+    !$omp end loop
+    IF ( (omp_get_thread_num() .EQ. 0) .AND. (omp_get_team_num() .EQ. 0) ) THEN
+       num_threads = omp_get_num_threads()
+    END IF
+    !$omp end target parallel
+
+    DO i = 1, N
+       DO j = 1, N
+          OMPVV_TEST_AND_SET_VERBOSE(errors, x(j,i) .NE. (1 + y(i)*z(i)))
+       END DO
+    END DO
+
+    OMPVV_WARNING_IF(num_threads .EQ. 1, "Test ran with one thread, so parallelism of loop construct can't be guaranteed.")
+    OMPVV_TEST_AND_SET_VERBOSE(errors, num_threads .LT. 1)
+    OMPVV_ERROR_IF(num_threads .LT. 1, "omp_get_num_threads() returned an invalid number of threads.")
+
+    test_bind_parallel = errors
+  END FUNCTION test_bind_parallel
+
+  INTEGER FUNCTION test_bind_thread_teams()
+    INTEGER,DIMENSION(N):: y
+    INTEGER,DIMENSION(N):: z
+    INTEGER,DIMENSION(OMPVV_NUM_TEAMS_DEVICE,N,N):: outData
+    INTEGER,DIMENSION(N,N):: x
+    INTEGER:: errors, num_teams, i, j, k
+
+    OMPVV_INFOMSG("test_loop_bind_thread_teams")
+
+    errors = 0
+    num_teams = -1
+
+    DO i = 1, N
+       DO j = 1, N
+          DO k = 1, OMPVV_NUM_TEAMS_DEVICE
+             outData(k,j,i) = 1
+          END DO
+       END DO
+       y(i) = i
+       z(i) = 2*i
+    END DO
+
+    !$omp target teams num_teams(OMPVV_NUM_TEAMS_DEVICE) thread_limit(OMPVV_NUM_THREADS_HOST) private(x) map(tofrom: outData, y, z, num_teams)
+    DO i = 1, N
+       DO j = 1, N
+          x(j,i) = 1
+       END DO
+    END DO
+    !$omp loop bind(thread)
+    DO i = 1, N
+       DO j = 1, N
+          x(j,i) = x(j,i) + y(i)*z(i)
+       END DO
+    END DO
+    !$omp end loop
+    !$omp parallel if(.FALSE.)
+    IF ( omp_get_team_num() .EQ. 0 ) THEN
+       num_teams = omp_get_num_teams()
+    END IF
+    !$omp end parallel
+    DO i = 1, N
+       DO j = 1, N
+          outData(omp_get_team_num()+1,j,i) = x(j,i)
+       END DO
+    END DO
+    !$omp end target teams
+
+    DO i = 1, N
+       DO j = 1, N
+          DO k = 1, num_teams
+             OMPVV_TEST_AND_SET_VERBOSE(errors, outData(k,j,i) .NE. (1 + y(i)*z(i)))
+          END DO
+       END DO
+    END DO
+
+    OMPVV_WARNING_IF(num_teams .EQ. 1, "Test ran with one team, so parallelism of loop construct can't be guaranteed.")
+    OMPVV_TEST_AND_SET_VERBOSE(errors, num_teams .LT. 1)
+    OMPVV_ERROR_IF(num_teams .LT. 1, "omp_get_num_teams() returned an invalid number of teams.")
+
+    test_bind_thread_teams = errors
+  END FUNCTION test_bind_thread_teams
+
+  INTEGER FUNCTION test_bind_thread_parallel()
+    INTEGER,DIMENSION(N):: y
+    INTEGER,DIMENSION(N):: z
+    INTEGER,DIMENSION(OMPVV_NUM_THREADS_HOST,N,N):: outData
+    INTEGER,DIMENSION(N,N):: x
+    INTEGER:: errors, num_threads, i, j, k
+
+    OMPVV_INFOMSG("test_loop_bind_thread_parallel")
+
+    errors = 0
+    num_threads = -1
+
+    DO i = 1, N
+       DO j = 1, N
+          DO k = 1, OMPVV_NUM_THREADS_HOST
+             outData(k,j,i) = 1
+          END DO
+       END DO
+       y(i) = i
+       z(i) = 2*i
+    END DO
+
+    !$omp target parallel shared(outData) num_threads(OMPVV_NUM_THREADS_HOST) private(x) map(tofrom: outData, y, z, num_threads)
+    DO i = 1, N
+       DO j = 1, N
+          x(j,i) = 1
+       END DO
+    END DO
+    !$omp loop bind(thread)
+    DO i = 1, N
+       DO j = 1, N
+          x(j,i) = x(j,i) + y(i)*z(i)
+       END DO
+    END DO
+    !$omp end loop
+    IF ( omp_get_thread_num() .EQ. 0 ) THEN
+       num_threads = omp_get_num_threads()
+    END IF
+    DO i = 1, N
+       DO j = 1, N
+          outData(omp_get_thread_num()+1,j,i) = x(j,i)
+       END DO
+    END DO
+    !$omp end target parallel
+
+    DO i = 1, N
+       DO j = 1, N
+          DO k = 1, num_threads
+             OMPVV_TEST_AND_SET_VERBOSE(errors, outData(k,j,i) .NE. (1 + y(i)*z(i)))
+          END DO
+       END DO
+    END DO
+
+    OMPVV_WARNING_IF(num_threads .EQ. 1, "Test ran with one thread, so parallelism of loop construct can't be guaranteed.")
+    OMPVV_TEST_AND_SET_VERBOSE(errors, num_threads .LT. 1)
+    OMPVV_ERROR_IF(num_threads .LT. 1, "omp_get_num_threads() returned an invalid number of threads.")
+
+    test_bind_thread_parallel = errors
+  END FUNCTION test_bind_thread_parallel
+
+END PROGRAM test_loop_bind_device

--- a/tests/5.0/loop/test_loop_bind_device.c
+++ b/tests/5.0/loop/test_loop_bind_device.c
@@ -57,7 +57,7 @@ int test_loop_bind_teams() {
 
   OMPVV_WARNING_IF(num_teams == 1, "Test ran with one team, so parallelism of loop construct with bind(teams) can't be guaranteed.");
   OMPVV_TEST_AND_SET_VERBOSE(errors, num_teams < 1);
-  OMPVV_ERROR_IF(num_teams < 1, "omp_get_num_teams() returned an invalid value.");
+  OMPVV_ERROR_IF(num_teams < 1, "omp_get_num_teams() returned an invalid number of teams.");
 
   return errors;
 }


### PR DESCRIPTION
        - NVHPC 22.11:
            - C test failed: NVC++-F-1196-OpenMP - 'omp parallel' in a 'loop' region is not supported yet.  (/gpfs/alpine/csc383/scratch/f6l/sollve/tests/5.0/loop/test_loop_bind_device.c: 46)
            - Fortran test failed: NVFORTRAN-S-1224-LOOP construct may not contain calls to the OpenMP Runtime API - . (/gpfs/alpine/csc383/scratch/f6l/sollve/tests/5.0/loop/test_loop_bind_device.F90: 60)
        - LLVM 15.0.0: C test passed but tested with one thread
        - GCC 12.2.1: C test passed; Fortran test passed but ran on the host
        - XL 16.1.1-10: C test passed, but tested with one team and one thread
            - Fortran test failed: line 52.10: 1515-019 (S) Syntax is incorrect.