### PR TITLE
Add new_test/test_atomic_acquire_release.F90

### DIFF
--- a/tests/5.0/atomic/test_atomic_acquire_release.F90
+++ b/tests/5.0/atomic/test_atomic_acquire_release.F90
@@ -1,0 +1,58 @@
+!//===------ test_atomic_acquire_release.F90 --------------------------===//
+!
+! OpenMP API Version 5.0 Nov 2018
+!
+! Adapted from OpenMP examples acquire_release.2.c
+! When the atomic read operation on thread 1 reads a non-zero value from y,
+! this results in a release/acquire synchronization that in turn implies that 
+! the assignment to x on thread 0 happens before the read of x on thread 1. 
+!
+!//===----------------------------------------------------------------------===//
+
+#include "ompvv.F90"
+
+#define N 1000
+
+PROGRAM test_atomic_acquire_release_program
+  USE iso_fortran_env
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+
+  OMPVV_TEST_OFFLOADING
+
+  OMPVV_TEST_VERBOSE(test_atomic_acquire_release() .ne. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION test_atomic_acquire_release()
+    INTEGER:: x, y, thrd, tmp, errors
+
+    x = 0
+    y = 0
+    errors = 0
+
+    OMPVV_INFOMSG("test_atomic_acquire_release")
+
+    !$omp parallel num_threads(2) private(thrd, tmp)
+       thrd = omp_get_thread_num()
+       IF (thrd .EQ. 0) THEN
+          x = 10 
+          !$omp atomic write release
+          y = 1
+          !$omp end atomic
+       ELSE
+          tmp = 0
+          DO WHILE (tmp .EQ. 0) 
+            !$omp atomic read acquire
+            tmp = y
+            !$omp end atomic 
+          END DO
+          OMPVV_TEST_AND_SET_VERBOSE(errors, x .NE. 10)
+       END IF
+    !$omp end parallel
+
+    test_atomic_acquire_release = errors
+  END FUNCTION test_atomic_acquire_release
+END PROGRAM test_atomic_acquire_release_program

--- a/tests/5.0/atomic/test_atomic_acquire_release.F90
+++ b/tests/5.0/atomic/test_atomic_acquire_release.F90
@@ -32,8 +32,11 @@ CONTAINS
     errors = 0
 
     OMPVV_INFOMSG("test_atomic_acquire_release")
+    
+    call omp_set_dynamic(.false.)
+    call omp_set_num_threads(2)
 
-    !$omp parallel num_threads(2) private(thrd, tmp)
+    !$omp parallel private(thrd, tmp)
        thrd = omp_get_thread_num()
        IF (thrd .EQ. 0) THEN
           x = 10 

--- a/tests/5.0/atomic/test_atomic_acquire_release.F90
+++ b/tests/5.0/atomic/test_atomic_acquire_release.F90
@@ -19,8 +19,6 @@ PROGRAM test_atomic_acquire_release_program
   USE omp_lib
   implicit none
 
-  OMPVV_TEST_OFFLOADING
-
   OMPVV_TEST_VERBOSE(test_atomic_acquire_release() .ne. 0)
 
   OMPVV_REPORT_AND_RETURN()


### PR DESCRIPTION
        - NVHPC 22.11:
            - C test failed: line 30: error: invalid text in pragma
            - Fortran test: NVFORTRAN-S-0034-Syntax error at or near identifier release
        - LLVM 15.0.0: C test passed.
        - LLVM 17.0.0: C test passed.
        - GCC 12.2.1:
            - Both C and Fortran tests passed.
        - XL 16.1.1-10:
            - C test passed.
            - Fortran test failed: line 42.16: 1515-019 (S) Syntax is incorrect.