### PR TITLE
test_atomic_num_hint.c: funct name in diagnostic + file name in comment

### DIFF
--- a/tests/5.0/atomic/test_atomic_num_hint.c
+++ b/tests/5.0/atomic/test_atomic_num_hint.c
@@ -1,4 +1,4 @@
-//===--- test_atomic_hint.c -------------------------------------------------===//
+//===--- test_atomic_num_hint.c -------------------------------------------===//
 //
 // OpenMP API Version 5.0 Nov 2018
 //
@@ -6,7 +6,7 @@
 //  are accepted by the compiler. If the sync hint is not
 //  yet defined in the specification, it defaults to 
 //  omp_sync_hint_none (0x0). 
-////===----------------------------------------------------------------------===//
+////===--------------------------------------------------------------------===//
 
 #include <assert.h>
 #include <omp.h>
@@ -17,7 +17,7 @@
 #define N 1024
 
 int test_atomic_with_used_enum_value() {
-  OMPVV_INFOMSG("test_atomic_by_used_enum_value");
+  OMPVV_INFOMSG("test_atomic_with_used_enum_value");
   int errors = 0, x = 0, num_threads = -1;
 
 #pragma omp parallel num_threads(2) default(shared)


### PR DESCRIPTION
Just as it says – the function name in OMPVV_INFOMSG is wrong (see preceeding line) and the filename in the comment at the top also missed a "num".

_(I found this diff in my repo – I think I did not have a pull request for it, but no idea when I changed my file.
The `====` lines are shortened to a length of 80 characters, which sounds reasonable but I don't know why I did this back then.)_

@nolanbaker31 @spophale @jrreap @krishols @mjcarr458 @seyonglee – please review