### PR TITLE
Add new_test/5.1/test_target_memcpy_rect_async_no_obj.F90

### DIFF
--- a/tests/5.1/target/test_target_memcpy_rect_async_no_obj.F90
+++ b/tests/5.1/target/test_target_memcpy_rect_async_no_obj.F90
@@ -1,0 +1,93 @@
+!===--- test_target_memcpy_rect_async_no_obj.F90 -------------------------------===//
+!
+! OpenMP API Version 5.1 Nov 2020
+!
+! Inspired from OpenMP 5.1 Examples Doc, 5.16.4 & 8.9
+! This test utilizes the omp_target_memcpy_rect_async construct to
+! allocate 2D memory on the device asynchronously. The construct
+! uses '0' for 'depobj_count', so that the clause is not dependent
+! and memory is therefore copied synchronously.
+!
+!//===---------------------------------------------------------------------===//
+
+#include "ompvv.F90"
+
+#define N 5
+#define M 10
+
+PROGRAM test_target_memcpy_rect_async_no_obj
+  USE iso_fortran_env
+  USE, INTRINSIC :: iso_c_binding
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+  OMPVV_TEST_OFFLOADING
+
+  OMPVV_TEST_VERBOSE(test_memcpy_rect_async_no_obj() .NE. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION test_memcpy_rect_async_no_obj()
+    INTEGER :: errors, i, j
+    DOUBLE PRECISION, POINTER :: fptr(:)
+    TYPE (C_PTR) :: mem, devRect
+    INTEGER (C_SIZE_T) :: csize
+    INTEGER (C_SIZE_T) :: offsets(2), volume(2), dimensions(2)
+    INTEGER (C_INT) :: h, t, depobj_count, num_dims
+    DOUBLE PRECISION, TARGET :: hostRect(M,N)
+
+    errors = 0
+    h = omp_get_initial_device()
+    t = omp_get_default_device()
+    volume = (/ 10, 5 /)
+    offsets = (/ 0, 0 /)
+    dimensions = (/ M, N /)
+    depobj_count = 0
+    num_dims = 2
+
+    OMPVV_TEST_AND_SET_VERBOSE(errors, omp_get_num_devices() .LT. 1 .OR. t .LT. 0)
+
+    mem = c_loc(hostRect(1,1))
+    csize = c_sizeof(hostRect(1,1)) * M * N
+    devRect = omp_target_alloc(csize, t)
+
+    OMPVV_TEST_AND_SET_VERBOSE(errors, .NOT. c_associated(devRect))
+
+    DO i=1, N
+      DO j=1, M
+      hostRect(j,i) = i + j
+      END DO
+    END DO
+
+    csize = c_sizeof(hostRect(1,1))
+    ! copy to device memory
+    omp_target_memcpy_async(devRect, mem, csize, num_dims, volume, offsets, offsets, dimensions, dimensions, t, h, depobj_count)
+
+    !$omp taskwait
+    !$omp target is_device_ptr(devRect) device(t)
+    DO i=1, N
+      DO j=1, M
+        CALL c_f_pointer(devRect, fptr, [M*N])
+        fptr(i*M+j) = fptr(i*M+j) * 2 ! initialize data
+      END DO
+    END DO
+    !$omp end target
+
+    ! copy to host memory
+    omp_target_memcpy_async(mem, devRect, csize, num_dims, volume, offsets, offsets, dimensions, dimensions, h, t, depobj_count)
+
+    !$omp taskwait
+    DO i=1, N
+      DO j=1, N
+        OMPVV_TEST_AND_SET(errors, hostRect(j,i) .NE. (i+j)*2)
+      END DO
+    END DO
+
+    ! free resources
+    omp_target_free(devRect, t)
+
+    test_memcpy_rect_async_no_obj = errors
+  END FUNCTION test_memcpy_rect_async_no_obj
+END PROGRAM test_target_memcpy_rect_async_no_obj
+

--- a/tests/5.1/target/test_target_memcpy_rect_async_no_obj.F90
+++ b/tests/5.1/target/test_target_memcpy_rect_async_no_obj.F90
@@ -40,7 +40,7 @@ CONTAINS
     errors = 0
     h = omp_get_initial_device()
     t = omp_get_default_device()
-    volume = (/ 10, 5 /)
+    volume = (/ M, N /)
     offsets = (/ 0, 0 /)
     dimensions = (/ M, N /)
     depobj_count = 0

--- a/tests/5.1/target/test_target_memcpy_rect_async_no_obj.F90
+++ b/tests/5.1/target/test_target_memcpy_rect_async_no_obj.F90
@@ -62,7 +62,7 @@ CONTAINS
 
     csize = c_sizeof(hostRect(1,1))
     ! copy to device memory
-    omp_target_memcpy_async(devRect, mem, csize, num_dims, volume, offsets, offsets, dimensions, dimensions, t, h, depobj_count)
+    errors = omp_target_memcpy_rect_async(devRect, mem, csize, num_dims, volume, offsets, offsets, dimensions, dimensions, t, h, depobj_count)
 
     !$omp taskwait
     !$omp target is_device_ptr(devRect) device(t)
@@ -75,7 +75,7 @@ CONTAINS
     !$omp end target
 
     ! copy to host memory
-    omp_target_memcpy_async(mem, devRect, csize, num_dims, volume, offsets, offsets, dimensions, dimensions, h, t, depobj_count)
+    errors = omp_target_memcpy_rect_async(mem, devRect, csize, num_dims, volume, offsets, offsets, dimensions, dimensions, h, t, depobj_count)
 
     !$omp taskwait
     DO i=1, N
@@ -85,7 +85,7 @@ CONTAINS
     END DO
 
     ! free resources
-    omp_target_free(devRect, t)
+    CALL omp_target_free(devRect, t)
 
     test_memcpy_rect_async_no_obj = errors
   END FUNCTION test_memcpy_rect_async_no_obj

--- a/tests/5.1/target/test_target_memcpy_rect_async_no_obj.c
+++ b/tests/5.1/target/test_target_memcpy_rect_async_no_obj.c
@@ -1,5 +1,7 @@
 //===--- test_target_memcpy_rect_async_no_obj.c ----------------------------===//
 //
+//  OpenMP API Version 5.1 Nov 2020
+//
 //  Inspired from OpenMP 5.1 Examples Doc, 5.16.4 & 8.9
 //  This test utilizes the omp_target_memcpy_rect_async construct to
 //  allocate 2D memory on the device asynchronously. The construct
@@ -50,6 +52,7 @@ int test_target_memcpy_async_depobj() {
                                 t,          h,
                                 0,          NULL);  // no dependent objects, 'depobj_list' i.e. NULL is ignored
 
+    #pragma omp taskwait
     #pragma omp target is_device_ptr(devRect) device(t)
     {
         for(i = 0; i < N; i++){
@@ -68,8 +71,9 @@ int test_target_memcpy_async_depobj() {
                                 h,          t,
                                 0,          NULL);
 
+    #pragma omp taskwait
     for(i = 0; i < N; i++){
-        for(j = 0; j < N; j++){
+        for(j = 0; j < M; j++){
             OMPVV_TEST_AND_SET(errors, hostRect[i][j]!=(i+j)*2);
         }
     }


### PR DESCRIPTION
Add new_test/5.1/test_target_memcpy_rect_async_no_obj.F90
Add missing task wait directives to the C version.

        - GCC 12.2.1:
            - C test passed.
            - Fortran test failed: Error: 'omp_target_memcpy_async' at (1) is not a variable
        - XL 16.1.1-10:
            - C test failed: undefined reference to `omp_target_memcpy_rect_async'
            - Fortran test failed: line 53.15: 1516-036 (S) Entity omp_target_alloc has undefined type.
        - NVHPC 22.11:
            - C test failed: FAIL. exit code: 134
            - Fortran test failed: NVFORTRAN-S-0034-Syntax error at or near end of line 65
        - LLVM 17.0.0:
            - C test passed.