### PR TITLE
Declare Mapper w/ Present 

### DIFF
--- a/tests/5.2/declare_mapper/test_declare_mapper_present.c
+++ b/tests/5.2/declare_mapper/test_declare_mapper_present.c
@@ -23,7 +23,7 @@ typedef struct myvec{
 } myvec_t;
 
 
-#pragma omp declare mapper(myvec_t v) map(present, tofrom: v, v.data[0:v.len]) 
+#pragma omp declare mapper(default:myvec_t v) map(present, tofrom: v, v.data[0:v.len]) 
 
 void init( myvec_t *s )
 { 

--- a/tests/5.2/declare_mapper/test_declare_mapper_present.c
+++ b/tests/5.2/declare_mapper/test_declare_mapper_present.c
@@ -19,15 +19,14 @@
 
 typedef struct myvec{
     size_t len;
-    double *data;
+    int *data;
 } myvec_t;
 
 
-#pragma omp declare mapper(default:myvec_t v) map(present, tofrom: v, v.data[0:v.len]) 
 
 void init( myvec_t *s )
 { 
-  for(size_t i = 0; i < s->len; i++)
+  for(int i = 0; i < s->len; i++)
     s->data[i] = i; 
 }
 
@@ -37,16 +36,17 @@ int test_declare_mapper_present() {
   OMPVV_INFOMSG("test_declare_mapper_present");
   int errors = 0;
 
-   myvec_t s;
+  myvec_t s;
 
-   s.data = (double *)calloc(N,sizeof(double));
-   s.len  = N;
-  #pragma omp target data map(tofrom: s, s.data[0:s.len])
+  s.data = (int *)calloc(N,sizeof(int));
+  s.len  = N;
+  #pragma omp target enter data map(to: s, s.data[0:s.len])
+
+  #pragma omp declare mapper(default:myvec_t v) map(present, from: v, v.data[0:v.len]) 
+
+  #pragma omp target map(s)
   {
-    #pragma omp target
-    {
-        init(&s);
-    }
+    init(&s);
   }
 
   for (int i = 0; i < N; ++i) {

--- a/tests/5.2/declare_mapper/test_declare_mapper_present.c
+++ b/tests/5.2/declare_mapper/test_declare_mapper_present.c
@@ -37,17 +37,18 @@ int test_declare_mapper_present() {
   int errors = 0;
 
   myvec_t s;
-
   s.data = (int *)calloc(N,sizeof(int));
   s.len  = N;
   #pragma omp target enter data map(to: s, s.data[0:s.len])
 
   #pragma omp declare mapper(default:myvec_t v) map(present, from: v, v.data[0:v.len]) 
 
-  #pragma omp target map(s)
+
+  #pragma omp target
   {
     init(&s);
   }
+  #pragma omp target exit data map(from: s, s.data[0:s.len])
 
   for (int i = 0; i < N; ++i) {
     OMPVV_TEST_AND_SET(errors, s.data[i] != i);

--- a/tests/5.2/declare_mapper/test_declare_mapper_present.c
+++ b/tests/5.2/declare_mapper/test_declare_mapper_present.c
@@ -1,0 +1,67 @@
+//===---- test_declare_mapper_present.c -------------------------------------===//
+// 
+// OpenMP API Version 5.2 
+//
+// This example has been adapted from the 5.2 OpenMP Examples document:
+// "declare mapper Directive", and "OpenMP Directive Syntax -> complex iterator"
+// The declare mapper directive will be used to automatically map variables
+// according to its prescription:  full structure, plus the dynamic storage of the
+// data element. These variable should be present on the device.
+//
+//===-------------------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1000
+
+typedef struct myvec{
+    size_t len;
+    double *data;
+} myvec_t;
+
+
+#pragma omp declare mapper(myvec_t v) map(present, tofrom: v, v.data[0:v.len]) 
+
+void init( myvec_t *s )
+{ 
+  for(size_t i = 0; i < s->len; i++)
+    s->data[i] = i; 
+}
+
+
+int test_declare_mapper_present() { 
+
+  OMPVV_INFOMSG("test_declare_mapper_present");
+  int errors = 0;
+
+   myvec_t s;
+
+   s.data = (double *)calloc(N,sizeof(double));
+   s.len  = N;
+  #pragma omp target data map(tofrom: s, s.data[0:s.len])
+  {
+    #pragma omp target
+    {
+        init(&s);
+    }
+  }
+
+  for (int i = 0; i < N; ++i) {
+    OMPVV_TEST_AND_SET(errors, s.data[i] != i);
+  }	
+  
+  return errors;
+}
+
+int main () {
+  OMPVV_TEST_OFFLOADING;
+
+  int errors = 0;
+
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_declare_mapper_present());
+
+  OMPVV_REPORT_AND_RETURN(errors);
+}  


### PR DESCRIPTION
Fails on GCC (not implemented)

Fails on LLVM 17 w/ message:
`Libomptarget message: device mapping required by 'present' map type modifier does not exist for host address 0x000000011df198e0 (8000 bytes) `

`Libomptarget error: Call to getTargetPointer returned null pointer ('present' map type modifier). `

`Libomptarget error: Call to targetDataBegin via targetDataMapper for custom mapper failed.`