### PR TITLE
Add OMPVV_NUM_TEAMS_HOST for Fortran | Fixes test_loop_bind.F90

### DIFF
--- a/ompvv/ompvv.F90
+++ b/ompvv/ompvv.F90
@@ -59,6 +59,10 @@
 #define OMPVV_NUM_TEAMS_DEVICE 8
 #endif
 
+#ifndef OMPVV_NUM_TEAMS_HOST
+#define OMPVV_NUM_TEAMS_HOST 4
+#endif
+
 #ifndef OMPVV_NUM_THREADS_HOST
 #define OMPVV_NUM_THREADS_HOST 8
 #endif


### PR DESCRIPTION
While commit commit fd0d51dfe7833e10ff1da7d6068923360f76d48f (Pull Request #668) added OMPVV_NUM_TEAMS_HOST for C/C++ to ompvv/ompvv.h, it was missing from ompvv/ompvv.F90 for Fortran.

Thus, add it now for Fortran; the value is actually already used for Fortran but not for C/C++ in tests/5.0/loop/test_loop_bind.F90 (Pull Request #644).

_Compilation fails here – and the issue was also mentioned by someone else post-merging in the pull-request for test_loop_bind.F90 (i.e. #644)._

@nolanbaker31 @spophale @jrreap @krishols @mjcarr458 @seyonglee – please review