### PR TITLE
Add new_test/5.1/test_target_memcpy_async_no_obj.F90

### DIFF
--- a/tests/5.1/target/test_target_memcpy_async_no_obj.F90
+++ b/tests/5.1/target/test_target_memcpy_async_no_obj.F90
@@ -58,6 +58,7 @@ CONTAINS
     ! copy to target
     omp_target_memcpy_async(mem_dev_cpy, mem, csize, dst_offset, src_offset, t, h, depobj_count)
 
+    !$omp taskwait
     !$omp target is_device_ptr(mem_dev_cpy) device(t)
     !$omp teams distribute parallel do
     DO i=1, N

--- a/tests/5.1/target/test_target_memcpy_async_no_obj.F90
+++ b/tests/5.1/target/test_target_memcpy_async_no_obj.F90
@@ -56,7 +56,7 @@ CONTAINS
     END DO
 
     ! copy to target
-    omp_target_memcpy_async(mem_dev_cpy, mem, csize, dst_offset, src_offset, t, h, depobj_count)
+    errors = omp_target_memcpy_async(mem_dev_cpy, mem, csize, dst_offset, src_offset, t, h, depobj_count)
 
     !$omp taskwait
     !$omp target is_device_ptr(mem_dev_cpy) device(t)
@@ -69,7 +69,7 @@ CONTAINS
     !$omp end target
 
     ! copy to host memory
-    omp_target_memcpy_async(mem, mem_dev_cpy, csize, dst_offset, src_offset, h, t, depobj_count)
+    errors = omp_target_memcpy_async(mem, mem_dev_cpy, csize, dst_offset, src_offset, h, t, depobj_count)
 
     !$omp taskwait
     DO i=1, N
@@ -78,7 +78,7 @@ CONTAINS
 
     ! free resources
     DEALLOCATE(arr)
-    omp_target_free(mem_dev_cpy, t)
+    CALL omp_target_free(mem_dev_cpy, t)
 
     test_memcpy_async_no_obj = errors
   END FUNCTION test_memcpy_async_no_obj

--- a/tests/5.1/target/test_target_memcpy_async_no_obj.F90
+++ b/tests/5.1/target/test_target_memcpy_async_no_obj.F90
@@ -5,8 +5,8 @@
 !  Inspired from OpenMP 5.1 Examples Doc, 5.16.4 & 8.9
 !  This test utilizes the omp_target_memcpy_async construct to
 !  allocate memory on the device asynchronously. The construct
-!  uses 0 for 'depobj_count', so that the clause is not dependent
-!  and memory is therefore copied synchronously.
+!  uses 0 for 'depobj_count'; therefore, the generated target task
+!  is not a dependent task, but the memory copy is still asynchronous.
 !
 !//===---------------------------------------------------------------------===//
 

--- a/tests/5.1/target/test_target_memcpy_async_no_obj.F90
+++ b/tests/5.1/target/test_target_memcpy_async_no_obj.F90
@@ -56,7 +56,7 @@ CONTAINS
 
     OMPVV_TEST_AND_SET_VERBOSE(errors, .NOT. c_associated(mem_dev_cpy))
     IF(.NOT. c_associated(mem_dev_cpy)) THEN
-      test_memcpy_async_depobj = errors
+      test_memcpy_async_no_obj = errors
       RETURN  
     END IF
 

--- a/tests/5.1/target/test_target_memcpy_async_no_obj.F90
+++ b/tests/5.1/target/test_target_memcpy_async_no_obj.F90
@@ -30,7 +30,6 @@ CONTAINS
   INTEGER FUNCTION test_memcpy_async_no_obj()
     INTEGER :: errors, i
     DOUBLE PRECISION, TARGET, ALLOCATABLE :: arr(:)
-    DOUBLE PRECISION, POINTER :: fptr(:)
     TYPE (C_PTR) :: mem, mem_dev_cpy
     INTEGER (C_SIZE_T) :: csize, dst_offset, src_offset
     INTEGER (C_INT) :: h, t, depobj_count

--- a/tests/5.1/target/test_target_memcpy_async_no_obj.F90
+++ b/tests/5.1/target/test_target_memcpy_async_no_obj.F90
@@ -79,8 +79,11 @@ CONTAINS
     !$omp target is_device_ptr(mem_dev_cpy) device(t)
     !$omp teams distribute parallel do
     DO i=1, N
+      BLOCK
+      DOUBLE PRECISION, POINTER :: fptr(:)
       CALL c_f_pointer(mem_dev_cpy, fptr, [N])
       fptr(i) = fptr(i) * 2 ! initialize data on device
+      END BLOCK
     END DO
     !$omp end teams distribute parallel do
     !$omp end target

--- a/tests/5.1/target/test_target_memcpy_async_no_obj.F90
+++ b/tests/5.1/target/test_target_memcpy_async_no_obj.F90
@@ -30,7 +30,7 @@ CONTAINS
   INTEGER FUNCTION test_memcpy_async_no_obj()
     INTEGER :: errors, i
     DOUBLE PRECISION, TARGET, ALLOCATABLE :: arr(:)
-    DOUBLE PRECISION, POINTER :: fptr
+    DOUBLE PRECISION, POINTER :: fptr(:)
     TYPE (C_PTR) :: mem, mem_dev_cpy
     INTEGER (C_SIZE_T) :: csize, dst_offset, src_offset
     INTEGER (C_INT) :: h, t, depobj_count
@@ -62,7 +62,7 @@ CONTAINS
     !$omp target is_device_ptr(mem_dev_cpy) device(t)
     !$omp teams distribute parallel do
     DO i=1, N
-      CALL c_f_pointer(mem_dev_cpy, fptr)
+      CALL c_f_pointer(mem_dev_cpy, fptr, [N])
       fptr(i) = fptr(i) * 2 ! initialize data on device
     END DO
     !$omp end teams distribute parallel do

--- a/tests/5.1/target/test_target_memcpy_async_no_obj.F90
+++ b/tests/5.1/target/test_target_memcpy_async_no_obj.F90
@@ -1,0 +1,85 @@
+!===--- test_target_memcpy_async_no_obj.F90 -------------------------------===//
+!
+! OpenMP API Version 5.1 Nov 2020
+!
+!  Inspired from OpenMP 5.1 Examples Doc, 5.16.4 & 8.9
+!  This test utilizes the omp_target_memcpy_async construct to
+!  allocate memory on the device asynchronously. The construct
+!  uses 0 for 'depobj_count', so that the clause is not dependent
+!  and memory is therefore copied synchronously.
+!
+!//===---------------------------------------------------------------------===//
+
+#include "ompvv.F90"
+
+#define N 1024
+
+PROGRAM test_target_memcpy_async_no_obj
+  USE iso_fortran_env
+  USE, INTRINSIC :: iso_c_binding
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+  OMPVV_TEST_OFFLOADING
+
+  OMPVV_TEST_VERBOSE(test_memcpy_async_no_obj() .NE. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION test_memcpy_async_no_obj()
+    INTEGER :: errors, i
+    DOUBLE PRECISION, TARGET, ALLOCATABLE :: arr(:)
+    DOUBLE PRECISION, POINTER :: fptr
+    TYPE (C_PTR) :: mem, mem_dev_cpy
+    INTEGER (C_SIZE_T) :: csize, dst_offset, src_offset
+    INTEGER (C_INT) :: h, t, depobj_count
+
+    errors = 0
+    h = omp_get_initial_device()
+    t = omp_get_default_device()
+    dst_offset = 0
+    src_offset = 0
+    depobj_count = 0
+
+    OMPVV_TEST_AND_SET_VERBOSE(errors, omp_get_num_devices() .LT. 1 .OR. t .LT. 0)
+
+    ALLOCATE(arr(N))
+    mem = c_loc(arr(1))
+    csize = c_sizeof(arr(1)) * N
+    mem_dev_cpy = omp_target_alloc(csize, t)
+
+    OMPVV_TEST_AND_SET_VERBOSE(errors, .NOT. c_associated(mem_dev_cpy))
+
+    DO i=1, N
+      arr(i) = i
+    END DO
+
+    ! copy to target
+    omp_target_memcpy_async(mem_dev_cpy, mem, csize, dst_offset, src_offset, t, h, depobj_count)
+
+    !$omp target is_device_ptr(mem_dev_cpy) device(t)
+    !$omp teams distribute parallel do
+    DO i=1, N
+      CALL c_f_pointer(mem_dev_cpy, fptr)
+      fptr(i) = fptr(i) * 2 ! initialize data on device
+    END DO
+    !$omp end teams distribute parallel do
+    !$omp end target
+
+    ! copy to host memory
+    omp_target_memcpy_async(mem, mem_dev_cpy, csize, dst_offset, src_offset, h, t, depobj_count)
+
+    !$omp taskwait
+    DO i=1, N
+      OMPVV_TEST_AND_SET(errors, arr(i) .NE. i*2)
+    END DO
+
+    ! free resources
+    DEALLOCATE(arr)
+    omp_target_free(mem_dev_cpy, t)
+
+    test_memcpy_async_no_obj = errors
+  END FUNCTION test_memcpy_async_no_obj
+END PROGRAM test_target_memcpy_async_no_obj
+

--- a/tests/5.1/target/test_target_memcpy_async_no_obj.F90
+++ b/tests/5.1/target/test_target_memcpy_async_no_obj.F90
@@ -71,7 +71,7 @@ CONTAINS
       OMPVV_ERROR("omp_target_memcpy_async returns not 0");
       DEALLOCATE(arr)
       CALL omp_target_free(mem_dev_cpy, t)
-      test_memcpy_async_depobj = errors
+      test_memcpy_async_no_obj = errors
       RETURN
     END IF
 

--- a/tests/5.1/target/test_target_memcpy_async_no_obj.F90
+++ b/tests/5.1/target/test_target_memcpy_async_no_obj.F90
@@ -50,7 +50,7 @@ CONTAINS
 
     OMPVV_TEST_AND_SET_VERBOSE(errors, .NOT. c_associated(mem))
     IF(.NOT. c_associated(mem)) THEN
-      test_memcpy_async_depobj = errors
+      test_memcpy_async_no_obj = errors
       RETURN
     END IF
 

--- a/tests/5.1/target/test_target_memcpy_async_no_obj.c
+++ b/tests/5.1/target/test_target_memcpy_async_no_obj.c
@@ -1,6 +1,6 @@
-//===--- test_target_memcpy_async_no_obj.c ----------------------------===//
+//===--- test_target_memcpy_async_no_obj.c --------------------------------===//
 //
-//  OpenMP API Version 5.1 Aug 2021
+//  OpenMP API Version 5.1 Nov 2020
 //
 //  Inspired from OpenMP 5.1 Examples Doc, 5.16.4 & 8.9
 //  This test utilizes the omp_target_memcpy_async construct to
@@ -8,7 +8,7 @@
 //  uses 0 for 'depobj_count', so that the clause is not dependent
 //  and memory is therefore copied synchronously.
 //
-////===----------------------------------------------------------------------===//
+////===--------------------------------------------------------------------===//
 
 #include <omp.h>
 #include <stdio.h>
@@ -36,6 +36,10 @@ int test_target_memcpy_async_no_obj() {
     mem_dev_cpy = (double *)omp_target_alloc( sizeof(double)*N, t);
 
     OMPVV_TEST_AND_SET_VERBOSE(errors, mem_dev_cpy == NULL);
+
+    for(i = 0; i < N; i++){
+        mem[i] = i;
+    }   
 
     /* copy to target */
     omp_target_memcpy_async(mem_dev_cpy, mem, sizeof(double)*N,

--- a/tests/5.1/target/test_target_memcpy_async_no_obj.c
+++ b/tests/5.1/target/test_target_memcpy_async_no_obj.c
@@ -47,6 +47,7 @@ int test_target_memcpy_async_no_obj() {
                                 t,          h,
                                 0,          NULL);
 
+    #pragma omp taskwait
     #pragma omp target is_device_ptr(mem_dev_cpy) device(t)
     #pragma omp teams distribute parallel for
     for(i = 0; i < N; i++){

--- a/tests/5.1/target/test_target_memcpy_async_no_obj.c
+++ b/tests/5.1/target/test_target_memcpy_async_no_obj.c
@@ -5,8 +5,8 @@
 //  Inspired from OpenMP 5.1 Examples Doc, 5.16.4 & 8.9
 //  This test utilizes the omp_target_memcpy_async construct to
 //  allocate memory on the device asynchronously. The construct
-//  uses 0 for 'depobj_count', so that the clause is not dependent
-//  and memory is therefore copied synchronously.
+//  uses 0 for 'depobj_count'; therefore, the generated target task
+//  is not a dependent task, but the memory copy is still asynchronous.
 //
 ////===--------------------------------------------------------------------===//
 


### PR DESCRIPTION
        - GCC 12.2.1:
            - C test passed.
            - Fortran test failed: Error: 'omp_target_memcpy_async' at (1) is not a variable
        - XL 16.1.1-10:
            - C test failed: undefined reference to `omp_target_memcpy_async'
            - Fortran test failed: line 50.19: 1516-036 (S) Entity omp_target_alloc has undefined type.
        - NVHPC 22.11:
            - C test failed: FAIL. exit code: 134
            - Fortran test failed: NVFORTRAN-S-0034-Syntax error at or near end of line 59
        - LLVM 17.0.0:
            - C test failed: Condition test_target_memcpy_async_no_obj() != 0 failed 