### PR TITLE
5.1 scope construct newtest

### DIFF
--- a/tests/5.1/scope/test_scope_construct.c
+++ b/tests/5.1/scope/test_scope_construct.c
@@ -4,6 +4,7 @@
 //
 //Tests the behavior of the scope construct with no clauses
 //specified.
+//Offloads to a gpu.
 //--------------------------------------------------------//
 
 #include <omp.h>
@@ -16,21 +17,24 @@
 int test_scope() {
   int errors = 0;
   int total = 0;
-  #pragma omp parallel shared(total) target(tofrom: total)
+  #pragma omp target parallel shared(total) map(tofrom: total)
 	{
 		#pragma omp scope
 		{
       #pragma omp for 
       for (int i=0; i < N; ++i){
+        #pragma omp atomic update
         ++total;
+        printf("<%i>\n",omp_get_num_threads());
       }
     }
   }
-  
+  printf("%i\n",total);
   OMPVV_TEST_AND_SET_VERBOSE(errors, total != N);
   return errors;
 }
 int main() {
+  int errors = 0;
 	OMPVV_TEST_OFFLOADING;
 	OMPVV_TEST_AND_SET_VERBOSE(errors, test_scope() != 0);
 	OMPVV_REPORT_AND_RETURN(errors);

--- a/tests/5.1/scope/test_scope_construct.c
+++ b/tests/5.1/scope/test_scope_construct.c
@@ -1,0 +1,37 @@
+//-------------test_scope_construct.c---------------------//
+//
+//OpenMP API Version 5.1 Aug 2021
+//
+//Tests the behavior of the scope construct with no clauses
+//specified.
+//--------------------------------------------------------//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 64
+
+int test_scope() {
+  int errors = 0;
+  int total = 0;
+  #pragma omp parallel shared(total) target(tofrom: total)
+	{
+		#pragma omp scope
+		{
+      #pragma omp for 
+      for (int i=0; i < N; ++i){
+        ++total;
+      }
+    }
+  }
+  
+  OMPVV_TEST_AND_SET_VERBOSE(errors, total != N);
+  return errors;
+}
+int main() {
+	OMPVV_TEST_OFFLOADING;
+	OMPVV_TEST_AND_SET_VERBOSE(errors, test_scope() != 0);
+	OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.1/scope/test_scope_construct.c
+++ b/tests/5.1/scope/test_scope_construct.c
@@ -1,41 +1,39 @@
 //-------------test_scope_construct.c---------------------//
 //
-//OpenMP API Version 5.1 Aug 2021
+// OpenMP API Version 5.1 Aug 2021
 //
-//Tests the behavior of the scope construct with no clauses
-//specified.
-//Offloads to a gpu.
+// Tests the behavior of the scope construct with no clauses
+// specified.
+// Offloads to a device.
 //--------------------------------------------------------//
 
+#include "ompvv.h"
 #include <omp.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include "ompvv.h"
 
 #define N 64
 
 int test_scope() {
   int errors = 0;
   int total = 0;
-  #pragma omp target parallel shared(total) map(tofrom: total)
-	{
-		#pragma omp scope
-		{
-      #pragma omp for 
-      for (int i=0; i < N; ++i){
+  #pragma omp target parallel shared(total) map(tofrom : total)
+  {
+    #pragma omp scope
+    {
+      #pragma omp for
+      for (int i = 0; i < N; ++i) {
         #pragma omp atomic update
         ++total;
-        printf("<%i>\n",omp_get_num_threads());
       }
     }
   }
-  printf("%i\n",total);
   OMPVV_TEST_AND_SET_VERBOSE(errors, total != N);
   return errors;
 }
 int main() {
   int errors = 0;
-	OMPVV_TEST_OFFLOADING;
-	OMPVV_TEST_AND_SET_VERBOSE(errors, test_scope() != 0);
-	OMPVV_REPORT_AND_RETURN(errors);
+  OMPVV_TEST_OFFLOADING;
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_scope() != 0);
+  OMPVV_REPORT_AND_RETURN(errors);
 }


### PR DESCRIPTION
On summit
gcc (GCC) 13.1.1 20230530 [devel/omp/gcc-13 04538859740]: PASS
test_scope_construct.c.o:
[OMPVV_INFO: test_scope_construct.c:36] Test is running on device.
[OMPVV_INFO: test_scope_construct.c:38] The value of errors is 0.
[OMPVV_RESULT: test_scope_construct.c] Test passed on the device.
clang version 17.0.0, InstalledDir: /sw/summit/ums/stf010/llvm/17.0.0-20230501/bin: FAIL
22:17: error: expected an OpenMP directive
    #pragma omp scope
nvc 22.5-0 linuxpower target on Linuxpower: FAIL
line 22: error: invalid text in pragma
      #pragma omp scope

