### PR TITLE
test_target_teams_thread_limit.c: Fix out of bounds

### DIFF
--- a/tests/5.1/teams/test_target_teams_thread_limit.c
+++ b/tests/5.1/teams/test_target_teams_thread_limit.c
@@ -2,7 +2,7 @@
 //
 // OpenMP API Version 5.1 Nov 2020
 //
-// This test uses the thread_limit clause on the teams construct. Specifically
+// This test uses the thread_limit clause on the target construct. Specifically
 // testing if a thread_limit from a above target construct properly carries
 // down to the nested teams construct, as if it were directly on the construct
 // as defined in the spec. The test validates that only the specified 

--- a/tests/5.1/teams/test_target_teams_thread_limit.c
+++ b/tests/5.1/teams/test_target_teams_thread_limit.c
@@ -3,11 +3,11 @@
 // OpenMP API Version 5.1 Nov 2020
 //
 // This test uses the thread_limit clause on the target construct. Specifically
-// testing if a thread_limit from a above target construct properly carries
+// testing if a thread_limit on a target construct properly carries
 // down to the nested teams construct, as if it were directly on the construct
 // as defined in the spec. The test validates that only the specified 
 // threads are created by summing a shared variable across all threads 
-// (and teams). If the threads are correctedly limited this should produce the 
+// (and teams). If the threads are correctly limited, this should produce the
 // expected value. Additional warnings are sent if specific issues occur.
 //
 ////===----------------------------------------------------------------------===//

--- a/tests/5.1/teams/test_target_teams_thread_limit.c
+++ b/tests/5.1/teams/test_target_teams_thread_limit.c
@@ -20,7 +20,7 @@
 #define N 1024
 
 int main() {
-	int errors[OMPVV_NUM_THREADS_DEVICE/OMPVV_NUM_TEAMS_DEVICE];
+	int errors[OMPVV_NUM_TEAMS_DEVICE];
 	int num_teams = 0;
         int sum_errors = 0;
         int i;
@@ -60,7 +60,7 @@ int main() {
              sum_errors += errors[i];
         }
 
-	OMPVV_WARNING_IF(num_teams != OMPVV_NUM_TEAMS_DEVICE, "The number of teams was unexpected, the test results are likely inconcuslive")
+	OMPVV_WARNING_IF(num_teams != OMPVV_NUM_TEAMS_DEVICE, "The number of teams was unexpected, the test results are likely inconclusive")
 	OMPVV_WARNING_IF(testing_thread_limit == 1, "Only one thread was allocated to each team, the test results are likely inconclusive");
 
 	OMPVV_REPORT_AND_RETURN(sum_errors);


### PR DESCRIPTION
Two simple fixes:
* Use OMPVV_NUM_TEAMS_DEVICE for the 'errors' array as it is iterated over teams. Before the patch, it has size 1 which is too small.
* Fix a typo

* * *

Found via GCC's warning `test_target_teams_thread_limit.c:36:25: warning: iteration 1 invokes undefined behavior`.

The problem is that `OMPVV_NUM_THREADS_DEVICE == 8` and `OMPVV_NUM_TEAMS_DEVICE == 8` such that the array has size 1 at
https://github.com/SOLLVE/sollve_vv/blob/6a7dcb7217aea5db5bbd5d8c63ccafa7a6544244/tests/5.1/teams/test_target_teams_thread_limit.c#L23

And, thus, the following two loops access the array out of bounds:

https://github.com/SOLLVE/sollve_vv/blob/6a7dcb7217aea5db5bbd5d8c63ccafa7a6544244/tests/5.1/teams/test_target_teams_thread_limit.c#L35-L36
https://github.com/SOLLVE/sollve_vv/blob/6a7dcb7217aea5db5bbd5d8c63ccafa7a6544244/tests/5.1/teams/test_target_teams_thread_limit.c#L59-L60

@nolanbaker31 @spophale @jrreap @krishols @mjcarr458 @seyonglee – please review