### PR TITLE
Adding 5.1 Loop Unroll Test

### DIFF
--- a/tests/5.1/loop/test_full_loop_unroll.c
+++ b/tests/5.1/loop/test_full_loop_unroll.c
@@ -1,0 +1,58 @@
+//===--- test_full_loop_unroll.c -----------------------------------------------===//
+//
+// OpenMP API Version 5.1 August 2021 
+//
+// This test checks the behavior of the 5.1 unroll construct (2.11.9.2 in 5.1 spec). 
+// "The unroll construct fully or partially unrolls a loop", which is more of a code generation
+// compiler feature. 
+// This test specifically checks the unroll construct with the full clause, in which the 
+// loop will be completely unrolled.
+// Referenced 5.1 Example Doc 7.2 
+////===--------------------------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+#include <math.h>
+
+# define N 1024
+
+int errors; 
+
+int test_full_loop_unroll() {
+	int arr[N];
+	int parallel_arr[N];
+	int sum = 0;
+	int parallel_sum = 0;
+
+	// sequential loop
+	for (int i = 0; i < N; i++) {
+		arr[i] = i;
+		sum += arr[i];
+	}
+
+	// omp unroll full loop
+# pragma omp unroll full
+	for (int i = 0; i < N; i++) {
+		parallel_arr[i] = i;
+	}
+
+	// sequential sum of parallel array
+	for (int i = 0; i < N; i++) {
+		parallel_sum += parallel_arr[i];
+	}
+	OMPVV_TEST_AND_SET_VERBOSE(errors, parallel_sum != sum);
+	OMPVV_INFOMSG_IF(sum == 0, "Array was not initialized.");
+	OMPVV_INFOMSG_IF(parallel_sum == 0, "Something went wrong with loop unroll.");
+	OMPVV_INFOMSG_IF(parallel_sum == sum, "Test passed.");
+	OMPVV_INFOMSG_IF(parallel_sum != sum, "Test did not pass.");
+	return errors;
+}
+
+int main() {
+	errors = 0;
+	OMPVV_TEST_OFFLOADING;
+	OMPVV_TEST_AND_SET_VERBOSE(errors, test_full_loop_unroll() != 0);
+	OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.1/loop/test_loop_unroll.c
+++ b/tests/5.1/loop/test_loop_unroll.c
@@ -22,6 +22,7 @@ int errors;
 
 int test_loop_unroll() {
 	int arr[N];
+	int parallel_arr[N];
 	int sum = 0;
 	int parallel_sum = 0;
 
@@ -34,7 +35,12 @@ int test_loop_unroll() {
 	// omp unroll loop
 # pragma omp unroll
 	for (int i = 0; i < N; i++) {
-		parallel_sum += arr[i];
+		parallel_arr[i] = i;
+	}
+
+	// sequential sum of parallel array
+	for (int i = 0; i < N; i++) {
+		parallel_sum += parallel_arr[i];
 	}
 	OMPVV_TEST_AND_SET_VERBOSE(errors, parallel_sum != sum);
 	OMPVV_INFOMSG_IF(sum == 0, "Array was not initialized.");

--- a/tests/5.1/loop/test_loop_unroll.c
+++ b/tests/5.1/loop/test_loop_unroll.c
@@ -1,0 +1,52 @@
+//===--- test_loop_unroll.c -----------------------------------------------===//
+//
+// OpenMP API Version 5.1 August 2021 
+//
+// This test checks the behavior of the 5.1 unroll construct (2.11.9.2 in 5.1 spec). 
+// "The unroll construct fully or partially unrolls a loop", which is more of a code generation
+// compiler feature. 
+// This test specifically checks the unroll construct without any clause, in which the compiler decides
+// how the loop unrolls.
+// Referenced 5.1 Example Doc 7.2 
+////===--------------------------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+#include <math.h>
+
+# define N 1024
+
+int errors; 
+
+int test_loop_unroll() {
+	int arr[N];
+	int sum = 0;
+	int parallel_sum = 0;
+
+	// sequential loop
+	for (int i = 0; i < N; i++) {
+		arr[i] = i;
+		sum += arr[i];
+	}
+
+	// omp unroll loop
+# pragma omp unroll
+	for (int i = 0; i < N; i++) {
+		parallel_sum += arr[i];
+	}
+	OMPVV_TEST_AND_SET_VERBOSE(errors, parallel_sum != sum);
+	OMPVV_INFOMSG_IF(sum == 0, "Array was not initialized.");
+	OMPVV_INFOMSG_IF(parallel_sum == 0, "Something went wrong with loop unroll.");
+	OMPVV_INFOMSG_IF(parallel_sum == sum, "Test passed.");
+	OMPVV_INFOMSG_IF(parallel_sum != sum, "Test did not pass.");
+	return errors;
+}
+
+int main() {
+	errors = 0;
+	OMPVV_TEST_OFFLOADING;
+	OMPVV_TEST_AND_SET_VERBOSE(errors, test_loop_unroll() != 0);
+	OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.1/loop/test_partial_loop_unroll.c
+++ b/tests/5.1/loop/test_partial_loop_unroll.c
@@ -1,0 +1,61 @@
+//===--- test_partial_loop_unroll.c -----------------------------------------------===//
+//
+// OpenMP API Version 5.1 August 2021 
+//
+// This test checks the behavior of the 5.1 unroll construct (2.11.9.2 in 5.1 spec). 
+// "The unroll construct fully or partially unrolls a loop", which is more of a code generation
+// compiler feature. 
+// This test specifically checks the unroll construct with the partial clause, 
+// with a loop-unroll factor which specifies: 
+// "specifies that the number of iterations will be reduced
+//  multiplicatively by the factor while the number of blocks 
+//  will be increased by the same factor." 
+// Referenced 5.1 Example Doc 7.2 
+////===--------------------------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+#include <math.h>
+
+# define N 1024
+
+int errors; 
+
+int test_partial_loop_unroll() {
+	int arr[N];
+	int parallel_arr[N];
+	int sum = 0;
+	int parallel_sum = 0;
+
+	// sequential loop
+	for (int i = 0; i < N; i++) {
+		arr[i] = i;
+		sum += arr[i];
+	}
+
+	// omp unroll loop partially
+# pragma omp unroll partial(4)
+	for (int i = 0; i < N; i++) {
+		parallel_arr[i] = i;
+	}
+
+	// sequential sum of parallel array
+	for (int i = 0; i < N; i++) {
+		parallel_sum += parallel_arr[i];
+	}
+	OMPVV_TEST_AND_SET_VERBOSE(errors, parallel_sum != sum);
+	OMPVV_INFOMSG_IF(sum == 0, "Array was not initialized.");
+	OMPVV_INFOMSG_IF(parallel_sum == 0, "Something went wrong with loop unroll.");
+	OMPVV_INFOMSG_IF(parallel_sum == sum, "Test passed.");
+	OMPVV_INFOMSG_IF(parallel_sum != sum, "Test did not pass.");
+	return errors;
+}
+
+int main() {
+	errors = 0;
+	OMPVV_TEST_OFFLOADING;
+	OMPVV_TEST_AND_SET_VERBOSE(errors, test_partial_loop_unroll() != 0);
+	OMPVV_REPORT_AND_RETURN(errors);
+}


### PR DESCRIPTION
PR is complete and ready for review. 
Added three new tests: 
* test_loop_unroll.c: test default loop unroll behavior when a clause is not provided. 
* test_full_loop_unroll.c: tests loop unroll with full clause 
* test_partial_loop_unroll.c: tests loop unroll with partial clause and unroll factor.

All three tests pass with LLVM 17.
