### PR TITLE
Add new_test/test_requires_atomic_default_mem_order_relaxed.F90

### DIFF
--- a/tests/5.0/requires/test_requires_atomic_default_mem_order_relaxed.F90
+++ b/tests/5.0/requires/test_requires_atomic_default_mem_order_relaxed.F90
@@ -37,7 +37,10 @@ CONTAINS
 
     OMPVV_INFOMSG("test_requires_atomic_relaxed")
 
-    !$omp parallel num_threads(2) private(thrd, tmp)
+    call omp_set_dynamic(.false.)
+    call omp_set_num_threads(2)
+    
+    !$omp parallel private(thrd, tmp)
        thrd = omp_get_thread_num()
        IF (thrd .EQ. 0) THEN
           x = 10 

--- a/tests/5.0/requires/test_requires_atomic_default_mem_order_relaxed.F90
+++ b/tests/5.0/requires/test_requires_atomic_default_mem_order_relaxed.F90
@@ -1,0 +1,61 @@
+!//===------ test_requires_default_mem_order_relaxed.F90 --------------------------===//
+!
+! OpenMP API Version 5.0 Nov 2018
+!
+! This test checks for support of the atomic_default_mem_order clause on the 
+! requires directive. This clause determines the default memory behavior for
+! atomic constructs. These behaviors are seq_cst, acq_rel, and relaxed.
+! This test checks for relaxed as the memory-order-clause.
+!
+! Adapted from 5.0 OpenMP example acquire_release.3.F90
+!
+!//===----------------------------------------------------------------------===//
+
+#include "ompvv.F90"
+
+PROGRAM test_requires_default_mem_order_relaxed
+  USE iso_fortran_env
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+
+  !$omp requires atomic_default_mem_order(relaxed)
+
+  OMPVV_TEST_OFFLOADING
+
+  OMPVV_TEST_VERBOSE(test_atomic_relaxed() .ne. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION test_atomic_relaxed()
+    INTEGER:: x, y, thrd, tmp, errors
+
+    x = 0
+    y = 0
+    errors = 0
+
+    OMPVV_INFOMSG("test_requires_atomic_relaxed")
+
+    !$omp parallel num_threads(2) private(thrd, tmp)
+       thrd = omp_get_thread_num()
+       IF (thrd .EQ. 0) THEN
+          x = 10 
+          !$omp flush
+          !$omp atomic write 
+          y = 1
+          !$omp end atomic
+       ELSE
+          tmp = 0
+          DO WHILE (tmp .EQ. 0) 
+            !$omp atomic read 
+            tmp = y
+            !$omp end atomic 
+          END DO
+          OMPVV_TEST_AND_SET_VERBOSE(errors, x .NE. 10)
+       END IF
+    !$omp end parallel
+
+    test_atomic_relaxed = errors
+  END FUNCTION test_atomic_relaxed
+END PROGRAM test_requires_default_mem_order_relaxed

--- a/tests/5.0/requires/test_requires_atomic_default_mem_order_relaxed.c
+++ b/tests/5.0/requires/test_requires_atomic_default_mem_order_relaxed.c
@@ -16,8 +16,6 @@
 #include <stdlib.h>
 #include "ompvv.h"
 
-#define N 1024
-
 #pragma omp requires atomic_default_mem_order(relaxed)
 
 int test_requires_atomic_relaxed() {

--- a/tests/5.0/requires/test_requires_atomic_default_mem_order_relaxed.c
+++ b/tests/5.0/requires/test_requires_atomic_default_mem_order_relaxed.c
@@ -23,8 +23,11 @@ int test_requires_atomic_relaxed() {
 
   int x = 0, y = 0;
   int errors = 0;
-
-#pragma omp parallel num_threads(2)
+  
+  omp_set_dynamic(0);
+  omp_set_num_threads(2);
+  
+#pragma omp parallel 
    {
       int thrd = omp_get_thread_num();
        if (thrd == 0) {


### PR DESCRIPTION
        - NVHPC 22.11:
            C test failed: line 19: error: invalid text in pragma
            Fortran test failed: NVFORTRAN-S-0034-Syntax error at or near (.../sollve/tests/5.0/requires/test_requires_atomic_default_mem_order_relaxed.F90: 22)
        - LLVM 15.0.0: C test passed.
        - LLVM 16.0.0: C test passed.
        - LLVM 17.0.0: C test passed.
        - GCC 12.2.1: Both C and Fortran tests passed.
        - XL 16.1.1-10: 
            - C test passed.
            - Fortran test failed: line 22.9: 1515-019 (S) Syntax is incorrect.