### PR TITLE
Add new_test/5.1/test_target_memcpy_async_depobj.F90

### DIFF
--- a/tests/5.1/target/test_target_memcpy_async_depobj.F90
+++ b/tests/5.1/target/test_target_memcpy_async_depobj.F90
@@ -30,7 +30,7 @@ CONTAINS
   INTEGER FUNCTION test_memcpy_async_depobj()
     INTEGER :: errors, i
     DOUBLE PRECISION, TARGET, ALLOCATABLE :: arr(:)
-    DOUBLE PRECISION, POINTER :: fptr
+    DOUBLE PRECISION, POINTER :: fptr(:)
     TYPE (C_PTR) :: mem, mem_dev_cpy
     INTEGER (C_SIZE_T) :: csize, dst_offset, src_offset
     INTEGER (C_INT) :: h, t, depobj_count
@@ -62,7 +62,7 @@ CONTAINS
 
     !$omp taskwait depend(depobj: obj)
     !$omp target is_device_ptr(mem_dev_cpy) device(t) depend(depobj: obj)
-    CALL c_f_pointer(mem_dev_cpy, fptr)
+    CALL c_f_pointer(mem_dev_cpy, fptr, [N])
     DO i=1, N
       fptr(i) = fptr(i) * 2 ! initialize data
     END DO

--- a/tests/5.1/target/test_target_memcpy_async_depobj.F90
+++ b/tests/5.1/target/test_target_memcpy_async_depobj.F90
@@ -79,6 +79,7 @@ CONTAINS
     END IF
 
     !$omp taskwait depend(depobj: obj)
+    fptr => null()  ! Avoid transfering the undefined pointer target
     !$omp target is_device_ptr(mem_dev_cpy) device(t) depend(depobj: obj)
     CALL c_f_pointer(mem_dev_cpy, fptr, [N])
     DO i=1, N

--- a/tests/5.1/target/test_target_memcpy_async_depobj.F90
+++ b/tests/5.1/target/test_target_memcpy_async_depobj.F90
@@ -1,0 +1,87 @@
+!===--- test_target_memcpy_async_depobj.F90 ---------------------------------------------===//
+!
+! OpenMP API Version 5.1 Nov 2020
+!
+!  Inspired from OpenMP 5.1 Examples Doc, 5.16.4 & 8.9
+!  This test utilizes the omp_target_memcpy_async construct to
+!  allocate memory on the device asynchronously. The construct
+!  uses 'obj' for dependency, so that memory is only copied once
+!  the variable listed in the depend clause is changed.
+!
+!//===-----------------------------------------------------------------------------------------===//
+
+#include "ompvv.F90"
+
+#define N 1024
+
+PROGRAM test_target_memcpy_async_depobj
+  USE iso_fortran_env
+  USE, INTRINSIC :: iso_c_binding
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+  OMPVV_TEST_OFFLOADING
+
+  OMPVV_TEST_VERBOSE(test_memcpy_async_depobj() .NE. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION test_memcpy_async_depobj()
+    INTEGER :: errors, i
+    DOUBLE PRECISION, TARGET, ALLOCATABLE :: arr(:)
+    DOUBLE PRECISION, POINTER :: fptr
+    TYPE (C_PTR) :: mem, mem_dev_cpy
+    INTEGER (C_SIZE_T) :: csize, dst_offset, src_offset
+    INTEGER (C_INT) :: h, t, depobj_count
+    INTEGER (omp_depend_kind) :: obj, obj_arr(1)
+
+    errors = 0
+    h = omp_get_initial_device()
+    t = omp_get_default_device()
+    dst_offset = 0
+    src_offset = 0
+    depobj_count = 1
+
+    ALLOCATE(arr(N))
+    mem = c_loc(arr(1))
+    csize = c_sizeof(arr(1)) * N
+    mem_dev_cpy = omp_target_alloc(csize, t)
+
+    OMPVV_TEST_AND_SET_VERBOSE(errors, .NOT. c_associated(mem_dev_cpy))
+
+    DO i=1, N
+      arr(i) = i
+    END DO
+
+    !$omp depobj(obj) depend(inout: mem_dev_cpy)
+    obj_arr(1) = obj
+
+    ! copy to device memory
+    omp_target_memcpy_async(mem_dev_cpy, mem, csize, dst_offset, src_offset, t, h, depobj_count, obj_arr)
+
+    !$omp taskwait depend(depobj: obj)
+    !$omp target is_device_ptr(mem_dev_cpy) device(t) depend(depobj: obj)
+    CALL c_f_pointer(mem_dev_cpy, fptr)
+    DO i=1, N
+      fptr(i) = fptr(i) * 2 ! initialize data
+    END DO
+    !$omp end target
+
+    ! copy to host memory
+    omp_target_memcpy_async(mem, mem_dev_cpy, csize, dst_offset, src_offset, h, t, depobj_count, obj_arr)
+
+    !$omp taskwait depend(depobj: obj)
+    DO i=1, N
+      OMPVV_TEST_AND_SET(errors, arr(i) .NE. i*2)
+    END DO
+
+    ! free resources
+    DEALLOCATE(arr)
+    omp_target_free(mem_dev_cpy, t)
+    !$omp depobj(obj) destroy
+
+    test_memcpy_async_depobj = errors
+  END FUNCTION test_memcpy_async_depobj
+END PROGRAM test_target_memcpy_async_depobj
+

--- a/tests/5.1/target/test_target_memcpy_async_depobj.F90
+++ b/tests/5.1/target/test_target_memcpy_async_depobj.F90
@@ -47,7 +47,7 @@ CONTAINS
     mem = c_loc(arr(1))
     csize = c_sizeof(arr(1)) * N
     mem_dev_cpy = omp_target_alloc(csize, t)
-
+ 
     OMPVV_TEST_AND_SET_VERBOSE(errors, .NOT. c_associated(mem_dev_cpy))
 
     DO i=1, N
@@ -58,7 +58,7 @@ CONTAINS
     obj_arr(1) = obj
 
     ! copy to device memory
-    omp_target_memcpy_async(mem_dev_cpy, mem, csize, dst_offset, src_offset, t, h, depobj_count, obj_arr)
+    errors = omp_target_memcpy_async(mem_dev_cpy, mem, csize, dst_offset, src_offset, t, h, depobj_count, obj_arr)
 
     !$omp taskwait depend(depobj: obj)
     !$omp target is_device_ptr(mem_dev_cpy) device(t) depend(depobj: obj)
@@ -69,7 +69,7 @@ CONTAINS
     !$omp end target
 
     ! copy to host memory
-    omp_target_memcpy_async(mem, mem_dev_cpy, csize, dst_offset, src_offset, h, t, depobj_count, obj_arr)
+    errors = omp_target_memcpy_async(mem, mem_dev_cpy, csize, dst_offset, src_offset, h, t, depobj_count, obj_arr)
 
     !$omp taskwait depend(depobj: obj)
     DO i=1, N
@@ -78,7 +78,7 @@ CONTAINS
 
     ! free resources
     DEALLOCATE(arr)
-    omp_target_free(mem_dev_cpy, t)
+    CALL omp_target_free(mem_dev_cpy, t)
     !$omp depobj(obj) destroy
 
     test_memcpy_async_depobj = errors

--- a/tests/5.1/target/test_target_memcpy_async_depobj.F90
+++ b/tests/5.1/target/test_target_memcpy_async_depobj.F90
@@ -1,4 +1,4 @@
-!===--- test_target_memcpy_async_depobj.F90 ---------------------------------------------===//
+!===--- test_target_memcpy_async_depobj.F90 ------------------------------===//
 !
 ! OpenMP API Version 5.1 Nov 2020
 !
@@ -8,7 +8,7 @@
 !  uses 'obj' for dependency, so that memory is only copied once
 !  the variable listed in the depend clause is changed.
 !
-!//===-----------------------------------------------------------------------------------------===//
+!//===--------------------------------------------------------------------===//
 
 #include "ompvv.F90"
 
@@ -48,6 +48,12 @@ CONTAINS
     csize = c_sizeof(arr(1)) * N
     mem_dev_cpy = omp_target_alloc(csize, t)
  
+    OMPVV_TEST_AND_SET_VERBOSE(errors, .NOT. c_associated(mem))
+    IF(.NOT. c_associated(mem)) THEN
+      test_memcpy_async_depobj = errors
+      RETURN  
+    END IF
+
     OMPVV_TEST_AND_SET_VERBOSE(errors, .NOT. c_associated(mem_dev_cpy))
     IF(.NOT. c_associated(mem_dev_cpy)) THEN
       test_memcpy_async_depobj = errors
@@ -63,6 +69,14 @@ CONTAINS
 
     ! copy to device memory
     errors = omp_target_memcpy_async(mem_dev_cpy, mem, csize, dst_offset, src_offset, t, h, depobj_count, obj_arr)
+
+    IF(errors /= 0) THEN
+      OMPVV_ERROR("omp_target_memcpy_async returns not 0");
+      DEALLOCATE(arr)
+      CALL omp_target_free(mem_dev_cpy, t)
+      test_memcpy_async_depobj = errors
+      RETURN  
+    END IF
 
     !$omp taskwait depend(depobj: obj)
     !$omp target is_device_ptr(mem_dev_cpy) device(t) depend(depobj: obj)

--- a/tests/5.1/target/test_target_memcpy_async_depobj.F90
+++ b/tests/5.1/target/test_target_memcpy_async_depobj.F90
@@ -49,6 +49,10 @@ CONTAINS
     mem_dev_cpy = omp_target_alloc(csize, t)
  
     OMPVV_TEST_AND_SET_VERBOSE(errors, .NOT. c_associated(mem_dev_cpy))
+    IF(.NOT. c_associated(mem_dev_cpy)) THEN
+      test_memcpy_async_depobj = errors
+      RETURN  
+    END IF
 
     DO i=1, N
       arr(i) = i

--- a/tests/5.1/target/test_target_memcpy_async_depobj.F90
+++ b/tests/5.1/target/test_target_memcpy_async_depobj.F90
@@ -85,6 +85,7 @@ CONTAINS
     DO i=1, N
       fptr(i) = fptr(i) * 2 ! initialize data
     END DO
+    fptr => null()  ! Reset to value of the beginning of the target region
     !$omp end target
 
     ! copy to host memory

--- a/tests/5.1/target/test_target_memcpy_async_depobj.c
+++ b/tests/5.1/target/test_target_memcpy_async_depobj.c
@@ -34,6 +34,9 @@ int test_target_memcpy_async_depobj() {
     mem_dev_cpy = (double *)omp_target_alloc( sizeof(double)*N, t);
 
     OMPVV_TEST_AND_SET_VERBOSE(errors, mem_dev_cpy == NULL);
+    if(mem_dev_cpy == NULL) {
+       return errors;
+    }
 
     for(i = 0; i < N; i++){
         mem[i] = i;

--- a/tests/5.1/target/test_target_memcpy_async_depobj.c
+++ b/tests/5.1/target/test_target_memcpy_async_depobj.c
@@ -1,4 +1,6 @@
-//===--- test_target_memcpy_async_depobj.c ----------------------------===//
+//===--- test_target_memcpy_async_depobj.c --------------------------------===//
+//
+//  OpenMP API Version 5.1 Nov 2020
 //
 //  Inspired from OpenMP 5.1 Examples Doc, 5.16.4 & 8.9
 //  This test utilizes the omp_target_memcpy_async construct to
@@ -6,7 +8,7 @@
 //  uses 'obj' for dependency, so that memory is only copied once
 //  the variable listed in the depend clause is changed.
 //
-////===----------------------------------------------------------------------===//
+////===--------------------------------------------------------------------===//
 
 #include <omp.h>
 #include <stdio.h>


### PR DESCRIPTION
        - GCC 12.2.1:
            - C test passed.
            - Fortran test failed: Error: 'omp_target_memcpy_async' at (1) is not a variable
        - XL 16.1.1-10:
            - C test failed: error: unknown type name 'omp_depend_t';
            - Fortran test failed: line 36.14: 1516-036 (S) Entity omp_depend_kind has undefined type.
        - NVHPC 22.11:
            - C test failed: line 42: error: invalid text in pragma
            - Fortran test failed: NVFORTRAN-W-0287-Unrecognized OpenMP directive - depobj 
        - LLVM 17.0.0:
            - C test passed.