### PR TITLE
New test for omp_set_num_teams()

### DIFF
--- a/tests/5.1/teams/test_target_set_num_teams.c
+++ b/tests/5.1/teams/test_target_set_num_teams.c
@@ -29,7 +29,7 @@ int main() {
 	
 	#pragma omp target teams map(tofrom: num_teams)
 	{
-		if (omp_get_team_num() == 0 && omp_get_thread_num() == 0) {
+		if (omp_get_team_num() == 0 ) {
 			num_teams = omp_get_num_teams();
 		}
 	}               
@@ -39,12 +39,13 @@ int main() {
 
 	#pragma omp target teams map(tofrom: num_teams) num_teams(OMPVV_NUM_TEAMS_DEVICE)
 	{
-		if (omp_get_team_num() == 0 && omp_get_thread_num() == 0) {
+		if (omp_get_team_num() == 0 ) {
 			num_teams = omp_get_num_teams();
 		}
 	}
 
 	OMPVV_ERROR_IF(num_teams != OMPVV_NUM_TEAMS_DEVICE, "Number of teams was not properly overriden by the num_teams clause");
+	
 	OMPVV_TEST_AND_SET(errors, num_teams != OMPVV_NUM_TEAMS_DEVICE);
 
 	OMPVV_REPORT_AND_RETURN(errors);

--- a/tests/5.1/teams/test_target_set_num_teams.c
+++ b/tests/5.1/teams/test_target_set_num_teams.c
@@ -15,8 +15,6 @@
 #include <stdlib.h>
 #include "ompvv.h"
 
-#define N 1024
-
 int main() {
 
 	OMPVV_TEST_OFFLOADING;
@@ -24,24 +22,24 @@ int main() {
 	int errors = 0; 
 	int num_teams = 0;
 
-#pragma omp target
-{
-	omp_set_num_teams(1);
-}
+        #pragma omp target
+        {
+	  omp_set_num_teams(4);
+        }
 	
 	#pragma omp target teams map(tofrom: num_teams)
 	{
-		if (omp_get_team_num() == 0) {
+		if (omp_get_team_num() == 0 && omp_get_thread_num == 0) {
 			num_teams = omp_get_num_teams();
 		}
 	}               
 	
-	OMPVV_ERROR_IF(num_teams != 1, "Number of teams detected was not the amount set by omp_set_num_teams()");
-	OMPVV_TEST_AND_SET(errors, num_teams != 1);
+	OMPVV_ERROR_IF(num_teams != 4, "Number of teams detected was not the number set by omp_set_num_teams()");
+	OMPVV_TEST_AND_SET(errors, num_teams != 4);
 
 	#pragma omp target teams map(tofrom: num_teams) num_teams(OMPVV_NUM_TEAMS_DEVICE)
 	{
-		if (omp_get_team_num() == 0) {
+		if (omp_get_team_num() == 0 && omp_get_thread_num == 0) {
 			num_teams = omp_get_num_teams();
 		}
 	}

--- a/tests/5.1/teams/test_target_set_num_teams.c
+++ b/tests/5.1/teams/test_target_set_num_teams.c
@@ -30,7 +30,7 @@ int main() {
 	}               
 	
 	OMPVV_ERROR_IF(num_teams <= 4, "Number of teams detected was not the number set by omp_set_num_teams()");
-	OMPVV_TEST_AND_SET(errors, num_teams != 4);
+	OMPVV_TEST_AND_SET(errors, num_teams <= 4);
 
 	#pragma omp teams num_teams(OMPVV_NUM_TEAMS_HOST)
 	{

--- a/tests/5.1/teams/test_target_set_num_teams.c
+++ b/tests/5.1/teams/test_target_set_num_teams.c
@@ -39,7 +39,7 @@ int main() {
 		}
 	}
 
-	OMPVV_ERROR_IF(num_teams != OMPVV_NUM_TEAMS_HOST, "Number of teams was not properly overriden by the num_teams clause");	
+	OMPVV_ERROR_IF(num_teams <= OMPVV_NUM_TEAMS_HOST, "Number of teams was not properly overriden by the num_teams clause");	
 	OMPVV_TEST_AND_SET(errors, num_teams != OMPVV_NUM_TEAMS_HOST);
 	OMPVV_REPORT_AND_RETURN(errors);
 }

--- a/tests/5.1/teams/test_target_set_num_teams.c
+++ b/tests/5.1/teams/test_target_set_num_teams.c
@@ -25,21 +25,21 @@ int main() {
 	#pragma omp teams 
 	{
 		if (omp_get_team_num() == 0 ) {
-			num_teams = omp_get_num_teams();
+			num_teams = omp_get_max_teams();
 		}
 	}               
 	
-	OMPVV_ERROR_IF(num_teams <= 4, "Number of teams detected was not the number set by omp_set_num_teams()");
-	OMPVV_TEST_AND_SET(errors, num_teams <= 4);
+	OMPVV_ERROR_IF(num_teams != 4, "Upper bound of the number of teams is not the number set by omp_set_num_teams()");
+	OMPVV_TEST_AND_SET(errors, num_teams != 4);
 
 	#pragma omp teams num_teams(OMPVV_NUM_TEAMS_HOST)
 	{
 		if (omp_get_team_num() == 0 ) {
-			num_teams = omp_get_num_teams();
+			num_teams = omp_get_max_teams();
 		}
 	}
 
-	OMPVV_ERROR_IF(num_teams <= OMPVV_NUM_TEAMS_HOST, "Number of teams was not properly overriden by the num_teams clause");	
-	OMPVV_TEST_AND_SET(errors, num_teams <= OMPVV_NUM_TEAMS_HOST);
+	OMPVV_ERROR_IF(num_teams != OMPVV_NUM_TEAMS_HOST, "Number of teams was not properly overriden by the num_teams clause");	
+	OMPVV_TEST_AND_SET(errors, num_teams != OMPVV_NUM_TEAMS_HOST);
 	OMPVV_REPORT_AND_RETURN(errors);
 }

--- a/tests/5.1/teams/test_target_set_num_teams.c
+++ b/tests/5.1/teams/test_target_set_num_teams.c
@@ -24,7 +24,10 @@ int main() {
 	int errors = 0; 
 	int num_teams = 0;
 
+#pragma omp target
+{
 	omp_set_num_teams(1);
+}
 	
 	#pragma omp target teams map(tofrom: num_teams)
 	{

--- a/tests/5.1/teams/test_target_set_num_teams.c
+++ b/tests/5.1/teams/test_target_set_num_teams.c
@@ -17,17 +17,12 @@
 
 int main() {
 
-	OMPVV_TEST_OFFLOADING;
 
 	int errors = 0; 
 	int num_teams = 0;
-
-        #pragma omp target
-        {
-	  omp_set_num_teams(4);
-        }
-	
-	#pragma omp target teams map(tofrom: num_teams)
+	omp_set_num_teams(4);
+        	
+	#pragma omp teams 
 	{
 		if (omp_get_team_num() == 0 ) {
 			num_teams = omp_get_num_teams();
@@ -37,16 +32,14 @@ int main() {
 	OMPVV_ERROR_IF(num_teams != 4, "Number of teams detected was not the number set by omp_set_num_teams()");
 	OMPVV_TEST_AND_SET(errors, num_teams != 4);
 
-	#pragma omp target teams map(tofrom: num_teams) num_teams(OMPVV_NUM_TEAMS_DEVICE)
+	#pragma omp teams num_teams(OMPVV_NUM_TEAMS_HOST)
 	{
 		if (omp_get_team_num() == 0 ) {
 			num_teams = omp_get_num_teams();
 		}
 	}
 
-	OMPVV_ERROR_IF(num_teams != OMPVV_NUM_TEAMS_DEVICE, "Number of teams was not properly overriden by the num_teams clause");
-	
-	OMPVV_TEST_AND_SET(errors, num_teams != OMPVV_NUM_TEAMS_DEVICE);
-
+	OMPVV_ERROR_IF(num_teams != OMPVV_NUM_TEAMS_HOST, "Number of teams was not properly overriden by the num_teams clause");	
+	OMPVV_TEST_AND_SET(errors, num_teams != OMPVV_NUM_TEAMS_HOST);
 	OMPVV_REPORT_AND_RETURN(errors);
 }

--- a/tests/5.1/teams/test_target_set_num_teams.c
+++ b/tests/5.1/teams/test_target_set_num_teams.c
@@ -29,7 +29,7 @@ int main() {
 	
 	#pragma omp target teams map(tofrom: num_teams)
 	{
-		if (omp_get_team_num() == 0 && omp_get_thread_num == 0) {
+		if (omp_get_team_num() == 0 && omp_get_thread_num() == 0) {
 			num_teams = omp_get_num_teams();
 		}
 	}               
@@ -39,7 +39,7 @@ int main() {
 
 	#pragma omp target teams map(tofrom: num_teams) num_teams(OMPVV_NUM_TEAMS_DEVICE)
 	{
-		if (omp_get_team_num() == 0 && omp_get_thread_num == 0) {
+		if (omp_get_team_num() == 0 && omp_get_thread_num() == 0) {
 			num_teams = omp_get_num_teams();
 		}
 	}

--- a/tests/5.1/teams/test_target_set_num_teams.c
+++ b/tests/5.1/teams/test_target_set_num_teams.c
@@ -29,7 +29,7 @@ int main() {
 		}
 	}               
 	
-	OMPVV_ERROR_IF(num_teams != 4, "Number of teams detected was not the number set by omp_set_num_teams()");
+	OMPVV_ERROR_IF(num_teams <= 4, "Number of teams detected was not the number set by omp_set_num_teams()");
 	OMPVV_TEST_AND_SET(errors, num_teams != 4);
 
 	#pragma omp teams num_teams(OMPVV_NUM_TEAMS_HOST)

--- a/tests/5.1/teams/test_target_set_num_teams.c
+++ b/tests/5.1/teams/test_target_set_num_teams.c
@@ -20,7 +20,7 @@ int main() {
 
 	int errors = 0; 
 	int num_teams = 0;
-	omp_set_num_teams(4);
+	omp_set_num_teams(8);
         	
 	#pragma omp teams 
 	{
@@ -29,17 +29,17 @@ int main() {
 		}
 	}               
 	
-	OMPVV_ERROR_IF(num_teams != 4, "Upper bound of the number of teams is not the number set by omp_set_num_teams()");
-	OMPVV_TEST_AND_SET(errors, num_teams != 4);
+	OMPVV_ERROR_IF(num_teams != 8, "Upper bound of the number of teams is not the number set by omp_set_num_teams()");
+	OMPVV_TEST_AND_SET(errors, num_teams != 8);
 
 	#pragma omp teams num_teams(OMPVV_NUM_TEAMS_HOST)
 	{
 		if (omp_get_team_num() == 0 ) {
-			num_teams = omp_get_max_teams();
+			num_teams = omp_get_num_teams();
 		}
 	}
 
-	OMPVV_ERROR_IF(num_teams != OMPVV_NUM_TEAMS_HOST, "The upper bound for the number of teams was not properly overriden by the num_teams clause");	
-	OMPVV_TEST_AND_SET(errors, num_teams != OMPVV_NUM_TEAMS_HOST);
+	OMPVV_ERROR_IF(num_teams <= OMPVV_NUM_TEAMS_HOST, "The number of teams was not overriden by the num_teams clause");	
+	OMPVV_TEST_AND_SET(errors, num_teams <= OMPVV_NUM_TEAMS_HOST);
 	OMPVV_REPORT_AND_RETURN(errors);
 }

--- a/tests/5.1/teams/test_target_set_num_teams.c
+++ b/tests/5.1/teams/test_target_set_num_teams.c
@@ -1,0 +1,61 @@
+//===--------------------- test_target_set_num_teams.c ----------------------===//
+//
+// OpenMP API Version 5.1 Nov 2020
+//
+// 
+//
+//===------------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+int main() {
+
+	OMPVV_TEST_OFFLOADING;
+
+	int errors = 0;
+	int not_shared = 5;
+	int num_teams = 0; 
+
+	#pragma omp target teams map(tofrom:num_teams, errors) 
+	{
+		#pragma omp parallel
+		{
+			if (omp_get_team_num() == 0) {
+				num_teams = omp_get_num_teams();
+			}
+		}
+	}
+
+	//Set the number of teams to be one less what the default is
+	//omp_set_num_teams(num_teams - 1);
+		
+
+	#pragma omp target teams map(tofrom: num_teams, errors)
+	{
+		#pragma omp parallel
+		{
+			if (omp_get_team_num() == 0) {
+				OMPVV_ERROR_IF(omp_get_num_teams() == num_teams, "Team count did not change when the teams limit was set");
+				OMPVV_TEST_AND_SET(errors, omp_get_num_teams() == num_teams);
+			}
+		}
+	}
+
+	#pragma omp target teams num_teams(OMPVV_NUM_TEAMS_DEVICE)
+	{
+		#pragma omp parallel
+		{
+			if (omp_get_team_num() == 0) {
+				OMPVV_ERROR_IF(omp_get_num_teams() != OMPVV_NUM_TEAMS_DEVICE, "Team count was not properly overriden by the num_teams clause");
+				OMPVV_TEST_AND_SET(errors, omp_get_num_teams() != OMPVV_NUM_TEAMS_DEVICE);
+			}
+		}
+	}
+
+	OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.1/teams/test_target_set_num_teams.c
+++ b/tests/5.1/teams/test_target_set_num_teams.c
@@ -36,8 +36,8 @@ int main() {
 		}
 	}               
 	
-	OMPVV_ERROR_IF(num_teams == 1, "Number of teams detected was not the amount set by omp_set_num_teams()");
-	OMPVV_TEST_AND_SET(errors, num_teams == 1);
+	OMPVV_ERROR_IF(num_teams != 1, "Number of teams detected was not the amount set by omp_set_num_teams()");
+	OMPVV_TEST_AND_SET(errors, num_teams != 1);
 
 	#pragma omp target teams map(tofrom: num_teams) num_teams(OMPVV_NUM_TEAMS_DEVICE)
 	{

--- a/tests/5.1/teams/test_target_set_num_teams.c
+++ b/tests/5.1/teams/test_target_set_num_teams.c
@@ -40,6 +40,6 @@ int main() {
 	}
 
 	OMPVV_ERROR_IF(num_teams <= OMPVV_NUM_TEAMS_HOST, "Number of teams was not properly overriden by the num_teams clause");	
-	OMPVV_TEST_AND_SET(errors, num_teams != OMPVV_NUM_TEAMS_HOST);
+	OMPVV_TEST_AND_SET(errors, num_teams <= OMPVV_NUM_TEAMS_HOST);
 	OMPVV_REPORT_AND_RETURN(errors);
 }

--- a/tests/5.1/teams/test_target_set_num_teams.c
+++ b/tests/5.1/teams/test_target_set_num_teams.c
@@ -2,7 +2,11 @@
 //
 // OpenMP API Version 5.1 Nov 2020
 //
-// 
+// This test uses the omp_set_num_teams utility to set the default number of
+// teams allocated for team clauses. The test runs teams and checks to see if
+// the number allocated is correct and reflective of the new default set. It
+// then checks to see if an explicitly stated num_teams clause overrides
+// the omp_set_num_teams properly.
 //
 //===------------------------------------------------------------------------===//
 
@@ -17,45 +21,30 @@ int main() {
 
 	OMPVV_TEST_OFFLOADING;
 
-	int errors = 0;
-	int not_shared = 5;
-	int num_teams = 0; 
+	int errors = 0; 
+	int num_teams = 0;
 
-	#pragma omp target teams map(tofrom:num_teams, errors) 
+	omp_set_num_teams(1);
+	
+	#pragma omp target teams map(tofrom: num_teams)
 	{
-		#pragma omp parallel
-		{
-			if (omp_get_team_num() == 0) {
-				num_teams = omp_get_num_teams();
-			}
+		if (omp_get_team_num() == 0) {
+			num_teams = omp_get_num_teams();
+		}
+	}               
+	
+	OMPVV_ERROR_IF(num_teams == 1, "Number of teams detected was not the amount set by omp_set_num_teams()");
+	OMPVV_TEST_AND_SET(errors, num_teams == 1);
+
+	#pragma omp target teams map(tofrom: num_teams) num_teams(OMPVV_NUM_TEAMS_DEVICE)
+	{
+		if (omp_get_team_num() == 0) {
+			num_teams = omp_get_num_teams();
 		}
 	}
 
-	//Set the number of teams to be one less what the default is
-	//omp_set_num_teams(num_teams - 1);
-		
-
-	#pragma omp target teams map(tofrom: num_teams, errors)
-	{
-		#pragma omp parallel
-		{
-			if (omp_get_team_num() == 0) {
-				OMPVV_ERROR_IF(omp_get_num_teams() == num_teams, "Team count did not change when the teams limit was set");
-				OMPVV_TEST_AND_SET(errors, omp_get_num_teams() == num_teams);
-			}
-		}
-	}
-
-	#pragma omp target teams num_teams(OMPVV_NUM_TEAMS_DEVICE)
-	{
-		#pragma omp parallel
-		{
-			if (omp_get_team_num() == 0) {
-				OMPVV_ERROR_IF(omp_get_num_teams() != OMPVV_NUM_TEAMS_DEVICE, "Team count was not properly overriden by the num_teams clause");
-				OMPVV_TEST_AND_SET(errors, omp_get_num_teams() != OMPVV_NUM_TEAMS_DEVICE);
-			}
-		}
-	}
+	OMPVV_ERROR_IF(num_teams != OMPVV_NUM_TEAMS_DEVICE, "Number of teams was not properly overriden by the num_teams clause");
+	OMPVV_TEST_AND_SET(errors, num_teams != OMPVV_NUM_TEAMS_DEVICE);
 
 	OMPVV_REPORT_AND_RETURN(errors);
 }

--- a/tests/5.1/teams/test_target_set_num_teams.c
+++ b/tests/5.1/teams/test_target_set_num_teams.c
@@ -39,7 +39,7 @@ int main() {
 		}
 	}
 
-	OMPVV_ERROR_IF(num_teams != OMPVV_NUM_TEAMS_HOST, "Number of teams was not properly overriden by the num_teams clause");	
+	OMPVV_ERROR_IF(num_teams != OMPVV_NUM_TEAMS_HOST, "The upper bound for the number of teams was not properly overriden by the num_teams clause");	
 	OMPVV_TEST_AND_SET(errors, num_teams != OMPVV_NUM_TEAMS_HOST);
 	OMPVV_REPORT_AND_RETURN(errors);
 }


### PR DESCRIPTION
Adds a test for the new `omp_set_num_teams()` routine which sets the default number of teams assigned to all subsequent teams regions. Also tests that an explicitly defined `num_teams()` clause overrides this set default as defined in the spec.

Compiles and runs as expected on Perlmutter with llvm 17