### PR TITLE
Add new_test/5.1/test_target_map_iterators.F90

### DIFF
--- a/tests/5.1/target/test_target_map_iterators.F90
+++ b/tests/5.1/target/test_target_map_iterators.F90
@@ -1,0 +1,55 @@
+!===--- test_target_map_iterator.F90 ----------------------------------===//
+!
+! OpenMP API Version 5.1 Nov 2020
+!
+! This test is designed to test the iterator map-type-modifier for the map
+! clause. The test should create a list of size N and then pass to the 
+! target region the length of the array 1:N and modify the values.
+! The test then checks to see if the appropriate range was modified.
+!
+!//===-----------------------------------------------------------------===//
+
+#include "ompvv.F90"
+
+#define N 1024
+
+PROGRAM test_target_map_iterator
+  USE iso_fortran_env
+  USE, INTRINSIC :: iso_c_binding
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+  OMPVV_TEST_OFFLOADING
+
+  OMPVV_TEST_VERBOSE(test_map_iterator() .NE. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION test_map_iterator()
+    INTEGER :: errors, i, listsum
+    INTEGER, DIMENSION(N) :: test_lst
+
+    errors = 0
+    listsum = 0
+
+    DO i=1, N
+      test_lst(i) = 1
+    END DO
+
+    !$omp target map(iterator(it = 1:N), tofrom: test_lst(it))
+    DO i=1, N
+      test_lst(i) = 2
+    END DO
+    !$omp end target
+
+    DO i=1, N
+      listsum = listsum + test_lst(i)
+    END DO
+
+    OMPVV_TEST_AND_SET(errors, listsum .NE. 2*N)
+
+    test_map_iterator = errors
+  END FUNCTION test_map_iterator
+END PROGRAM test_target_map_iterator
+

--- a/tests/5.1/target/test_target_map_iterators.c
+++ b/tests/5.1/target/test_target_map_iterators.c
@@ -1,6 +1,6 @@
-//-------------------------test_map_iterator.c-----------------------------
+//-------------------------test_target_map_iterator.c----------------------
 //
-//OpenMP API Version 5.1 Jan 2023
+//OpenMP API Version 5.1 Nov 2020
 //
 // This test is designed to test the iterator map-type-modifier for the map
 // clause. The test should create a list of size N and then pass to the 


### PR DESCRIPTION
        - GCC 12.2.1:
            - C test failed: error: 'iterator' undeclared (first use in this function)
            - Fortran test failed: Error: Syntax error in OpenMP variable list at (1)
        - XL 16.1.1-10:
            - C test passed but ran on the host.
            - Fortran test failed: line 40.37: 1515-019 (S) Syntax is incorrect.
        - NVHPC 22.11:
            - C test failed: line 26: error: invalid text in pragma
            - Fortran test failed: NVFORTRAN/power Linux 22.11-0: compilation completed with severe errors
        - LLVM 17.0.0:
            - C test failed: error: incorrect map type modifier, expected one of: 'always', 'close', 'mapper', 'present', 'ompx_hold'
