### PR TITLE
Add new_test/test_target_simd_nontemporal.F90

### DIFF
--- a/tests/5.0/target_simd/test_target_simd_nontemporal.F90
+++ b/tests/5.0/target_simd/test_target_simd_nontemporal.F90
@@ -1,0 +1,59 @@
+!===--- test_target_simd_nontemporal.F90 ------------------------------------------===//
+!
+! OpenMP API Version 5.0 Nov 2018
+!
+! This test checks for support of the nontemporal clause on a target simd construct. 
+! The nontemporal clause indicates that accesses to the storage location of list items
+! have low temporal locality across the iterations in which those storage 
+! locations are accessed. 
+!
+!//===-----------------------------------------------------------------------------===//
+
+#include "ompvv.F90"
+
+#define N 1028
+#define STRIDE_LEN 100
+
+PROGRAM test_target_simd_nontemporal
+
+  USE iso_fortran_env
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+
+  OMPVV_TEST_OFFLOADING
+
+  OMPVV_TEST_VERBOSE(test_target_simd_nontemp() .ne. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION test_target_simd_nontemp()
+  INTEGER,DIMENSION(N):: a, b, c
+  INTEGER:: i, errors
+
+  errors = 0
+
+  DO i = 1, N
+    a(i) = 10
+    b(i) = i
+    c(i) = 2 * i
+  END DO
+
+  !$omp target simd nontemporal(a, b, c)
+  DO i = 1, N, STRIDE_LEN
+     a(i) = b(i) * c(i)
+  END DO
+  !$omp end target simd
+
+  DO i = 1, N
+     IF ( MOD(i, STRIDE_LEN) .EQ. 1 ) THEN
+       OMPVV_TEST_AND_SET(errors, a(i) .NE. (b(i) * c(i)))
+     ELSE
+       OMPVV_TEST_AND_SET(errors, a(i) .NE. 10)
+     END IF
+  END DO
+
+  test_target_simd_nontemp = errors
+  END FUNCTION test_target_simd_nontemp
+END PROGRAM test_target_simd_nontemporal


### PR DESCRIPTION
       - NVHPC 22.11:
            - C test failed: line 30: error: invalid text in pragma
            - Fortran test failed: NVFORTRAN-S-0034-Syntax error at or near identifier nontemporal
        - LLVM 15.0.0: C test passed
        - GCC 12.2.1:
            - Both C and Fortran test passed.
        - XL 16.1.1-10:
            - C test passed but ran on the host.
            - Fortran test failed: line 43.21: 1515-022 (S) Syntax Error: Extra token " nontemporal " was found. The token is ignored.
