### PR TITLE
test_target_update_to_present.c: Fix undefined behaviour

### DIFF
--- a/tests/5.1/target_update/test_target_update_to_present.c
+++ b/tests/5.1/target_update/test_target_update_to_present.c
@@ -43,18 +43,22 @@ int test_motion_present() {
   
    // Tests OpenMP 5.1 Specification pp. 207 lines 2-4
    #pragma omp target update to(scalar_var, A, new_struct) 
-   #pragma omp target map(tofrom: errors) defaultmap(none) map(from: scalar_var, A, new_struct)
-   {     
-        if(scalar_var == 1){errors++;}
-        if(A[0] == 0 || A[50] == 50){errors++;}
-        if(A[50] == 50 || A[51] == 51){errors++;}
-        if(new_struct.s == 10){errors++;}
-        if(new_struct.S[0] == 10){errors++;}
-   }
+   if (omp_target_is_present(&scalar_var, omp_get_default_device()))
+     errors++;
+   if (omp_target_is_present(&A, omp_get_default_device()))
+     errors++;
+   if (omp_target_is_present(&new_struct, omp_get_default_device()))
+     errors++;
 
    // Tests OpenMP 5.1 Specification pp. 207 lines 5-6
    #pragma omp target enter data map(alloc: scalar_var, A, new_struct)
    #pragma omp target update to(present: scalar_var, A, new_struct) 
+   if (!omp_target_is_present(&scalar_var, omp_get_default_device()))
+     errors++;
+   if (!omp_target_is_present(&A, omp_get_default_device()))
+     errors++;
+   if (!omp_target_is_present(&new_struct, omp_get_default_device()))
+     errors++;
    #pragma omp target map(tofrom: errors) defaultmap(none) map(from: scalar_var, A, new_struct)
    {     
         if(scalar_var != 1){errors++;}
@@ -63,6 +67,7 @@ int test_motion_present() {
         if(new_struct.s != 10){errors++;}
         if(new_struct.S[0] != 10){errors++;}
    }
+   #pragma omp target exit data map(release: scalar_var, A, new_struct)
    
    return errors;
 }


### PR DESCRIPTION
Issue #672
The tests/5.1/target_update/test_target_update_to_present.c has the following issues:

* The first target region uses 'from:' but accesses the uninitialized memory on the device. (Used to test that the variable is not yet mapped.)
* On exit of the target region, the 'from:' causes that this memory is copied back to the host - but the checks in the second target region check that the original value is present, which will fail.

Solution:
* The second issue could be mended by using 'alloc:' instead of 'from:', but it still has the undefined behavior as the variables are then uninitialized. Hence, the first target region has been removed. Instead:
* A omp_target_is_present check (an OpenMP 5.0 API routine) is now used to check whether the variable has been mapped - both instead of the first target region (nothing should be mapped) and before the second one (here, the variables should be mapped; added for completeness).
* Finally, the memory is unmapped - just for cleanness.

@seyonglee, @nolanbaker31, @jrreap, @spophale – please review.