### PR TITLE
Issue 731: Fix test_loop_{nested,bind}{,_device}.F90: Add missing private(j)

### DIFF
--- a/tests/5.0/loop/test_loop_bind.F90
+++ b/tests/5.0/loop/test_loop_bind.F90
@@ -48,7 +48,7 @@ CONTAINS
     END DO
 
     !$omp teams num_teams(OMPVV_NUM_TEAMS_HOST) thread_limit(OMPVV_NUM_THREADS_HOST)
-    !$omp loop bind(teams)
+    !$omp loop bind(teams) private(j)
     DO i = 1, N
        DO j = 1, N
           x(j,i) = x(j,i) + y(i)*z(i)

--- a/tests/5.0/loop/test_loop_bind_device.F90
+++ b/tests/5.0/loop/test_loop_bind_device.F90
@@ -49,7 +49,7 @@ CONTAINS
     END DO
 
     !$omp target teams num_teams(OMPVV_NUM_TEAMS_DEVICE) thread_limit(OMPVV_NUM_THREADS_DEVICE) map(tofrom: x, y, z, num_teams)
-    !$omp loop bind(teams)
+    !$omp loop bind(teams) private(j)
     DO i = 1, N
        DO j = 1, N
           x(j,i) = x(j,i) + y(i)*z(i)

--- a/tests/5.0/loop/test_loop_nested.F90
+++ b/tests/5.0/loop/test_loop_nested.F90
@@ -46,7 +46,7 @@ CONTAINS
     END DO
 
     !$omp teams num_teams(OMPVV_NUM_TEAMS_DEVICE) thread_limit(OMPVV_NUM_THREADS_HOST)
-    !$omp loop
+    !$omp loop private(j)
     DO i = 1, N
        DO j = 1, N
           x(j,i) = x(j,i) + y(i)*z(i)

--- a/tests/5.0/loop/test_loop_nested_device.F90
+++ b/tests/5.0/loop/test_loop_nested_device.F90
@@ -47,7 +47,7 @@ CONTAINS
     END DO
 
     !$omp target teams num_teams(OMPVV_NUM_TEAMS_DEVICE) thread_limit(OMPVV_NUM_THREADS_DEVICE) map(tofrom: x, y, z, num_teams)
-    !$omp loop
+    !$omp loop private(j)
     DO i = 1, N
        DO j = 1, N
           x(j,i) = x(j,i) + y(i)*z(i)


### PR DESCRIPTION
Issue #731

The inner loop variable 'j' is not associated with 'omp loop'. While private(j) is implied 'teams', it is not for 'loop'. To avoid unspecified behavior that might lead to data races, use private(j) on the 'loop' construct.

@nolanbaker31 @spophale @jrreap @krishols @mjcarr458 @seyonglee – please review; _cf. also (non-public-accessible) OpenMP specification Issue 3607, I filed today. And GCC's https://gcc.gnu.org/PR109767._