### PR TITLE
Adding test for scope directive, allocate clause, on device

### DIFF
--- a/tests/5.2/scope/test_scope_allocate_construct.c
+++ b/tests/5.2/scope/test_scope_allocate_construct.c
@@ -4,7 +4,15 @@
 //
 // This test checks that the scope directive with the allocate clause is
 // working correctly.
-// This is done by specifying
+// Note: restrictions for the allocate clause require that a private clause
+// be present when allocate is used with scope.
+// The allocator() argument to the allocate clause selects one of the 
+// predefined allocators which are listed under Table 6.3 on pg. 174 
+// in the specifications.
+// 
+// In this test, the clause is used to allocate memory to an array of integers, which is then
+// written to. Each section of the array is subsequently read to check if the 
+// correct integer values are present.
 //----------------------------------------------------------------------------//
 
 #include <omp.h>

--- a/tests/5.2/scope/test_scope_allocate_construct.c
+++ b/tests/5.2/scope/test_scope_allocate_construct.c
@@ -1,4 +1,4 @@
-//--------------- test_scope_allocate_construct.c -----------------------------//
+//--------------- test_scope_allocate_construct.c ----------------------------//
 //
 // OpenMP API Version 5.2 Nov 2021
 //
@@ -6,45 +6,46 @@
 // working correctly.
 // Note: restrictions for the allocate clause require that a private clause
 // be present when allocate is used with scope.
-// The allocator() argument to the allocate clause selects one of the 
-// predefined allocators which are listed under Table 6.3 on pg. 174 
+// The allocator() argument to the allocate clause selects one of the
+// predefined allocators which are listed under Table 6.3 on pg. 174
 // in the specifications.
-// 
-// In this test, the clause is used to allocate memory to an array of integers, which is then
-// written to. Each section of the array is subsequently read to check if the 
-// correct integer values are present.
+//
+// In this test, the clause is used to allocate memory to an array of integers,
+// which is then written to. Each section of the array is subsequently read
+// to check if the correct integer values are present.
 //----------------------------------------------------------------------------//
 
+#include "ompvv.h"
 #include <omp.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include "ompvv.h"
 
 #define N 1024
 
-int test_allocate(){
-        int errors=0;
-        int arr[N];
+int test_allocate() {
+  int errors = 0;
+  int arr[N];
 
-	#pragma omp target parallel map(tofrom: errors) 
-        #pragma omp scope private(arr) allocate(allocator(omp_low_lat_mem_alloc): arr)
-        {
-		int err = 0;
-		for(int i=0; i< N; i++){
-                	arr[i] = i;
-                }
-		for(int j=0; j< N; j++){
-			if(arr[j] != j) err++;
-		}
-		#pragma omp atomic update
-		errors += err;
-        }
-        return errors;
+  #pragma omp target parallel map(tofrom : errors)
+  #pragma omp scope private(arr) allocate(allocator(omp_low_lat_mem_alloc) : arr)
+  {
+    int err = 0;
+    for (int i = 0; i < N; i++) {
+      arr[i] = i;
+    }
+    for (int j = 0; j < N; j++) {
+      if (arr[j] != j)
+        err++;
+    }
+    #pragma omp atomic update
+    errors += err;
+  }
+  return errors;
 }
 
-int main(){
-        int errors = 0;
-        OMPVV_TEST_OFFLOADING;
-        OMPVV_TEST_AND_SET_VERBOSE(errors, test_allocate() != 0);
-        OMPVV_REPORT_AND_RETURN(errors);
+int main() {
+  int errors = 0;
+  OMPVV_TEST_OFFLOADING;
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_allocate() != 0);
+  OMPVV_REPORT_AND_RETURN(errors);
 }

--- a/tests/5.2/scope/test_scope_allocate_construct.c
+++ b/tests/5.2/scope/test_scope_allocate_construct.c
@@ -26,15 +26,18 @@ int test_allocate(){
         int errors=0;
         int arr[N];
 
-	#pragma omp target map(tofrom: errors) 
+	#pragma omp target parallel map(tofrom: errors) 
         #pragma omp scope private(arr) allocate(allocator(omp_low_lat_mem_alloc): arr)
         {
+		int err = 0;
 		for(int i=0; i< N; i++){
                 	arr[i] = i;
                 }
 		for(int j=0; j< N; j++){
-			if(arr[j] != j) errors++;
+			if(arr[j] != j) err++;
 		}
+		#pragma omp atomic update
+		errors += err;
         }
         return errors;
 }

--- a/tests/5.2/scope/test_scope_allocate_construct.c
+++ b/tests/5.2/scope/test_scope_allocate_construct.c
@@ -1,0 +1,39 @@
+//--------------- test_scope_allocate_construct.c -----------------------------//
+//
+// OpenMP API Version 5.2 Nov 2021
+//
+// This test checks that the scope directive with the allocate clause is
+// working correctly.
+// This is done by specifying
+//----------------------------------------------------------------------------//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+int test_allocate(){
+        int errors=0;
+        int arr[N];
+
+	#pragma omp target map(tofrom: errors) 
+        #pragma omp scope private(arr) allocate(allocator(omp_low_lat_mem_alloc): arr)
+        {
+		for(int i=0; i< N; i++){
+                	arr[i] = i;
+                }
+		for(int j=0; j< N; j++){
+			if(arr[j] != j) errors++;
+		}
+        }
+        return errors;
+}
+
+int main(){
+        int errors = 0;
+        OMPVV_TEST_OFFLOADING;
+        OMPVV_TEST_AND_SET_VERBOSE(errors, test_allocate() != 0);
+        OMPVV_REPORT_AND_RETURN(errors);
+}


### PR DESCRIPTION
On Summit
gcc (GCC) 13.1.1 20230530 [devel/omp/gcc-13 04538859740]: PASS
test_scope_allocate_construct.c.o:
[OMPVV_INFO: test_scope_allocate_construct.c:48] Test is running on device.
[OMPVV_INFO: test_scope_allocate_construct.c:50] The value of errors is 0.
[OMPVV_RESULT: test_scope_allocate_construct.c] Test passed on the device.
clang version 17.0.0, InstalledDir: /sw/summit/ums/stf010/llvm/17.0.0-20230501/bin: FAIL
30:15: error: expected an OpenMP directive
  #pragma omp scope private(arr) allocate(allocator(omp_low_lat_mem_alloc) : arr)
nvc 22.5-0 linuxpower target on Linuxpower: FAIL
line 30: error: invalid text in pragma
    #pragma omp scope private(arr) allocate(allocator(omp_low_lat_mem_alloc) : arr)
