### PR TITLE
5.2 otherwise clause on metadirective construct newtest

### DIFF
--- a/tests/5.1/teams/test_omp_set_teams_thread_limit_routine.c
+++ b/tests/5.1/teams/test_omp_set_teams_thread_limit_routine.c
@@ -1,0 +1,40 @@
+//--------------- test_omp_set_teams_thread_limit_routine.c ----------------//
+//
+// OpenMP API Version 5.1 Aug 2020
+//
+// The objective of this test is to check that the teams-thread-limit-var ICV
+// is set properly. This test itself simply checks
+// that the threadlimit is set to the appropriate variable value specified
+// in the test name.//////////////
+//--------------------------------------------------------------------------//
+
+#include "ompvv.h"
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int test_set_teams_thread_limit() {
+  int errors = 0;
+  int limit_value = OMPVV_NUM_THREADS_DEVICE / OMPVV_NUM_TEAMS_DEVICE;
+  int current_limit_value = omp_get_teams_thread_limit(); // default is 0
+
+  if (limit_value == 1)
+    limit_value = 2;
+
+  omp_set_teams_thread_limit(limit_value);
+  current_limit_value = omp_get_teams_thread_limit();
+
+  OMPVV_ERROR_IF(current_limit_value != limit_value,
+                 "teams-thread-limit-var ICV not set correctly");
+  OMPVV_INFOMSG_IF(current_limit_value == 0,
+                   "teams-thread-limit-var ICV is default value");
+  OMPVV_TEST_AND_SET(errors, current_limit_value != limit_value);
+  return errors;
+}
+
+int main() {
+  int errors = 0;
+  OMPVV_TEST_OFFLOADING;
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_set_teams_thread_limit() != 0);
+  OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.2/metadirective/test_metadirective_otherwise.c
+++ b/tests/5.2/metadirective/test_metadirective_otherwise.c
@@ -1,0 +1,56 @@
+//--------------- test_scope_allocate_construct.c ----------------------------//
+// OpenMP API Version 5.2 Nov 2021
+// ************************
+// DIRECTIVE: metadirective
+// CLAUSES: when, otherwise 
+// ************************
+// The otherwise clause of the metadirective construct is being tested. The
+// metadirective construct contains a when clause, which itself contains a
+// context-selector (device = {kind(host)}) and a directive-variant (nothing).
+// The metadirective construct also contains a otherwise clause, which itself
+// contains a directive-variant (parallel for).
+// The when clause of the metadirective construct is
+// evaluated for a valid context-selector pertaining to an implementation
+// defined device of kind host. If no target construct were specified, the
+// evaluation would be true, and the directive-variant nothing would be executed
+// as if #pragma omp nothing were present. Target is present, so the
+// directive-variant of the otherwise clause will be executed. This would not 
+// occur if device = {kind(nohost)} were specified. If the given for loop 
+// executes in parallel, the test will pass.
+//----------------------------------------------------------------------------//
+
+#include <omp.h>
+#include "ompvv.h"
+
+#define N 16
+
+int test_otherwise() {
+  int errors = 0;
+  int total = 0;
+
+#pragma omp target map(tofrom : total)
+{
+  #pragma omp metadirective \
+    when(device = {kind(host)}: nothing) \
+    otherwise(parallel for)
+    {
+      for (int i = 0; i < N; ++i) {
+        if (omp_in_parallel()) {
+          #pragma omp atomic update
+          ++total;
+        }
+      }
+    }
+}
+  OMPVV_ERROR_IF(total != N, "Value of total is %i, not %i", total, N);
+  OMPVV_TEST_AND_SET_VERBOSE(errors, total != N);
+
+  return errors;
+}
+
+int main() {
+  int errors = 0;
+  OMPVV_TEST_OFFLOADING;
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_otherwise() != 0);
+  OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.2/runtime_calls/test_omp_in_explicit_task.c
+++ b/tests/5.2/runtime_calls/test_omp_in_explicit_task.c
@@ -1,0 +1,56 @@
+//===---- test_omp_in_explicit_task.c ----------------------------------------------===//
+// 
+// OpenMP API Version 5.2 Nov 2021
+//
+// Uses omp_in_explicit_task() runtime call to ensure it is 1 when in an explicit
+// task and 0 otherwise.
+// 
+//===-------------------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include "ompvv.h"
+#include <stdbool.h>
+
+#define N 256
+
+int errors;
+
+int test_wrapper() { 
+    errors = 0;
+    int A[N];
+    for(int i = 0; i < N; i++){
+        A[i] = 0;
+    }
+    #pragma omp task shared(A)// creates EXPLICIT task, omp_in_explicit_task = 1
+    {
+        for(int i = 0; i < N; i++){
+            A[i] = omp_in_explicit_task();
+        }
+    }
+    for(int i = 0; i < N; i++){
+        OMPVV_TEST_AND_SET(errors, A[i] == 0);
+    }
+    OMPVV_ERROR_IF(A[rand()%N] == 0, "omp_in_explicit_task() did not return correct value when called inside an explicit task");
+    
+    for(int i = 0; i < N; i++){
+        A[i] = 1;
+        #pragma omp parallel for // creates IMPLICIT tasks, omp_in_explicit_task = 0
+        for(int i = 0; i < N; i++){
+            A[i] = omp_in_explicit_task();
+        }
+    }
+    OMPVV_ERROR_IF(A[rand()%N] != 0, "omp_in_explicit_task() did not return correct value when called inside an implicit task");
+    
+    for(int i = 0; i < N; i++){
+        OMPVV_TEST_AND_SET(errors, A[i] != 0);
+    }
+    return errors;
+}
+
+int main () {
+   OMPVV_TEST_AND_SET_VERBOSE(errors, test_wrapper());
+   OMPVV_REPORT_AND_RETURN(errors);
+}  

--- a/tests/5.2/scope/test_scope_firstprivate_construct.c
+++ b/tests/5.2/scope/test_scope_firstprivate_construct.c
@@ -1,0 +1,39 @@
+//--------------- test_scope_firstprivate_construct.c -----------------------------//
+//
+// OpenMP API Version 5.2 Nov 2021 
+//
+// This test checks that the scope firstprivate construct clause is properly working.
+// The test itself passes a test integer into the scope pragma and ensures that
+// all changes made to it are not kept outside of the scope region.
+//----------------------------------------------------------------------------//
+
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+#include <math.h>
+
+int test_scope(){
+	int errors = 0;
+	int test_int = 1;
+	#pragma omp target parallel map(tofrom: errors) 
+	{
+		#pragma omp scope firstprivate(test_int)
+		{
+			test_int += 1;
+			OMPVV_TEST_AND_SET(errors,test_int != 2);
+		}
+	}
+	OMPVV_ERROR_IF(errors, "firstprivate int is not updating correctly");
+	OMPVV_TEST_AND_SET_VERBOSE(errors,test_int != 1);
+	OMPVV_INFOMSG_IF(test_int == 2, "test int was not firstprivate");
+	return errors;
+}
+
+int main(){
+	int errors = 0;
+	OMPVV_TEST_OFFLOADING;
+	OMPVV_TEST_AND_SET_VERBOSE(errors, test_scope() != 0);
+	OMPVV_REPORT_AND_RETURN(errors);
+}


### PR DESCRIPTION
clang version 17.0.0
InstalledDir: /sw/summit/ums/stf010/llvm/17.0.0-20230501/bin
PASS
 warning: extra tokens at the end of '#pragma omp nothing' are ignored [-Wextra-tokens]
    when(device = {kind(host)}: nothing) \
test_metadirective_otherwise.c.o:
[OMPVV_INFO: test_metadirective_otherwise.c:53] Test is running on device.
[OMPVV_INFO: test_metadirective_otherwise.c:55] The value of errors is 0.
[OMPVV_RESULT: test_metadirective_otherwise.c] Test passed on the device.
gcc (GCC) 13.1.1 20230614 [devel/omp/gcc-13 aa827ff02ec]
FAIL
 In function 'test_otherwise':
/autofs/nccs-svm1_home1/andrewka/sollve_vv/tests/5.2/metadirective/test_metadirective_otherwise.c:35:14: error: expected 'when' or 'default' before '(' token
   35 |     otherwise(parallel for)
/autofs/nccs-svm1_home1/andrewka/sollve_vv/tests/5.2/metadirective/test_metadirective_otherwise.c:39:30: error: expected end of line before 'update'
   39 |           #pragma omp atomic update
nvc 22.5-0 linuxpower target on Linuxpower
FAIL
 line 34: error: invalid text in pragma
      when(device = {kind(host)}: nothing) \
 line 35: error: extra text after expected end of preprocessing directive
      otherwise(parallel for)