### PR TITLE
Add new_test/5.1/test_target_defaultmap_present_pointer.F90

### DIFF
--- a/tests/5.1/target/test_target_defaultmap_present_pointer.F90
+++ b/tests/5.1/target/test_target_defaultmap_present_pointer.F90
@@ -1,0 +1,61 @@
+!===--- test_target_defaultmap_present_pointer.F90 ---------------------- -===//
+!
+! OpenMP API Version 5.1 Nov 2021
+!
+! This test checks behavior of the defaultmap clause when the specified 
+! implicit-behavior is present. The variable-categories available for defaultmap
+! are scalar, aggregate, and pointer. If implicit-behavior is present, each 
+! variable referenced in the construct in the category specified by 
+! variable-category is treated as if it had been listed in a map clause with the
+! map-type of alloc and map-type-modifier of present.
+!
+!//===----------------------------------------------------------------------===//
+
+#include "ompvv.F90"
+
+#define N 1024
+
+PROGRAM test_target_defaultmap_present_pointer
+  USE iso_fortran_env
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+  OMPVV_TEST_OFFLOADING
+
+  OMPVV_TEST_VERBOSE(defaultmap_present_pointer() .NE. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION defaultmap_present_pointer()
+    INTEGER :: errors, i
+    INTEGER, TARGET, DIMENSION(N) :: A !aggregate
+    INTEGER, POINTER :: ptr(:) !pointer
+
+    errors = 0
+
+    DO i = 1, N
+        A(i) = i
+    END DO
+
+    !$omp target enter data map(to: ptr)
+    !$omp target map(tofrom: errors) defaultmap(present:pointer)
+    ptr => A
+    DO i = 1, N
+        IF (ptr(i) .NE. i) then
+            errors = errors + 1
+        END IF 
+        ptr(i) = i + 2
+    END DO
+    !$omp end target
+    !$omp target exit data map(delete: ptr)
+
+    OMPVV_ERROR_IF(errors .GT. 0, "Values were not mapped to the device properly")
+
+    DO i = 1, N
+        OMPVV_TEST_AND_SET(errors, A(i) .NE. 2+i)
+    END DO
+
+    defaultmap_present_pointer = errors
+  END FUNCTION defaultmap_present_pointer
+END PROGRAM test_target_defaultmap_present_pointer

--- a/tests/5.1/target/test_target_defaultmap_present_pointer.F90
+++ b/tests/5.1/target/test_target_defaultmap_present_pointer.F90
@@ -1,6 +1,6 @@
 !===--- test_target_defaultmap_present_pointer.F90 ---------------------- -===//
 !
-! OpenMP API Version 5.1 Nov 2021
+! OpenMP API Version 5.1 Nov 2020
 !
 ! This test checks behavior of the defaultmap clause when the specified 
 ! implicit-behavior is present. The variable-categories available for defaultmap

--- a/tests/5.1/target/test_target_defaultmap_present_pointer.F90
+++ b/tests/5.1/target/test_target_defaultmap_present_pointer.F90
@@ -33,6 +33,7 @@ CONTAINS
     INTEGER, POINTER :: ptr(:) !pointer
 
     errors = 0
+    ptr => A
 
     DO i = 1, N
         A(i) = i
@@ -40,7 +41,6 @@ CONTAINS
 
     !$omp target enter data map(to: ptr)
     !$omp target map(tofrom: errors) defaultmap(present:pointer)
-    ptr => A
     DO i = 1, N
         IF (ptr(i) .NE. i) then
             errors = errors + 1

--- a/tests/5.1/target/test_target_defaultmap_present_pointer.c
+++ b/tests/5.1/target/test_target_defaultmap_present_pointer.c
@@ -1,6 +1,6 @@
 //===--- test_target_defaultmap_present_pointer.c ---------------------------===//
 //
-//  OpenMP API Version 5.1 Aug 2021
+//  OpenMP API Version 5.1 Aug 2020
 //
 //  This test checks behavior of the defaultmap clause when the specified 
 //  implicit-behavior is present. The variable-categories available for defaultmap

--- a/tests/5.1/target/test_target_defaultmap_present_pointer.c
+++ b/tests/5.1/target/test_target_defaultmap_present_pointer.c
@@ -6,7 +6,7 @@
 //  implicit-behavior is present. The variable-categories available for defaultmap
 //  are scalar, aggregate, and pointer. If implicit-behavior is present, each 
 //  variable referenced in the construct in the category specified by 
-//  variable-category is treated as if it had been listed in a map clause wih the
+//  variable-category is treated as if it had been listed in a map clause with the
 //  map-type of alloc and map-type-modifier of present.
 //
 ////===----------------------------------------------------------------------===//
@@ -43,11 +43,12 @@ int test_defaultmap_present_pointer() {
          ptr[i] = 2+i;
       }
    }
+   #pragma omp target exit data map(delete: ptr)
    
    OMPVV_ERROR_IF(errors > 0, "Values were not mapped to the device properly");
    
    for (i = 0; i < N; i++) {
-      OMPVV_TEST_AND_SET_VERBOSE(errors, A[i] != 2+i);
+      OMPVV_TEST_AND_SET(errors, A[i] != 2+i);
    }
 
    return errors;


### PR DESCRIPTION
        - GCC 12.2.1:
            - C test passed.
            - Fortran test failed: libgomp: nvptx_alloc error: out of memory
                - If `ptr => A` is added before target enter directive, the following error occurs:
                    [OMPVV_INFOMSG ompvv.F90:249] The value of errors is 1025 
        - XL 16.1.1-10:
            - C test passed but ran on the host.
            - Fortran test failed: line 42.38: 1515-022 (S) Syntax Error: Extra token " defaultmap " was found. The token is ignored.
        - NVHPC 22.11:
            - C test failed: NVC++-F-1196-OpenMP - 'defaultmap(present)' behaviour is not supported yet.
            - Fortran test failed: NVFORTRAN-S-1197-OpenMP GPU - presents cannot be used with defaultmap clause.
        - LLVM 17.0.0: C test passed.
