### PR TITLE
Dispatch w/ no clause; Dispatch w/ device clause

### DIFF
--- a/tests/5.1/dispatch/test_dispatch.c
+++ b/tests/5.1/dispatch/test_dispatch.c
@@ -61,6 +61,9 @@ int test_wrapper() {
 }
 
 int main () {
+    for (int i = 0; i < N; i++){
+      arr[i] = 1;
+    }
    OMPVV_TEST_AND_SET_VERBOSE(errors, test_wrapper());
    OMPVV_REPORT_AND_RETURN(errors);
 } 

--- a/tests/5.1/dispatch/test_dispatch.c
+++ b/tests/5.1/dispatch/test_dispatch.c
@@ -28,14 +28,14 @@ void add_two(int *arr);
 #pragma omp declare variant(add_two) match(construct={dispatch}) 
 void add(int *arr){
     #pragma omp parallel for
-    for (int i = 0; i < N; i++){ // Base function adds 2 to array values
+    for (int i = 0; i < N; i++){ // Base function adds 1 to array values
       arr[i] = arr[i]+1;
     }
 }
 
 void add_two(int *arr){
     for (int i = 0; i < N; i++){
-      arr[i] = arr[i]+2; // Variant function adds 4 to array values
+      arr[i] = arr[i]+2; // Variant function adds 2 to array values
     }
 }
 
@@ -44,7 +44,7 @@ int test_wrapper() {
 
     add(arr);
     for(i = 0; i < N; i++){
-        OMPVV_TEST_AND_SET(errors, arr[i] != i+1);
+        OMPVV_TEST_AND_SET(errors, arr[i] != 1);
     } 
     OMPVV_ERROR_IF(errors > 0, "Base function is not working properly");
 
@@ -52,7 +52,7 @@ int test_wrapper() {
         add(arr);
    
     for(i = 0; i < N; i++){
-        OMPVV_TEST_AND_SET(errors, arr[i] != i+2);
+        OMPVV_TEST_AND_SET(errors, arr[i] != 3);
     }
     OMPVV_ERROR_IF(errors > 0, "Dispatch is not working properly");
     return errors;

--- a/tests/5.1/dispatch/test_dispatch.c
+++ b/tests/5.1/dispatch/test_dispatch.c
@@ -62,7 +62,7 @@ int test_wrapper() {
 
 int main () {
     for (int i = 0; i < N; i++){
-      arr[i] = 1;
+      arr[i] = 0;
     }
    OMPVV_TEST_AND_SET_VERBOSE(errors, test_wrapper());
    OMPVV_REPORT_AND_RETURN(errors);

--- a/tests/5.1/dispatch/test_dispatch.c
+++ b/tests/5.1/dispatch/test_dispatch.c
@@ -1,0 +1,64 @@
+//===---- test_dispatch_device.c -----------------------------------------===//
+// 
+// OpenMP API Version 5.1
+//
+// Uses dispatch construct as context for variant directive. When the dispatch
+// construct is reached, the variant function, add_two, should be used.
+//
+// Inspired by "OpenMP 5.1 Features: The Dispatch Construct" video:
+// https://www.youtube.com/watch?v=ruugaX95gIs
+// 
+//===-------------------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include "ompvv.h"
+#include <stdbool.h>
+
+#define N 1024
+
+int errors;
+int i = 0;
+int arr[N];
+
+void add_two(int *arr);
+
+#pragma omp declare variant(add_two) match(construct={dispatch}) 
+void add(int *arr){
+    #pragma omp parallel for
+    for (int i = 0; i < N; i++){ // Base function adds 2 to array values
+      arr[i] = arr[i]+1;
+    }
+}
+
+void add_two(int *arr){
+    for (int i = 0; i < N; i++){
+      arr[i] = arr[i]+2; // Variant function adds 4 to array values
+    }
+}
+
+int test_wrapper() { 
+    errors = 0;
+
+    add(arr);
+    for(i = 0; i < N; i++){
+        OMPVV_TEST_AND_SET(errors, arr[i] != i+1);
+    } 
+    OMPVV_ERROR_IF(errors > 0, "Base function is not working properly");
+
+    #pragma omp dispatch
+        add(arr);
+   
+    for(i = 0; i < N; i++){
+        OMPVV_TEST_AND_SET(errors, arr[i] != i+2);
+    }
+    OMPVV_ERROR_IF(errors > 0, "Dispatch is not working properly");
+    return errors;
+}
+
+int main () {
+   OMPVV_TEST_AND_SET_VERBOSE(errors, test_wrapper());
+   OMPVV_REPORT_AND_RETURN(errors);
+}  

--- a/tests/5.1/dispatch/test_dispatch.c
+++ b/tests/5.1/dispatch/test_dispatch.c
@@ -52,13 +52,15 @@ int test_wrapper() {
         add(arr);
    
     for(i = 0; i < N; i++){
-        OMPVV_TEST_AND_SET(errors, arr[i] != 3);
+        OMPVV_TEST_AND_SET(errors, arr[i] != 3 && arr[i] != 2);
     }
-    OMPVV_ERROR_IF(errors > 0, "Dispatch is not working properly");
+    OMPVV_INFOMSG_IF(errors > 0 || arr[0] == 2,
+                   "Dispatch is either not working or was not considered"
+                   " by the implementation as part of the context selector.");
     return errors;
 }
 
 int main () {
    OMPVV_TEST_AND_SET_VERBOSE(errors, test_wrapper());
    OMPVV_REPORT_AND_RETURN(errors);
-}  
+} 

--- a/tests/5.1/dispatch/test_dispatch_device.c
+++ b/tests/5.1/dispatch/test_dispatch_device.c
@@ -36,7 +36,7 @@ void add(int *arr){
 
 void add_dev(int *arr){
    for (int i = 0; i < N; i++){
-      arr[i] = arr[i]+2+omp_get_default_device(); // Variant function adds 4 to array values
+      arr[i] = arr[i]+2+omp_get_default_device(); // Variant function adds at least 2 to array values
    }
 }
 

--- a/tests/5.1/dispatch/test_dispatch_device.c
+++ b/tests/5.1/dispatch/test_dispatch_device.c
@@ -46,7 +46,7 @@ int test_wrapper() {
 
    add(arr);
    for(i = 0; i < N; i++){
-      OMPVV_TEST_AND_SET(errors, arr[i] != i+1);
+      OMPVV_TEST_AND_SET(errors, arr[i] != 1);
    } 
    OMPVV_ERROR_IF(errors > 0, "Base function is not working properly");
 
@@ -54,9 +54,11 @@ int test_wrapper() {
       add(arr);
    
    for(i = 0; i < N; i++){
-      OMPVV_TEST_AND_SET(errors, arr[i] != i+2+device_num);
+      OMPVV_TEST_AND_SET(errors, arr[i] != 2 && arr[i] != 3+device_num);
    }
-   OMPVV_ERROR_IF(errors > 0, "Dispatch is not working properly");
+   OMPVV_INFOMSG_IF(errors > 0 || arr[0] == 2,
+                   "Dispatch is either not working or was not considered"
+                   " by the implementation as part of the context selector.");
 
    return errors;
 }

--- a/tests/5.1/dispatch/test_dispatch_device.c
+++ b/tests/5.1/dispatch/test_dispatch_device.c
@@ -1,0 +1,67 @@
+//===---- test_dispatch_device.c -----------------------------------------===//
+// 
+// OpenMP API Version 5.1
+//
+// Uses dispatch construct as context for variant directive. Uses device
+// clause on last device. While default device could be used, this would
+// not change omp_get_default_device, so using the last device is more
+// exhaustive. 
+//
+// Inspired by "OpenMP 5.1 Features: The Dispatch Construct" video:
+// https://www.youtube.com/watch?v=ruugaX95gIs
+// 
+//===-------------------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include "ompvv.h"
+#include <stdbool.h>
+
+#define N 1024
+
+int errors;
+int i = 0;
+int arr[N];
+void add_dev(int *arr);
+
+#pragma omp declare variant(add_dev) match(construct={dispatch}) 
+void add(int *arr){
+   #pragma omp parallel for
+   for (int i = 0; i < N; i++){ // Base function adds 2 to array values
+      arr[i] = arr[i]+1;
+   }
+}
+
+void add_dev(int *arr){
+   for (int i = 0; i < N; i++){
+      arr[i] = arr[i]+2+omp_get_default_device(); // Variant function adds 4 to array values
+   }
+}
+
+int test_wrapper() { 
+   errors = 0;
+   int device_num = omp_get_num_devices()-1; // last available device. 
+
+   add(arr);
+   for(i = 0; i < N; i++){
+      OMPVV_TEST_AND_SET(errors, arr[i] != i+1);
+   } 
+   OMPVV_ERROR_IF(errors > 0, "Base function is not working properly");
+
+   #pragma omp dispatch device(device_num)
+      add(arr);
+   
+   for(i = 0; i < N; i++){
+      OMPVV_TEST_AND_SET(errors, arr[i] != i+2+device_num);
+   }
+   OMPVV_ERROR_IF(errors > 0, "Dispatch is not working properly");
+
+   return errors;
+}
+
+int main () {
+   OMPVV_TEST_AND_SET_VERBOSE(errors, test_wrapper());
+   OMPVV_REPORT_AND_RETURN(errors);
+}  

--- a/tests/5.1/dispatch/test_dispatch_device.c
+++ b/tests/5.1/dispatch/test_dispatch_device.c
@@ -29,7 +29,7 @@ void add_dev(int *arr);
 #pragma omp declare variant(add_dev) match(construct={dispatch}) 
 void add(int *arr){
    #pragma omp parallel for
-   for (int i = 0; i < N; i++){ // Base function adds 2 to array values
+   for (int i = 0; i < N; i++){ // Base function adds 1 to array values
       arr[i] = arr[i]+1;
    }
 }
@@ -42,7 +42,7 @@ void add_dev(int *arr){
 
 int test_wrapper() { 
    errors = 0;
-   int device_num = omp_get_num_devices()-1; // last available device. 
+   int device_num = omp_get_num_devices() ? omp_get_num_devices()-1 : 0;  // last available device. 
 
    add(arr);
    for(i = 0; i < N; i++){


### PR DESCRIPTION
Similar to PR #590
Fails w/ gcc error: `error: selector 'dispatch' not allowed for context selector set 'construct':
                                #pragma omp declare variant(add_two) match(construct={dispatch})`