### PR TITLE
New test/test_loop_private.f90

### DIFF
--- a/tests/5.0/loop/test_loop_private.F90
+++ b/tests/5.0/loop/test_loop_private.F90
@@ -1,0 +1,61 @@
+!===--- test_loop_private.F90 ----------------------------------------------===//
+!
+! OpenMP API Version 5.0 Nov 2018
+!
+! This test uses the private clause on a loop directive to indicate that the
+! variable in the private clause should be made private to each thread
+! executing the loop region.  The test then operates on the privatized
+! variable in such a way that would most likely cause competing operations
+! if the variable is not privatized.  If the computation completes without
+! errors, we assume that the privatization occured.
+!
+!//===----------------------------------------------------------------------===//
+
+#include "ompvv.F90"
+
+#define NSIZE 1024
+
+PROGRAM test_loop_private
+  USE iso_fortran_env
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+
+  INTEGER,DIMENSION(NSIZE):: a, b, c, d
+  INTEGER:: privatized, num_threads, x, y
+
+  num_threads = -1
+
+  DO x = 1, NSIZE
+     a(x) = 1
+     b(x) = x
+     c(x) = 2*x
+     d(x) = 0
+  END DO
+
+  !$omp parallel num_threads(OMPVV_NUM_THREADS_HOST)
+  !$omp loop private(privatized)
+  DO x = 1, NSIZE
+     privatized = 0
+     DO y = 1, a(x) + b(x)
+        privatized = privatized + 1 
+     END DO
+     d(x) = c(x) * privatized
+  END DO
+  !$omp end loop
+  IF (omp_get_thread_num() .eq. 0 ) THEN
+     num_threads = omp_get_num_threads()
+  END IF
+  !$omp end parallel
+
+  DO x = 1, NSIZE
+     OMPVV_TEST_VERBOSE(d(x) .ne. (1 + x)*2*x)
+     IF (d(x) .ne. (1 + x)*2*x) THEN
+        exit
+     END IF
+  END DO
+
+  OMPVV_WARNING_IF(num_threads .eq. 1, "Test ran with one thread. Results of private test are inconclusive.")
+  OMPVV_TEST_VERBOSE(num_threads .lt. 1)
+  OMPVV_REPORT_AND_RETURN()
+END PROGRAM test_loop_private


### PR DESCRIPTION
        - NVHPC 22.11:
            - C test failed: NVC++-S-0155-'parallel' clause on 'loop' construct is only supported within a target region.
            - Fortran test failed: NVFORTRAN-S-1224-LOOP construct may not contain calls to the OpenMP Runtime API 
        - LLVM 15.0.0: clang-15: error: clang frontend command failed due to signal
        - LLVM 16.0.0: clang-17: error: clang frontend command failed due to signal
        - LLVM 17.0.0: clang-17: error: clang frontend command failed due to signal
        - GCC 12.2.1:
            - Both C and Fortran tests passed.
        - XL 16.1.1-10:
            - C test passed but ran with one thread.
            - Fortran test failed: line 37.8: 1515-019 (S) Syntax is incorrect.