### PR TITLE
Ordered doacross tests

### DIFF
--- a/tests/5.2/ordered/test_ordered_doacross.c
+++ b/tests/5.2/ordered/test_ordered_doacross.c
@@ -32,7 +32,9 @@ int ordered_doacross(){
   int a[N];
   int b[N];
   int c[N];
-  a[0], b[0], c[0] = 0;
+  a[0] = 0;
+  b[0] = 0;
+  c[0] = 0;
 
   #pragma omp parallel for ordered
   for(int i = 1; i < N; i++){

--- a/tests/5.2/ordered/test_ordered_doacross.c
+++ b/tests/5.2/ordered/test_ordered_doacross.c
@@ -47,7 +47,7 @@ int ordered_doacross(){
   for(int i = 1; i < N; i++){
     OMPVV_TEST_AND_SET(errors, a[i] != i);
     OMPVV_TEST_AND_SET(errors, b[i] != i-1)
-    OMPVV_TEST_AND_SET_VERBOSE(errors, c[i] != (i-1) + i);
+    OMPVV_TEST_AND_SET(errors, c[i] != (i-1) + i);
   }
   return errors;
 

--- a/tests/5.2/ordered/test_ordered_doacross.c
+++ b/tests/5.2/ordered/test_ordered_doacross.c
@@ -1,0 +1,60 @@
+//===---- test_ordered_doacross.c -------------------------------------===//
+//
+// OpenMP API Version 5.2
+//
+// This example has been adapted from the 5.2 OpenMP Examples document:
+// "9.10 Doacross Loop Nest"
+// 
+// OpenMP specification states that "the doacross clause identifies cross-iteration
+// dependences that imply additional constraints on the scheduling of loop iterations."
+// This test uses the arrays a, b, and c to test before the sink, after the sink, and
+// after the source. Array b relies on the previous iteration, which changes array a,
+// which would normally be a race condition. Doacross ensures that the previous iteration
+// has already reached this point before changing b[i].
+//
+// The specification states that if the vector for source is ommited, it assumed to be
+// omp_cur_iteration.
+//===-------------------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+#include <math.h>
+
+#define N 1024
+
+int errors;
+int arr[N];
+
+int ordered_doacross(){
+
+  int a[N];
+  int b[N];
+  int c[N];
+  a[0], b[0], c[0] = 0;
+
+  #pragma omp parallel for ordered
+  for(int i = 1; i < N; i++){
+    a[i] = i;
+    #pragma omp ordered doacross(sink: i-1)
+    b[i] = a[i-1];
+    #pragma omp ordered doacross(source:)
+    c[i] = a[i] + b[i];
+  }
+  for(int i = 1; i < N; i++){
+    OMPVV_TEST_AND_SET(errors, a[i] != i);
+    OMPVV_TEST_AND_SET(errors, b[i] != i-1)
+    OMPVV_TEST_AND_SET_VERBOSE(errors, c[i] != (i-1) + i);
+  }
+  return errors;
+
+}
+
+int main() {
+   errors = 0;
+   OMPVV_TEST_OFFLOADING;
+   OMPVV_TEST_AND_SET_VERBOSE(errors, ordered_doacross() != 0);
+   OMPVV_REPORT_AND_RETURN(errors);
+   
+}

--- a/tests/5.2/ordered/test_ordered_doacross_defined_source.c
+++ b/tests/5.2/ordered/test_ordered_doacross_defined_source.c
@@ -1,0 +1,60 @@
+//===---- test_ordered_doacross.c -------------------------------------===//
+//
+// OpenMP API Version 5.2
+//
+// This example has been adapted from the 5.2 OpenMP Examples document:
+// "9.10 Doacross Loop Nest"
+// 
+// OpenMP specification states that "the doacross clause identifies cross-iteration
+// dependences that imply additional constraints on the scheduling of loop iterations."
+// This test uses the arrays a, b, and c to test before the sink, after the sink, and
+// after the source. Array b relies on the previous iteration, which changes array a,
+// which would normally be a race condition. Doacross ensures that the previous iteration
+// has already reached this point before changing b[i].
+//
+// The specification states that if the vector for source is ommited, it assumed to be
+// omp_cur_iteration.
+//===-------------------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+#include <math.h>
+
+#define N 1024
+
+int errors;
+int arr[N];
+
+int ordered_doacross(){
+
+  int a[N];
+  int b[N];
+  int c[N];
+  a[0], b[0], c[0] = 0;
+
+  #pragma omp parallel for ordered
+  for(int i = 1; i < N; i++){
+    a[i] = i;
+    #pragma omp ordered doacross(sink: i-2)
+    b[i-1] = a[i-2];
+    #pragma omp ordered doacross(source:i-1)
+    c[i] = a[i] + b[i];
+  }
+  for(int i = 1; i < N; i++){
+    OMPVV_TEST_AND_SET(errors, a[i] != i);
+    OMPVV_TEST_AND_SET(errors, b[i] != i-1)
+    OMPVV_TEST_AND_SET_VERBOSE(errors, c[i] != (i-1) + i);
+  }
+  return errors;
+
+}
+
+int main() {
+   errors = 0;
+   OMPVV_TEST_OFFLOADING;
+   OMPVV_TEST_AND_SET_VERBOSE(errors, ordered_doacross() != 0);
+   OMPVV_REPORT_AND_RETURN(errors);
+   
+}

--- a/tests/5.2/ordered/test_ordered_doacross_defined_source.c
+++ b/tests/5.2/ordered/test_ordered_doacross_defined_source.c
@@ -32,7 +32,9 @@ int ordered_doacross(){
   int a[N];
   int b[N];
   int c[N];
-  a[0], b[0], c[0] = 0;
+  a[0] = 0;
+  b[0] = 0;
+  c[0] = 0;
 
   #pragma omp parallel for ordered
   for(int i = 1; i < N; i++){

--- a/tests/5.2/ordered/test_ordered_doacross_omp_cur_iteration.c
+++ b/tests/5.2/ordered/test_ordered_doacross_omp_cur_iteration.c
@@ -1,0 +1,60 @@
+//===---- test_ordered_doacross_omp_cur_iteration.c -------------------------------------===//
+//
+// OpenMP API Version 5.2
+//
+// This example has been adapted from the 5.2 OpenMP Examples document:
+// "9.10 Doacross Loop Nest"
+// 
+// OpenMP specification states that "the doacross clause identifies cross-iteration
+// dependences that imply additional constraints on the scheduling of loop iterations."
+// This test uses the arrays a, b, and c to test before the sink, after the sink, and
+// after the source. Array b relies on the previous iteration, which changes array a,
+// which would normally be a race condition. Doacross ensures that the previous iteration
+// has already reached this point before changing b[i].
+//
+// The specification states that if the vector for source is ommited, it assumed to be
+// omp_cur_iteration.
+//===-------------------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+#include <math.h>
+
+#define N 1024
+
+int errors;
+int arr[N];
+
+int ordered_doacross(){
+
+  int a[N];
+  int b[N];
+  int c[N];
+  a[0], b[0], c[0] = 0;
+
+  #pragma omp parallel for ordered
+  for(int i = 1; i < N; i++){
+    a[i] = i;
+    #pragma omp ordered doacross(sink: i-1)
+    b[i] = a[i-1];
+    #pragma omp ordered doacross(source:omp_cur_iteration)
+    c[i] = a[i] + b[i];
+  }
+  for(int i = 1; i < N; i++){
+    OMPVV_TEST_AND_SET(errors, a[i] != i);
+    OMPVV_TEST_AND_SET(errors, b[i] != i-1)
+    OMPVV_TEST_AND_SET_VERBOSE(errors, c[i] != (i-1) + i);
+  }
+  return errors;
+
+}
+
+int main() {
+   errors = 0;
+   OMPVV_TEST_OFFLOADING;
+   OMPVV_TEST_AND_SET_VERBOSE(errors, ordered_doacross() != 0);
+   OMPVV_REPORT_AND_RETURN(errors);
+   
+}

--- a/tests/5.2/ordered/test_ordered_doacross_omp_cur_iteration.c
+++ b/tests/5.2/ordered/test_ordered_doacross_omp_cur_iteration.c
@@ -32,7 +32,9 @@ int ordered_doacross(){
   int a[N];
   int b[N];
   int c[N];
-  a[0], b[0], c[0] = 0;
+  a[0] = 0;
+  b[0] = 0;
+  c[0] = 0;
 
   #pragma omp parallel for ordered
   for(int i = 1; i < N; i++){


### PR DESCRIPTION
I believe ordered_doacross.c & order_doacross_omp_cur_iteration.c (basically the same test) are ready.

The defined source test is WIP. OpenMP 5.2 states "If the source dependence-type is specified then the vector argument is optional." This seems to mean it may/may not be ignored, but I am unsure. I am also unsure of how the source could be any iteration but the current one.