### PR TITLE
target_device with "kind" clause (in metadirective) test

### DIFF
--- a/tests/5.1/metadirective/test_metadirective_target_device_kind.c
+++ b/tests/5.1/metadirective/test_metadirective_target_device_kind.c
@@ -1,0 +1,63 @@
+//===--------------------- test_metadirective_target_device_kind.c ---------------------===//
+//
+// OpenMP API Version 5.1 Nov 2020
+// 
+// Tests that target_device is recognized & will work properly when matching an nvidia
+// GPU. More specifically, uses the kind clause to see if gpu or nohost is recognized
+// as the target device's "kind" implementation. 
+//
+////===---------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+int test_metadirective_target_device() {
+   int errors = 0;
+   int A[N];
+
+   for (int i = 0; i < N; i++) {
+      A[i] = 1;
+   }
+
+   #pragma omp target map(tofrom: A)
+   {
+      #pragma omp parallel num_threads(4)
+      {
+      // Expect that one of these are true, so the array should be set to masked thread num (0)
+      #pragma omp metadirective \
+         when( target_device={kind(gpu)}: masked ) \
+         when( target_device={kind(nohost)}: masked ) \
+         default( for)
+            for (int i = 0; i < N; i++) {
+               A[i] = omp_get_thread_num();
+            }
+      }
+   }
+
+   for (int i = 0; i < N; i++) {
+      OMPVV_TEST_AND_SET(errors, A[i] != 0);
+   }
+
+   OMPVV_INFOMSG("Test ran with a number of available devices greater than 0");
+
+   return errors;
+}
+
+int main () {
+  int errors = 0;
+  OMPVV_TEST_OFFLOADING;
+
+  if (omp_get_num_devices() > 0) {
+    errors = test_metadirective_target_device();
+  } else {
+    OMPVV_INFOMSG("Cannot test target_device without a target device!")
+  }
+
+  OMPVV_REPORT_AND_RETURN(errors);
+
+  return 0;
+}

--- a/tests/5.1/metadirective/test_metadirective_target_device_kind.c
+++ b/tests/5.1/metadirective/test_metadirective_target_device_kind.c
@@ -2,7 +2,7 @@
 //
 // OpenMP API Version 5.1 Nov 2020
 // 
-// Tests that target_device is recognized & will work properly when matching an nvidia
+// Tests that target_device is recognized & will work properly when matching a
 // GPU. More specifically, uses the kind clause to see if gpu or nohost is recognized
 // as the target device's "kind" implementation. 
 //
@@ -23,23 +23,17 @@ int test_metadirective_target_device() {
       A[i] = 1;
    }
 
-   #pragma omp target map(tofrom: A)
-   {
-      #pragma omp parallel num_threads(4)
-      {
       // Expect that one of these are true, so the array should be set to masked thread num (0)
       #pragma omp metadirective \
-         when( target_device={kind(gpu)}: masked ) \
-         when( target_device={kind(nohost)}: masked ) \
-         default( for)
-            for (int i = 0; i < N; i++) {
-               A[i] = omp_get_thread_num();
-            }
-      }
-   }
+         when( target_device={kind(gpu)}: target defaultmap(none) map(tofrom: A)) \
+         when( target_device={kind(nohost)}: target defaultmap(none) map(tofrom: A)) \
+         default( target defaultmap(none) map(to: A))
+         for(int i = 0; i < N; i++){
+            A[i] = i;
+         }
 
    for (int i = 0; i < N; i++) {
-      OMPVV_TEST_AND_SET(errors, A[i] != 0);
+      OMPVV_TEST_AND_SET(errors, A[i] != i);
    }
 
    OMPVV_INFOMSG("Test ran with a number of available devices greater than 0");

--- a/tests/5.1/metadirective/test_metadirective_target_device_kind_any.c
+++ b/tests/5.1/metadirective/test_metadirective_target_device_kind_any.c
@@ -1,0 +1,64 @@
+//===--------------------- test_metadirective_target_device_kind_any.c ---------------------===//
+//
+// OpenMP API Version 5.1 Nov 2020
+// 
+// Tests that target_device is recognized & will work properly when matching an nvidia
+// GPU. More specifically, uses the kind clause with "any" specified, which is defined
+// as "which is as if no kind selector was specified", so any kind of target
+// device should match.
+//
+////===---------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+int test_metadirective_target_device() {
+   int errors = 0;
+   int A[N];
+
+   for (int i = 0; i < N; i++) {
+      A[i] = 1;
+   }
+
+   #pragma omp target map(tofrom: A)
+   {
+      #pragma omp parallel num_threads(4)
+      {
+      // Expect that one of these are true, so the array should be set to masked thread num (0)
+      #pragma omp metadirective \
+         when( target_device={kind(any)}: masked ) \
+         default( for)
+            for (int i = 0; i < N; i++) {
+               A[i] = omp_get_thread_num();
+            }
+      }
+   }
+
+   for (int i = 0; i < N; i++) {
+      OMPVV_TEST_AND_SET(errors, A[i] != 0);
+   }
+
+   OMPVV_INFOMSG("Test ran with a number of available devices greater than 0");
+
+   return errors;
+}
+
+int main () {
+  int errors = 0;
+  OMPVV_TEST_OFFLOADING;
+
+  if (omp_get_num_devices() > 0) {
+    errors = test_metadirective_target_device();
+  } else {
+    OMPVV_INFOMSG("Cannot test target_device without a target device!")
+  }
+
+  OMPVV_REPORT_AND_RETURN(errors);
+
+  return 0;
+}
+

--- a/tests/5.1/metadirective/test_metadirective_target_device_kind_any.c
+++ b/tests/5.1/metadirective/test_metadirective_target_device_kind_any.c
@@ -24,22 +24,16 @@ int test_metadirective_target_device() {
       A[i] = 1;
    }
 
-   #pragma omp target map(tofrom: A)
-   {
-      #pragma omp parallel num_threads(4)
-      {
       // Expect that one of these are true, so the array should be set to masked thread num (0)
       #pragma omp metadirective \
-         when( target_device={kind(any)}: masked ) \
-         default( for)
-            for (int i = 0; i < N; i++) {
-               A[i] = omp_get_thread_num();
-            }
-      }
-   }
+         when( target_device={kind(any)}: target defaultmap(none) map(tofrom: A)) \
+         default( target defaultmap(none) map(to: A))
+         for(int i = 0; i < N; i++){
+            A[i] = i;
+         }
 
    for (int i = 0; i < N; i++) {
-      OMPVV_TEST_AND_SET(errors, A[i] != 0);
+      OMPVV_TEST_AND_SET(errors, A[i] != i);
    }
 
    OMPVV_INFOMSG("Test ran with a number of available devices greater than 0");


### PR DESCRIPTION
References #637, this is for the "kind" clause specifically.

I am struggling to find any clear list of "isa" or "arch", as these are implementation-defined. 