### PR TITLE
test_omp_places_: Improve, typo + warning fixes

### DIFF
--- a/tests/5.1/env_var/test_omp_places_env_ll_caches.c
+++ b/tests/5.1/env_var/test_omp_places_env_ll_caches.c
@@ -18,7 +18,6 @@ int test_places(){
 	int errors = 0;
 	int test = 1;
 	char* ret_val = NULL;
-	setenv("OMP_PLACES", "ll_caches", 1 );
 	ret_val = getenv("OMP_PLACES");
 	test = ret_val == NULL || strcmp(ret_val, "ll_caches");
 	OMPVV_TEST_AND_SET(errors,test != 0);

--- a/tests/5.1/env_var/test_omp_places_env_ll_caches.c
+++ b/tests/5.1/env_var/test_omp_places_env_ll_caches.c
@@ -3,9 +3,9 @@
 //OpenMP API Version 5.1 Aug 2021
 //
 //Tests the omp_places environment variable. This test sets the
-//omp_places environment variable and then retrives it form the
+//omp_places environment variable and then retrieves it from the
 //environment. If the architecture supports the ll_caches 
-//argument then the retrived value will be ll_caches.
+//argument then the retrieved value will be ll_caches.
 //-------------------------------------------------------------
 
 #include <omp.h>
@@ -17,10 +17,10 @@
 int test_places(){
 	int errors = 0;
 	int test = 1;
-	char* ret_val = ""; 
+	char* ret_val = NULL;
 	setenv("OMP_PLACES", "ll_caches", 1 );
 	ret_val = getenv("OMP_PLACES");
-	test = strcmp(ret_val, "ll_caches");
+	test = ret_val == NULL || strcmp(ret_val, "ll_caches");
 	OMPVV_TEST_AND_SET(errors,test != 0);
 	return errors;
 }

--- a/tests/5.1/env_var/test_omp_places_env_numa_domains.c
+++ b/tests/5.1/env_var/test_omp_places_env_numa_domains.c
@@ -18,7 +18,6 @@ int test_places(){
 	int errors = 0;
 	int test = 1;
 	char* ret_val = NULL;
-	setenv("OMP_PLACES", "numa_domains", 1);
 	ret_val = getenv("OMP_PLACES");
 	test = ret_val == NULL || strcmp(ret_val, "numa_domains");
 	OMPVV_TEST_AND_SET(errors, test != 0);

--- a/tests/5.1/env_var/test_omp_places_env_numa_domains.c
+++ b/tests/5.1/env_var/test_omp_places_env_numa_domains.c
@@ -3,12 +3,13 @@
 // OpenMP API Version 5.1 Nov 2020
 //
 //This test intends to test the omp_places numa domain option. 
-//First the test sets the value of omp_placesto numa_domain. 
+//First the test sets the value of omp_places to numa_domain.
 //Then the test checks for equal distribution in threads.
 //-------------------------------------------------------------//
 
 #include <omp.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include "ompvv.h"
 #include <math.h>
 
@@ -16,10 +17,10 @@
 int test_places(){
 	int errors = 0;
 	int test = 1;
-	char* ret_val = "";
+	char* ret_val = NULL;
 	setenv("OMP_PLACES", "numa_domains", 1);
 	ret_val = getenv("OMP_PLACES");
-	test = strcmp(ret_val, "numa_domains");
+	test = ret_val == NULL || strcmp(ret_val, "numa_domains");
 	OMPVV_TEST_AND_SET(errors, test != 0);
 	return errors;
 }


### PR DESCRIPTION
* Silence g++'s "warning: ISO C++ forbids converting a string constant to ‘char*’"
* Include 'stdlib.h' as setenv/getenv are in stdlib.h according to POSIX.
* Rename test_omp_places_numa_domains.c to test_omp_places_env_numa_domains.c as Makefile handles `*_env_*` files in a special way such that now OMP_PLACES is set to 'numa_domains'.
* Additionally, I fixed some typos.

_Note that the setenv/getenv inside the two files is nice - but only checks that those POSIX functions work. With the Makefile `_env_` handling, an unsupported/bogus value at least might get diagnosed. GCC prints `libgomp: Invalid value for environment variable OMP_PLACES` for an unsupported or bogus value – but in case of GCC that's just a warning._

@nolanbaker31 @spophale @jrreap @krishols @mjcarr458 @seyonglee – please review

_NOTE: Force committed two follow-up fixes: Another typo and fixed my updated 'test =' change._
* * *

For completeness, that's the Makefile's handling for `*_env_*`:
https://github.com/SOLLVE/sollve_vv/blob/6a7dcb7217aea5db5bbd5d8c63ccafa7a6544244/Makefile#L309-L318

PS: Found when looking at the testcases after seeing a compiler warning.

PPS: Manually, looking at the output – when OMP_DISPLAY_ENV is set or the omp_display_env routine is invoked – is a more proper check, but difficult to automatize. On my 12 SMT-core laptop, I get `[host] OMP_PLACES = '{0:12}'` when it is set to either 'll_caches' or 'numa_domains' and `[host] OMP_PLACES = ''` if unset.