### PR TITLE
test_target_defaultmap_present.c: Map 'ptr'

### DIFF
--- a/tests/5.1/target/test_target_defaultmap_present.c
+++ b/tests/5.1/target/test_target_defaultmap_present.c
@@ -40,7 +40,7 @@ int test_defaultmap_present() {
    ptr = &A[0]; 
    ptr[50] = 50; ptr[51] = 51;
    
-   #pragma omp target enter data map(to: scalar_var, A, new_struct)
+   #pragma omp target enter data map(to: scalar_var, A, new_struct, ptr)
    
    #pragma omp target map(tofrom: errors) defaultmap(present)
    {     


### PR DESCRIPTION
Issue #671
* tests/5.1/target/test_target_defaultmap_present.c: Map 'ptr' in target enter data. (As 'ptr' is used in a target region with 'defaultmap(present)', it needs to be mapped before to avoid runtime error termination.)

@seyonglee, @nolanbaker31, @jrreap, @spophale – please review.