### PR TITLE
New test for omp_get_max_teams()

### DIFF
--- a/ompvv/ompvv.F90
+++ b/ompvv/ompvv.F90
@@ -59,6 +59,10 @@
 #define OMPVV_NUM_TEAMS_DEVICE 8
 #endif
 
+#ifndef OMPVV_NUM_TEAMS_HOST
+#define OMPVV_NUM_TEAMS_HOST 4
+#endif
+
 #ifndef OMPVV_NUM_THREADS_HOST
 #define OMPVV_NUM_THREADS_HOST 8
 #endif

--- a/tests/5.0/loop/test_loop_bind.F90
+++ b/tests/5.0/loop/test_loop_bind.F90
@@ -48,7 +48,7 @@ CONTAINS
     END DO
 
     !$omp teams num_teams(OMPVV_NUM_TEAMS_HOST) thread_limit(OMPVV_NUM_THREADS_HOST)
-    !$omp loop bind(teams)
+    !$omp loop bind(teams) private(j)
     DO i = 1, N
        DO j = 1, N
           x(j,i) = x(j,i) + y(i)*z(i)

--- a/tests/5.0/loop/test_loop_bind_device.F90
+++ b/tests/5.0/loop/test_loop_bind_device.F90
@@ -49,7 +49,7 @@ CONTAINS
     END DO
 
     !$omp target teams num_teams(OMPVV_NUM_TEAMS_DEVICE) thread_limit(OMPVV_NUM_THREADS_DEVICE) map(tofrom: x, y, z, num_teams)
-    !$omp loop bind(teams)
+    !$omp loop bind(teams) private(j)
     DO i = 1, N
        DO j = 1, N
           x(j,i) = x(j,i) + y(i)*z(i)

--- a/tests/5.0/loop/test_loop_nested.F90
+++ b/tests/5.0/loop/test_loop_nested.F90
@@ -46,7 +46,7 @@ CONTAINS
     END DO
 
     !$omp teams num_teams(OMPVV_NUM_TEAMS_DEVICE) thread_limit(OMPVV_NUM_THREADS_HOST)
-    !$omp loop
+    !$omp loop private(j)
     DO i = 1, N
        DO j = 1, N
           x(j,i) = x(j,i) + y(i)*z(i)

--- a/tests/5.0/loop/test_loop_nested_device.F90
+++ b/tests/5.0/loop/test_loop_nested_device.F90
@@ -47,7 +47,7 @@ CONTAINS
     END DO
 
     !$omp target teams num_teams(OMPVV_NUM_TEAMS_DEVICE) thread_limit(OMPVV_NUM_THREADS_DEVICE) map(tofrom: x, y, z, num_teams)
-    !$omp loop
+    !$omp loop private(j)
     DO i = 1, N
        DO j = 1, N
           x(j,i) = x(j,i) + y(i)*z(i)

--- a/tests/5.0/requires/test_requires_unified_address.c
+++ b/tests/5.0/requires/test_requires_unified_address.c
@@ -20,23 +20,51 @@ int unified_address() {
 
    int errors = 0;
    int i;
-   int * mem_ptr = (int *)malloc(N * sizeof(int));
+   int *mem_ptr = (int *)omp_target_alloc(N * sizeof(int), omp_get_default_device());
+   int *mem_ptr2 = NULL;
 
-   OMPVV_ERROR_IF(mem_ptr == NULL, "Memory was not properly allocated");
+   OMPVV_ERROR_IF(mem_ptr == NULL, "Target memory was not properly allocated");
+   if (mem_ptr == NULL)
+     return ++errors;
    
-   #pragma omp target map(to: mem_ptr)
+   #pragma omp target map(from:mem_ptr2) /* is_device_ptr(mem_ptr) - which is optional.  */
    {
       for (i = 0; i < N; i++) {
          mem_ptr[i] = i + 1;
       }
+      mem_ptr2 = &mem_ptr[0] + 5;
    }
+
+   /* Pointer arithmetic is permitted; assumes sizeof(int) is the same.  */
+   mem_ptr2 += 4;
    
+   #pragma omp target map(tofrom:errors) /* is_device_ptr(mem_ptr2) - which is optional.  */
    for (i = 0; i < N; i++) {
-      if(mem_ptr[i] != i + 1) {
+      if(mem_ptr2[i - 5 - 4] != i + 1) {
          errors++;
       }  
    }
-   
+
+   int *mem_ptr3 = (int*)malloc(N * sizeof(int));
+   OMPVV_ERROR_IF(mem_ptr3 == NULL, "Host memory was not properly allocated");
+   if (mem_ptr3 == NULL)
+     return ++errors;
+
+   if (0 == omp_target_memcpy(mem_ptr3, mem_ptr, N * sizeof(int), 0, 0,
+                              omp_get_initial_device(), omp_get_default_device())) {
+     for (i = 0; i < N; i++) {
+       if (mem_ptr3[i] != i + 1) {
+         errors++;
+       }
+     }
+   } else {
+     OMPVV_ERROR("omp_target_memcpy failed");
+     errors++;
+   }
+
+   free (mem_ptr3);
+   omp_target_free (mem_ptr, omp_get_default_device());
+
    return errors;
 }
 

--- a/tests/5.0/requires/test_requires_unified_address.c
+++ b/tests/5.0/requires/test_requires_unified_address.c
@@ -27,7 +27,7 @@ int unified_address() {
    if (mem_ptr == NULL)
      return ++errors;
    
-   #pragma omp target map(from:mem_ptr2) /* is_device_ptr(mem_ptr) - which is optional.  */
+   #pragma omp target map(from:mem_ptr2) defaultmap(firstprivate) /* is_device_ptr(mem_ptr) - which is optional.  */
    {
       for (i = 0; i < N; i++) {
          mem_ptr[i] = i + 1;
@@ -38,7 +38,7 @@ int unified_address() {
    /* Pointer arithmetic is permitted; assumes sizeof(int) is the same.  */
    mem_ptr2 += 4;
    
-   #pragma omp target map(tofrom:errors) /* is_device_ptr(mem_ptr2) - which is optional.  */
+   #pragma omp target map(tofrom:errors) defaultmap(to) /* is_device_ptr(mem_ptr2) - which is optional.  */
    for (i = 0; i < N; i++) {
       if(mem_ptr2[i - 5 - 4] != i + 1) {
          errors++;

--- a/tests/5.1/loop/test_full_loop_unroll.c
+++ b/tests/5.1/loop/test_full_loop_unroll.c
@@ -1,0 +1,58 @@
+//===--- test_full_loop_unroll.c -----------------------------------------------===//
+//
+// OpenMP API Version 5.1 August 2021 
+//
+// This test checks the behavior of the 5.1 unroll construct (2.11.9.2 in 5.1 spec). 
+// "The unroll construct fully or partially unrolls a loop", which is more of a code generation
+// compiler feature. 
+// This test specifically checks the unroll construct with the full clause, in which the 
+// loop will be completely unrolled.
+// Referenced 5.1 Example Doc 7.2 
+////===--------------------------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+#include <math.h>
+
+# define N 1024
+
+int errors; 
+
+int test_full_loop_unroll() {
+	int arr[N];
+	int parallel_arr[N];
+	int sum = 0;
+	int parallel_sum = 0;
+
+	// sequential loop
+	for (int i = 0; i < N; i++) {
+		arr[i] = i;
+		sum += arr[i];
+	}
+
+	// omp unroll full loop
+# pragma omp unroll full
+	for (int i = 0; i < N; i++) {
+		parallel_arr[i] = i;
+	}
+
+	// sequential sum of parallel array
+	for (int i = 0; i < N; i++) {
+		parallel_sum += parallel_arr[i];
+	}
+	OMPVV_TEST_AND_SET_VERBOSE(errors, parallel_sum != sum);
+	OMPVV_INFOMSG_IF(sum == 0, "Array was not initialized.");
+	OMPVV_INFOMSG_IF(parallel_sum == 0, "Something went wrong with loop unroll.");
+	OMPVV_INFOMSG_IF(parallel_sum == sum, "Test passed.");
+	OMPVV_INFOMSG_IF(parallel_sum != sum, "Test did not pass.");
+	return errors;
+}
+
+int main() {
+	errors = 0;
+	OMPVV_TEST_OFFLOADING;
+	OMPVV_TEST_AND_SET_VERBOSE(errors, test_full_loop_unroll() != 0);
+	OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.1/loop/test_loop_unroll.c
+++ b/tests/5.1/loop/test_loop_unroll.c
@@ -1,0 +1,58 @@
+//===--- test_loop_unroll.c -----------------------------------------------===//
+//
+// OpenMP API Version 5.1 August 2021 
+//
+// This test checks the behavior of the 5.1 unroll construct (2.11.9.2 in 5.1 spec). 
+// "The unroll construct fully or partially unrolls a loop", which is more of a code generation
+// compiler feature. 
+// This test specifically checks the unroll construct without any clause, in which the compiler decides
+// how the loop unrolls.
+// Referenced 5.1 Example Doc 7.2 
+////===--------------------------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+#include <math.h>
+
+# define N 1024
+
+int errors; 
+
+int test_loop_unroll() {
+	int arr[N];
+	int parallel_arr[N];
+	int sum = 0;
+	int parallel_sum = 0;
+
+	// sequential loop
+	for (int i = 0; i < N; i++) {
+		arr[i] = i;
+		sum += arr[i];
+	}
+
+	// omp unroll loop
+# pragma omp unroll
+	for (int i = 0; i < N; i++) {
+		parallel_arr[i] = i;
+	}
+
+	// sequential sum of parallel array
+	for (int i = 0; i < N; i++) {
+		parallel_sum += parallel_arr[i];
+	}
+	OMPVV_TEST_AND_SET_VERBOSE(errors, parallel_sum != sum);
+	OMPVV_INFOMSG_IF(sum == 0, "Array was not initialized.");
+	OMPVV_INFOMSG_IF(parallel_sum == 0, "Something went wrong with loop unroll.");
+	OMPVV_INFOMSG_IF(parallel_sum == sum, "Test passed.");
+	OMPVV_INFOMSG_IF(parallel_sum != sum, "Test did not pass.");
+	return errors;
+}
+
+int main() {
+	errors = 0;
+	OMPVV_TEST_OFFLOADING;
+	OMPVV_TEST_AND_SET_VERBOSE(errors, test_loop_unroll() != 0);
+	OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.1/loop/test_partial_loop_unroll.c
+++ b/tests/5.1/loop/test_partial_loop_unroll.c
@@ -1,0 +1,61 @@
+//===--- test_partial_loop_unroll.c -----------------------------------------------===//
+//
+// OpenMP API Version 5.1 August 2021 
+//
+// This test checks the behavior of the 5.1 unroll construct (2.11.9.2 in 5.1 spec). 
+// "The unroll construct fully or partially unrolls a loop", which is more of a code generation
+// compiler feature. 
+// This test specifically checks the unroll construct with the partial clause, 
+// with a loop-unroll factor which specifies: 
+// "specifies that the number of iterations will be reduced
+//  multiplicatively by the factor while the number of blocks 
+//  will be increased by the same factor." 
+// Referenced 5.1 Example Doc 7.2 
+////===--------------------------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+#include <math.h>
+
+# define N 1024
+
+int errors; 
+
+int test_partial_loop_unroll() {
+	int arr[N];
+	int parallel_arr[N];
+	int sum = 0;
+	int parallel_sum = 0;
+
+	// sequential loop
+	for (int i = 0; i < N; i++) {
+		arr[i] = i;
+		sum += arr[i];
+	}
+
+	// omp unroll loop partially
+# pragma omp unroll partial(4)
+	for (int i = 0; i < N; i++) {
+		parallel_arr[i] = i;
+	}
+
+	// sequential sum of parallel array
+	for (int i = 0; i < N; i++) {
+		parallel_sum += parallel_arr[i];
+	}
+	OMPVV_TEST_AND_SET_VERBOSE(errors, parallel_sum != sum);
+	OMPVV_INFOMSG_IF(sum == 0, "Array was not initialized.");
+	OMPVV_INFOMSG_IF(parallel_sum == 0, "Something went wrong with loop unroll.");
+	OMPVV_INFOMSG_IF(parallel_sum == sum, "Test passed.");
+	OMPVV_INFOMSG_IF(parallel_sum != sum, "Test did not pass.");
+	return errors;
+}
+
+int main() {
+	errors = 0;
+	OMPVV_TEST_OFFLOADING;
+	OMPVV_TEST_AND_SET_VERBOSE(errors, test_partial_loop_unroll() != 0);
+	OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.1/target/test_target_has_device_addr.F90
+++ b/tests/5.1/target/test_target_has_device_addr.F90
@@ -1,0 +1,67 @@
+!===--- test_target_has_device_addr.F90 ------------------------------------===//
+!
+! OpenMP API Version 5.1 Nov 2020
+!
+! This test verifies the 'has_device_addr' feature added to the target construct.
+! We tested this by mapping a scalar & array to the device
+! and ensuring that the address does not change when using
+! has_device_addr on another target region.
+!
+!//===----------------------------------------------------------------------===//
+
+#include "ompvv.F90"
+
+#define N 1024
+
+PROGRAM test_target_has_device_addr
+  USE iso_fortran_env
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+  OMPVV_TEST_OFFLOADING
+
+  OMPVV_TEST_VERBOSE(target_has_device_addr() .NE. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION target_has_device_addr()
+    INTEGER :: errors, i
+    INTEGER, TARGET :: x
+    INTEGER, TARGET, DIMENSION(N) :: arr
+    INTEGER, POINTER :: first_scalar_device_addr
+    INTEGER, POINTER :: first_arr_device_addr(:)
+    INTEGER, POINTER :: second_scalar_device_addr
+    INTEGER, POINTER :: second_arr_device_addr(:)
+
+    errors = 0
+    x = 10
+    DO i=1, N
+      arr(i) = i
+    END DO
+
+    OMPVV_INFOMSG("test_target_has_device_addr")
+
+    ! test by mapping to device use 'target map' construct
+    !$omp target enter data map(to: x, arr)
+    !$omp target map(from: first_scalar_device_addr, first_arr_device_addr) map(to: x, arr)
+    first_scalar_device_addr => x
+    first_arr_device_addr => arr
+    !$omp end target
+
+    ! check addresses are same on device region
+    !$omp target data use_device_addr(x, arr)
+    !$omp target map(from: second_scalar_device_addr, second_arr_device_addr) has_device_addr(x, arr)
+    second_scalar_device_addr => x
+    second_arr_device_addr => arr
+    !$omp end target
+    !$omp end target data
+    !$omp target exit data map(release: x, arr)
+
+    OMPVV_TEST_AND_SET(errors, associated(first_scalar_device_addr, target=second_scalar_device_addr))
+    OMPVV_TEST_AND_SET(errors, associated(first_arr_device_addr, target=second_arr_device_addr))
+
+    target_has_device_addr = errors
+  END FUNCTION target_has_device_addr
+END PROGRAM test_target_has_device_addr
+

--- a/tests/5.1/target/test_target_has_device_addr.c
+++ b/tests/5.1/target/test_target_has_device_addr.c
@@ -14,7 +14,7 @@
 #include <stdlib.h>
 #include "ompvv.h"
 
-#define N 1000
+#define N 1024
 
 //test by mapping to device use 'target map' construct
 int test_target_has_device_addr() {
@@ -43,7 +43,7 @@ int test_target_has_device_addr() {
   }
   #pragma omp target exit data map(release: x, arr)
   OMPVV_TEST_AND_SET(errors, first_scalar_device_addr != second_scalar_device_addr);
-  OMPVV_TEST_AND_SET(errors, first_arr_device_addr != second_arr_device_addr)
+  OMPVV_TEST_AND_SET(errors, first_arr_device_addr != second_arr_device_addr);
   return errors;
 }
 

--- a/tests/5.1/target/test_target_map_with_present_modifier.F90
+++ b/tests/5.1/target/test_target_map_with_present_modifier.F90
@@ -1,0 +1,70 @@
+!===--- test_target_map_with_present_modifier.F90 ---------------------------------------------===//
+!
+! OpenMP API Version 5.1 Nov 2020
+!
+! This test checks tests the present map-type-modifier on a map clause. The test maps several
+! different data types to device with tofrom map-type and then checks for expected updated values on
+! the host.
+!
+!//===-----------------------------------------------------------------------------------------===//
+
+#include "ompvv.F90"
+
+#define N 1024
+
+PROGRAM test_target_map_with_present_modifier
+  USE iso_fortran_env
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+  OMPVV_TEST_OFFLOADING
+
+  OMPVV_TEST_VERBOSE(test_present_modifier() .NE. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION test_present_modifier()
+    INTEGER :: errors, i
+    INTEGER :: scalar
+    INTEGER, DIMENSION(N) :: a
+
+    TYPE memberType
+    INTEGER :: var
+    INTEGER, DIMENSION(N) :: b
+    END TYPE memberType
+
+    TYPE (memberType) :: member
+
+    errors = 0
+    scalar = 1
+    member%var = 1
+
+    DO i=1, N
+      a(i) = i
+      member%b(i) = i
+    END DO
+
+    !$omp target data map(tofrom: scalar, a, member)
+    !$omp target map(present, tofrom: scalar, a, member)
+    scalar = scalar + 1
+    member%var = member%var + 2
+    DO i=1, N
+      a(i) = a(i) + i
+      member%b(i) = member%b(i) + i
+    END DO
+    !$omp end target
+    !$omp end target data
+
+    DO i=1, N
+      OMPVV_TEST_AND_SET(errors, a(i) .NE. i*2)
+      OMPVV_TEST_AND_SET(errors, member%b(i) .NE. i*2)
+    END DO
+
+    OMPVV_TEST_AND_SET(errors, scalar .NE. 2)
+    OMPVV_TEST_AND_SET(errors, member%var .NE. 3)
+
+    test_present_modifier = errors
+  END FUNCTION test_present_modifier
+END PROGRAM test_target_map_with_present_modifier
+

--- a/tests/5.1/teams/test_target_get_max_teams.c
+++ b/tests/5.1/teams/test_target_get_max_teams.c
@@ -1,0 +1,56 @@
+//===--------------------- test_target_get_max_teams.c ----------------------===//
+//
+// OpenMP API Version 5.1 Nov 2020
+//
+// This test uses the omp_get_max_teams routine to check what the max teams 
+// capacity is for this device. It should return the total amount of teams
+// that could be allocated to a specific teams region
+//
+//===------------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+int main() {
+
+        OMPVV_TEST_OFFLOADING;
+
+        int errors = 0;
+        int MAX_TEAMS = omp_get_max_teams(); //on host
+        int num_teams = MAX_TEAMS + 1; //a value that is not possible
+        printf("max on host:%d\n",MAX_TEAMS);
+        #pragma omp teams
+        {
+                if (omp_get_team_num() == 0) {
+                        num_teams = omp_get_num_teams();
+                }
+        }       
+
+        OMPVV_ERROR_IF(MAX_TEAMS > 0 && num_teams > MAX_TEAMS, "Number of teams reported on host exceeded max number of teams (max no. > 0)");
+        OMPVV_ERROR_IF(num_teams <= 0, "Number of teams reported on host is 0 or negative");
+        OMPVV_TEST_AND_SET(errors, num_teams > MAX_TEAMS);
+        OMPVV_TEST_AND_SET(errors, num_teams <= 0);
+        
+        #pragma omp target map(tofrom:num_teams)
+        {
+           MAX_TEAMS = omp_get_max_teams(); //first-private
+          #pragma omp teams 
+          {
+             if (omp_get_team_num() == 0) {
+               printf("max on target:%d\n",MAX_TEAMS);
+               num_teams = MAX_TEAMS + 1; //a value that is not possible
+               num_teams = omp_get_num_teams();
+             }  
+          }
+        }
+        OMPVV_ERROR_IF(MAX_TEAMS > 0 && num_teams > MAX_TEAMS, "Number of teams reported on device exceeded max number of teams (max no. > 0)");
+        OMPVV_ERROR_IF(num_teams <= 0, "Number of teams reported on device is 0 or negative");
+        OMPVV_TEST_AND_SET(errors, num_teams > MAX_TEAMS);
+        OMPVV_TEST_AND_SET(errors, num_teams <= 0);
+
+        OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.1/teams/test_target_get_max_teams.c
+++ b/tests/5.1/teams/test_target_get_max_teams.c
@@ -1,56 +1,59 @@
-//===--------------------- test_target_get_max_teams.c ----------------------===//
-//
+//--------------- test_target_get_max_teams.c --------------------------------//
 // OpenMP API Version 5.1 Nov 2020
-//
-// This test uses the omp_get_max_teams routine to check what the max teams 
-// capacity is for this device. It should return the total amount of teams
-// that could be allocated to a specific teams region
-//
-//===------------------------------------------------------------------------===//
-
-#include <omp.h>
-#include <stdio.h>
-#include <stdlib.h>
+// ***************************
+// ROUTINE: omp_get_max_teams
+// ***************************
+// This test uses the omp_get_max_teams routine to check what the max teams
+// capacity is for the current device. If the routine returns 0, the nteams-var
+// ICV is 0, thus it is not treated as an upper bound and the behavior of the
+// program is implementation defined. If the routine were to return a negative
+// integer, the same behavior applies. If the routine returns a positive
+// integer, the value of the ICV is treated as an upperbound. If the value is a
+// number greater than the maximum capacity which an implementation supports,
+// than the test will pass as the number of teams is less than that value, but
+// the value itself has no functional purpose. The ICV is initialized to 0 per
+// device. Thus, if omp_get_num_teams returns a positive number as
+// expected, the test will pass when the ICV value is 0 or less than 0. In the
+// case where the OMP_NUM_TEAMS environmental variable is set to a positive
+// integer, or the omp_set_num_teams routine is given a positive integer as an
+// argument, the test will pass if and only if the omp_get_num_teams routine
+// returns an integer that is less than or equal to the positive ICV value.
+//----------------------------------------------------------------------------//
 #include "ompvv.h"
+#include <omp.h>
 
-#define N 1024
+int test_get_max_teams(int offload) {
+  int errors = 0;
+  int max_teams = omp_get_max_teams(); // on host
+  int num_teams = 0; // a value that is not possible for omp_get_num_teams()
+
+  // clang-format off
+  #pragma omp target map(tofrom : num_teams) if(offload)
+  {
+    #pragma omp teams 
+    {
+      num_teams = omp_get_num_teams();
+    }
+  }
+  // clang-format on
+
+  OMPVV_ERROR_IF(
+      max_teams <= 0 && num_teams <= 0,
+      "Number of teams reported is non-positive, should not be possible");
+  OMPVV_ERROR_IF(
+      max_teams > 0 && num_teams > max_teams,
+      "Number of teams reported exceeded max number of teams (max no. > 0)");
+  OMPVV_TEST_AND_SET(errors, max_teams <= 0 && num_teams <= 0);
+  OMPVV_TEST_AND_SET(errors, max_teams > 0 && num_teams > max_teams);
+
+  return errors;
+}
 
 int main() {
-
-        OMPVV_TEST_OFFLOADING;
-
-        int errors = 0;
-        int MAX_TEAMS = omp_get_max_teams(); //on host
-        int num_teams = MAX_TEAMS + 1; //a value that is not possible
-        printf("max on host:%d\n",MAX_TEAMS);
-        #pragma omp teams
-        {
-                if (omp_get_team_num() == 0) {
-                        num_teams = omp_get_num_teams();
-                }
-        }       
-
-        OMPVV_ERROR_IF(MAX_TEAMS > 0 && num_teams > MAX_TEAMS, "Number of teams reported on host exceeded max number of teams (max no. > 0)");
-        OMPVV_ERROR_IF(num_teams <= 0, "Number of teams reported on host is 0 or negative");
-        OMPVV_TEST_AND_SET(errors, num_teams > MAX_TEAMS);
-        OMPVV_TEST_AND_SET(errors, num_teams <= 0);
-        
-        #pragma omp target map(tofrom:num_teams)
-        {
-           MAX_TEAMS = omp_get_max_teams(); //first-private
-          #pragma omp teams 
-          {
-             if (omp_get_team_num() == 0) {
-               printf("max on target:%d\n",MAX_TEAMS);
-               num_teams = MAX_TEAMS + 1; //a value that is not possible
-               num_teams = omp_get_num_teams();
-             }  
-          }
-        }
-        OMPVV_ERROR_IF(MAX_TEAMS > 0 && num_teams > MAX_TEAMS, "Number of teams reported on device exceeded max number of teams (max no. > 0)");
-        OMPVV_ERROR_IF(num_teams <= 0, "Number of teams reported on device is 0 or negative");
-        OMPVV_TEST_AND_SET(errors, num_teams > MAX_TEAMS);
-        OMPVV_TEST_AND_SET(errors, num_teams <= 0);
-
-        OMPVV_REPORT_AND_RETURN(errors);
+  int errors = 0;
+  OMPVV_TEST_AND_SET(errors, test_get_max_teams(0) != 0);
+  OMPVV_TEST_OFFLOADING;
+  OMPVV_TEST_AND_SET(errors, test_get_max_teams(1) != 0);
+  OMPVV_REPORT_AND_RETURN(errors);
+  return errors;
 }

--- a/tests/5.2/runtime_calls/test_omp_in_explicit_task.c
+++ b/tests/5.2/runtime_calls/test_omp_in_explicit_task.c
@@ -1,0 +1,56 @@
+//===---- test_omp_in_explicit_task.c ----------------------------------------------===//
+// 
+// OpenMP API Version 5.2 Nov 2021
+//
+// Uses omp_in_explicit_task() runtime call to ensure it is 1 when in an explicit
+// task and 0 otherwise.
+// 
+//===-------------------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include "ompvv.h"
+#include <stdbool.h>
+
+#define N 256
+
+int errors;
+
+int test_wrapper() { 
+    errors = 0;
+    int A[N];
+    for(int i = 0; i < N; i++){
+        A[i] = 0;
+    }
+    #pragma omp task shared(A)// creates EXPLICIT task, omp_in_explicit_task = 1
+    {
+        for(int i = 0; i < N; i++){
+            A[i] = omp_in_explicit_task();
+        }
+    }
+    for(int i = 0; i < N; i++){
+        OMPVV_TEST_AND_SET(errors, A[i] == 0);
+    }
+    OMPVV_ERROR_IF(A[rand()%N] == 0, "omp_in_explicit_task() did not return correct value when called inside an explicit task");
+    
+    for(int i = 0; i < N; i++){
+        A[i] = 1;
+        #pragma omp parallel for // creates IMPLICIT tasks, omp_in_explicit_task = 0
+        for(int i = 0; i < N; i++){
+            A[i] = omp_in_explicit_task();
+        }
+    }
+    OMPVV_ERROR_IF(A[rand()%N] != 0, "omp_in_explicit_task() did not return correct value when called inside an implicit task");
+    
+    for(int i = 0; i < N; i++){
+        OMPVV_TEST_AND_SET(errors, A[i] != 0);
+    }
+    return errors;
+}
+
+int main () {
+   OMPVV_TEST_AND_SET_VERBOSE(errors, test_wrapper());
+   OMPVV_REPORT_AND_RETURN(errors);
+}  

--- a/tests/5.2/scope/test_scope_allocate_construct.c
+++ b/tests/5.2/scope/test_scope_allocate_construct.c
@@ -1,0 +1,51 @@
+//--------------- test_scope_allocate_construct.c ----------------------------//
+//
+// OpenMP API Version 5.2 Nov 2021
+//
+// This test checks that the scope directive with the allocate clause is
+// working correctly.
+// Note: restrictions for the allocate clause require that a private clause
+// be present when allocate is used with scope.
+// The allocator() argument to the allocate clause selects one of the
+// predefined allocators which are listed under Table 6.3 on pg. 174
+// in the specifications.
+//
+// In this test, the clause is used to allocate memory to an array of integers,
+// which is then written to. Each section of the array is subsequently read
+// to check if the correct integer values are present.
+//----------------------------------------------------------------------------//
+
+#include "ompvv.h"
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define N 1024
+
+int test_allocate() {
+  int errors = 0;
+  int arr[N];
+
+  #pragma omp target parallel map(tofrom : errors)
+  #pragma omp scope private(arr) allocate(allocator(omp_low_lat_mem_alloc) : arr)
+  {
+    int err = 0;
+    for (int i = 0; i < N; i++) {
+      arr[i] = i;
+    }
+    for (int j = 0; j < N; j++) {
+      if (arr[j] != j)
+        err++;
+    }
+    #pragma omp atomic update
+    errors += err;
+  }
+  return errors;
+}
+
+int main() {
+  int errors = 0;
+  OMPVV_TEST_OFFLOADING;
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_allocate() != 0);
+  OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.2/scope/test_scope_firstprivate_construct.c
+++ b/tests/5.2/scope/test_scope_firstprivate_construct.c
@@ -1,0 +1,39 @@
+//--------------- test_scope_firstprivate_construct.c -----------------------------//
+//
+// OpenMP API Version 5.2 Nov 2021 
+//
+// This test checks that the scope firstprivate construct clause is properly working.
+// The test itself passes a test integer into the scope pragma and ensures that
+// all changes made to it are not kept outside of the scope region.
+//----------------------------------------------------------------------------//
+
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+#include <math.h>
+
+int test_scope(){
+	int errors = 0;
+	int test_int = 1;
+	#pragma omp target parallel map(tofrom: errors) 
+	{
+		#pragma omp scope firstprivate(test_int)
+		{
+			test_int += 1;
+			OMPVV_TEST_AND_SET(errors,test_int != 2);
+		}
+	}
+	OMPVV_ERROR_IF(errors, "firstprivate int is not updating correctly");
+	OMPVV_TEST_AND_SET_VERBOSE(errors,test_int != 1);
+	OMPVV_INFOMSG_IF(test_int == 2, "test int was not firstprivate");
+	return errors;
+}
+
+int main(){
+	int errors = 0;
+	OMPVV_TEST_OFFLOADING;
+	OMPVV_TEST_AND_SET_VERBOSE(errors, test_scope() != 0);
+	OMPVV_REPORT_AND_RETURN(errors);
+}


### PR DESCRIPTION
Tests the new `omp_get_max_teams()` routine. Currently compiles and runs but the test fails on Perlmutter llvm 17