### PR TITLE
Add new_test/test_atomic_num_hint.F90

### DIFF
--- a/tests/5.0/atomic/test_atomic_num_hint.F90
+++ b/tests/5.0/atomic/test_atomic_num_hint.F90
@@ -43,7 +43,7 @@ CONTAINS
        !$omp end atomic 
     !$omp end parallel
 
-    OMPVV_ERROR_IF(num_threads .LT. 0, "Test ran with invalid number of teams (less than zero)")
+    OMPVV_ERROR_IF(num_threads .LT. 0, "Test ran with invalid number of threads (less than zero)")
     OMPVV_WARNING_IF(num_threads .EQ. 1, "Test ran with one thread, so the results are not conclusive")
 
     OMPVV_TEST_AND_SET_VERBOSE(errors, x .NE. num_threads)
@@ -69,7 +69,7 @@ CONTAINS
        !$omp end atomic 
     !$omp end parallel
 
-    OMPVV_ERROR_IF(num_threads .LT. 0, "Test ran with invalid number of teams (less than zero)")
+    OMPVV_ERROR_IF(num_threads .LT. 0, "Test ran with invalid number of threads (less than zero)")
     OMPVV_WARNING_IF(num_threads .EQ. 1, "Test ran with one thread, so the results are not conclusive")
 
     OMPVV_TEST_AND_SET_VERBOSE(errors, x .NE. num_threads)

--- a/tests/5.0/atomic/test_atomic_num_hint.F90
+++ b/tests/5.0/atomic/test_atomic_num_hint.F90
@@ -1,0 +1,80 @@
+!//===------ test_atomic_num_hint.F90 -------------------------------------===//
+!
+! OpenMP API Version 5.0 Nov 2018
+!
+!  This test checks if atomic hints passed by enum value
+!  are accepted by the compiler. If the sync hint is not
+!  yet defined in the specification, it defaults to 
+!  omp_sync_hint_none (0x0). 
+!
+!//===---------------------------------------------------------------------===//
+
+#include "ompvv.F90"
+
+#define N 1024
+
+PROGRAM test_atomic_num_hint
+  USE iso_fortran_env
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+
+  OMPVV_TEST_VERBOSE(test_atomic_with_used_enum_value() .ne. 0)
+  OMPVV_TEST_VERBOSE(test_atomic_with_unused_enum_value() .ne. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION test_atomic_with_used_enum_value()
+    INTEGER:: x, num_threads, errors
+
+    errors = 0
+    x = 0
+    num_threads = -1
+
+    OMPVV_INFOMSG("test_atomic_with_used_enum_value")
+
+    !$omp parallel num_threads(2) default(shared)
+       IF (omp_get_thread_num() .EQ. 0) THEN
+          num_threads = omp_get_num_threads()
+       END IF
+       !$omp atomic hint(4) ! corrosponds to omp_sync_hint_nonspeculative
+          x = x + 1
+       !$omp end atomic 
+    !$omp end parallel
+
+    OMPVV_ERROR_IF(num_threads .LT. 0, "Test ran with invalid number of teams (less than zero)")
+    OMPVV_WARNING_IF(num_threads .EQ. 1, "Test ran with one thread, so the results are not conclusive")
+
+    OMPVV_TEST_AND_SET_VERBOSE(errors, x .NE. num_threads)
+
+    test_atomic_with_used_enum_value = errors
+  END FUNCTION test_atomic_with_used_enum_value
+
+  INTEGER FUNCTION test_atomic_with_unused_enum_value()
+    INTEGER:: x, num_threads, errors
+
+    errors = 0
+    x = 0
+    num_threads = -1
+
+    OMPVV_INFOMSG("test_atomic_with_unused_enum_value")
+
+    !$omp parallel num_threads(OMPVV_NUM_THREADS_HOST) default(shared)
+       IF (omp_get_thread_num() .EQ. 0) THEN
+          num_threads = omp_get_num_threads()
+       END IF
+       !$omp atomic hint(4132) ! As of OMP Spec 5.0 only values till 0x8 have been taken
+          x = x + 1
+       !$omp end atomic 
+    !$omp end parallel
+
+    OMPVV_ERROR_IF(num_threads .LT. 0, "Test ran with invalid number of teams (less than zero)")
+    OMPVV_WARNING_IF(num_threads .EQ. 1, "Test ran with one thread, so the results are not conclusive")
+
+    OMPVV_TEST_AND_SET_VERBOSE(errors, x .NE. num_threads)
+
+    test_atomic_with_unused_enum_value = errors
+  END FUNCTION test_atomic_with_unused_enum_value
+
+END PROGRAM test_atomic_num_hint

--- a/tests/5.0/atomic/test_atomic_num_hint.F90
+++ b/tests/5.0/atomic/test_atomic_num_hint.F90
@@ -38,7 +38,7 @@ CONTAINS
        IF (omp_get_thread_num() .EQ. 0) THEN
           num_threads = omp_get_num_threads()
        END IF
-       !$omp atomic hint(4) ! corrosponds to omp_sync_hint_nonspeculative
+       !$omp atomic hint(4) ! corresponds to omp_sync_hint_nonspeculative
           x = x + 1
        !$omp end atomic 
     !$omp end parallel

--- a/tests/5.0/atomic/test_atomic_num_hint.c
+++ b/tests/5.0/atomic/test_atomic_num_hint.c
@@ -1,4 +1,4 @@
-//===--- test_atomic_hint.c -------------------------------------------------===//
+//===--- test_atomic_num_hint.c -------------------------------------------===//
 //
 // OpenMP API Version 5.0 Nov 2018
 //
@@ -6,7 +6,7 @@
 //  are accepted by the compiler. If the sync hint is not
 //  yet defined in the specification, it defaults to 
 //  omp_sync_hint_none (0x0). 
-////===----------------------------------------------------------------------===//
+////===--------------------------------------------------------------------===//
 
 #include <assert.h>
 #include <omp.h>
@@ -17,7 +17,7 @@
 #define N 1024
 
 int test_atomic_with_used_enum_value() {
-  OMPVV_INFOMSG("test_atomic_by_used_enum_value");
+  OMPVV_INFOMSG("test_atomic_with_used_enum_value");
   int errors = 0, x = 0, num_threads = -1;
 
 #pragma omp parallel num_threads(2) default(shared)


### PR DESCRIPTION
new_test/test_atomic_num_hint.F90

        - NVHPC 22.11:
            - C test failed: line 28: error: invalid text in pragma
            - Fortran test failed: NVFORTRAN-S-0034-Syntax error at or near identifier hint 
        - LLVM 15.0.0: C test passed.
        - LLVM 17.0.0: C test passed.
        - GCC 12.2.1:
            - Both C and Fortran tests passed.
        - XL 16.1.1-10:
            - C test passed, but test ran with one thread, so the results are not conclusive
            - Fortran test failed:  line 41.13: 1515-019 (S) Syntax is incorrect.
