### PR TITLE
Added initial file for testing mapping of pointer with not matching data item

### DIFF
--- a/tests/5.1/scope/test_scope_construct.c
+++ b/tests/5.1/scope/test_scope_construct.c
@@ -1,0 +1,41 @@
+//------------ test_scope_construct.c --------------------//
+// OpenMP API Version 5.1 Nov 2020
+// *****************
+// DIRECTIVE: scope
+// *****************
+// The scope directive is being tested. Scope binds to the 
+// innermost parallel region. However, since no
+// clauses are specified, there should be no modification
+// to the behavior of code execution. Therefore, the test
+// checks that the the total is updated correctly as if the
+// scope directive were not present.
+//--------------------------------------------------------//
+
+#include <omp.h>
+#include "ompvv.h"
+
+#define N 64
+
+int test_scope() {
+  int errors = 0;
+  int total = 0;
+  #pragma omp target parallel shared(total) map(tofrom : total)
+  {
+    #pragma omp scope
+    {
+      #pragma omp for
+      for (int i = 0; i < N; ++i) {
+        #pragma omp atomic update
+        ++total;
+      }
+    }
+  }
+  OMPVV_TEST_AND_SET_VERBOSE(errors, total != N);
+  return errors;
+}
+int main() {
+  int errors = 0;
+  OMPVV_TEST_OFFLOADING;
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_scope() != 0);
+  OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.1/target/test_target_map_iterators.F90
+++ b/tests/5.1/target/test_target_map_iterators.F90
@@ -1,0 +1,55 @@
+!===--- test_target_map_iterator.F90 ----------------------------------===//
+!
+! OpenMP API Version 5.1 Nov 2020
+!
+! This test is designed to test the iterator map-type-modifier for the map
+! clause. The test should create a list of size N and then pass to the 
+! target region the length of the array 1:N and modify the values.
+! The test then checks to see if the appropriate range was modified.
+!
+!//===-----------------------------------------------------------------===//
+
+#include "ompvv.F90"
+
+#define N 1024
+
+PROGRAM test_target_map_iterator
+  USE iso_fortran_env
+  USE, INTRINSIC :: iso_c_binding
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+  OMPVV_TEST_OFFLOADING
+
+  OMPVV_TEST_VERBOSE(test_map_iterator() .NE. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION test_map_iterator()
+    INTEGER :: errors, i, listsum
+    INTEGER, DIMENSION(N) :: test_lst
+
+    errors = 0
+    listsum = 0
+
+    DO i=1, N
+      test_lst(i) = 1
+    END DO
+
+    !$omp target map(iterator(it = 1:N), tofrom: test_lst(it))
+    DO i=1, N
+      test_lst(i) = 2
+    END DO
+    !$omp end target
+
+    DO i=1, N
+      listsum = listsum + test_lst(i)
+    END DO
+
+    OMPVV_TEST_AND_SET(errors, listsum .NE. 2*N)
+
+    test_map_iterator = errors
+  END FUNCTION test_map_iterator
+END PROGRAM test_target_map_iterator
+

--- a/tests/5.1/target/test_target_map_iterators.c
+++ b/tests/5.1/target/test_target_map_iterators.c
@@ -1,6 +1,6 @@
-//-------------------------test_map_iterator.c-----------------------------
+//-------------------------test_target_map_iterator.c----------------------
 //
-//OpenMP API Version 5.1 Jan 2023
+//OpenMP API Version 5.1 Nov 2020
 //
 // This test is designed to test the iterator map-type-modifier for the map
 // clause. The test should create a list of size N and then pass to the 

--- a/tests/5.2/target/test_target_map_device_pointer.c
+++ b/tests/5.2/target/test_target_map_device_pointer.c
@@ -1,53 +1,63 @@
-//===--- test_declare_target_map_device_pointer.c ------------------------------------------===//
-// 
-// OpenMP API Version 5.2 Nov 2021 
-//
-//This test checks if, after offloading, the initalized pointer variable retains its 
-//original value as per the semantics of the firstprivate clause. 
-//The pointer variable, nor the array it refers to, are not mapped to the device. This 
-//ensures that a matching mapped data item is not found for the pointer, so it retains
-//its original value.
-//===---------------------------------------------------------------------------------------===//
-
-#include <stdio.h>
-#include <stdlib.h>
-#include <omp.h>
+//--------------- test_target_map_device_pointer.c ---------------------------//
+// OpenMP API Version 5.2 Nov 2021
+// Pg. 627, line 24
+// This test ensures that--paraphrase of Section 5.8.6--a pointer that is
+// implicitly mapped or explicitely mapped to the device, predetermined to be
+// firstprivate in the device data environment, will retain its original value
+// (attained prior to the target region) and follow the semantics of the
+// firstprivate clause. This is true if a matching mapped list item, as defined
+// in Section 5.8.6, is not found for the pointer. In the test, the pointer p1
+// is initialized with the base array address of arr2. When p1 is implicitly
+// mapped to the device, it should retain the same base array address, as the
+// array itself is not mapped (a matching mapped list item is not found). This
+// check is made in the target region with a mapped integer variable holding the
+// base address of arr2. The pointer p2 is initialized to NULL, and is checked
+// to remain NULL after being initialized on a device. Following the checks, p1
+// is changed to NULL on the device and checked outside of the target region if
+// it was not changed from its initial value of the base address of arr2 (per
+// firstprivate semnatics). p2 is given an arbitrary value for the purpose of
+// ensuring that it too retains its original value after the target region. A
+// defaultmap clause is present on the target construct to explicitely ensure
+// that the default semantics of mapping apply to all mapped (implicit/explicit)
+// pointer types. The zero length array, arr1, is mapped to the device to ensure
+// that a runtime check occurs in accordance with the semantics described in the
+// target construct on page 285 of the specifications.
+//----------------------------------------------------------------------------//
 #include "ompvv.h"
+#include <omp.h>
+#include <stdint.h> //includes intptr_t
 
-#define N 1000
+#define N 16
 
-int test_pointer() {
-  int compute_array[N];
-  int *p;
+int test_target_pointer() {
   int errors = 0;
-  int i;
-  
-  // Array initialization
-  for (i = 0; i < N; i++)
-    compute_array[i] = i;
-  p = &compute_array[0];
+  int arr1[0], arr2[N];
+  int *p1 = &arr2[0];
+  int *p2 = NULL;
+  intptr_t hold_arr2 = (intptr_t)&arr2[0];
 
-  #pragma omp target defaultmap(none:pointer)
+  #pragma omp target map(tofrom:errors) map(to:hold_arr2,arr1[:0]) defaultmap(default:pointer)
   {
-    // Array modified through the pointer
-    int index=0;
-    for (i = N-1; i >= 0; i--){
-      p[index] = i;
-      index++;
-    }
-  } // end target
+    OMPVV_TEST_AND_SET(errors, ((intptr_t) p1 != hold_arr2) || (p2 != NULL));
+    
+    p1 = NULL;
+    p2 = (int *) 0x12345;
+  }
 
-  // Pointer values comparison
-  for (i = 0; i < N; i++)
-    if (p[i] != i) errors++;
-
-  OMPVV_ERROR_IF(errors!=0, "ERROR COUNT (DIFFERING VALUES): %d",errors);
-  
+  OMPVV_ERROR_IF(errors != 0,
+                 "At least one pointer did not retain its original value");
+  OMPVV_ERROR_IF(p1 != &arr2[0],
+                 "The value of p1 was updated, p1 was not firstprivate");
+  OMPVV_ERROR_IF(p2 != NULL,
+                 "The value of p2 was updated, p2 was not firstprivate");
+  OMPVV_TEST_AND_SET(errors, (p1 != &arr2[0]) || (p2 != NULL))
   return errors;
 }
-int main(){
-  int errors=0;
+
+int main() {
+  int errors = 0;
   OMPVV_TEST_OFFLOADING;
-  OMPVV_TEST_AND_SET_VERBOSE(errors, test_pointer() != 0);
+  OMPVV_TEST_AND_SET(errors, test_target_pointer() != 0)
   OMPVV_REPORT_AND_RETURN(errors);
+  return errors;
 }

--- a/tests/5.2/target/test_target_map_device_pointer.c
+++ b/tests/5.2/target/test_target_map_device_pointer.c
@@ -56,8 +56,9 @@ int test_target_pointer() {
 
 int main() {
   int errors = 0;
-  OMPVV_TEST_OFFLOADING;
-  OMPVV_TEST_AND_SET(errors, test_target_pointer() != 0)
+  int on_device = 0;
+  OMPVV_TEST_AND_SET_OFFLOADING(on_device);
+  OMPVV_TEST_AND_SET(errors, test_target_pointer() != 0 || on_device == 0)
   OMPVV_REPORT_AND_RETURN(errors);
   return errors;
 }

--- a/tests/5.2/target/test_target_map_device_pointer.c
+++ b/tests/5.2/target/test_target_map_device_pointer.c
@@ -19,9 +19,7 @@
 // ensuring that it too retains its original value after the target region. A
 // defaultmap clause is present on the target construct to explicitely ensure
 // that the default semantics of mapping apply to all mapped (implicit/explicit)
-// pointer types. The zero length array, arr1, is mapped to the device to ensure
-// that a runtime check occurs in accordance with the semantics described in the
-// target construct on page 285 of the specifications.
+// pointer types.
 //----------------------------------------------------------------------------//
 #include "ompvv.h"
 #include <omp.h>
@@ -31,12 +29,12 @@
 
 int test_target_pointer() {
   int errors = 0;
-  int arr1[0], arr2[N];
+  int arr2[N];
   int *p1 = &arr2[0];
   int *p2 = NULL;
   intptr_t hold_arr2 = (intptr_t)&arr2[0];
 
-  #pragma omp target map(tofrom:errors) map(to:hold_arr2,arr1[:0]) defaultmap(default:pointer)
+  #pragma omp target map(tofrom:errors) map(to:hold_arr2) defaultmap(default:pointer)
   {
     OMPVV_TEST_AND_SET(errors, ((intptr_t) p1 != hold_arr2) || (p2 != NULL));
     
@@ -64,7 +62,6 @@ int test_target_pointer() {
 
 int main() {
   int errors = 0;
-  int on_device = 0;
   OMPVV_TEST_AND_SET(errors, test_target_pointer() != 0)
   OMPVV_REPORT_AND_RETURN(errors);
   return errors;

--- a/tests/5.2/target/test_target_map_device_pointer.c
+++ b/tests/5.2/target/test_target_map_device_pointer.c
@@ -44,21 +44,28 @@ int test_target_pointer() {
     p2 = (int *) 0x12345;
   }
 
-  OMPVV_ERROR_IF(errors != 0,
-                 "At least one pointer did not retain its original value");
-  OMPVV_ERROR_IF(p1 != &arr2[0],
-                 "The value of p1 was updated, p1 was not firstprivate");
-  OMPVV_ERROR_IF(p2 != NULL,
-                 "The value of p2 was updated, p2 was not firstprivate");
-  OMPVV_TEST_AND_SET(errors, (p1 != &arr2[0]) || (p2 != NULL))
+  OMPVV_TEST_OFFLOADING_PROBE;
+  OMPVV_TEST_SHARED_ENVIRONMENT_PROBE;
+
+  if (_ompvv_isOffloadingOn && !_ompvv_isSharedEnv){
+    OMPVV_ERROR_IF(errors != 0,
+                   "At least one pointer did not retain its original value");
+    OMPVV_ERROR_IF(p1 != &arr2[0],
+                   "The value of p1 was updated, p1 was not firstprivate");
+    OMPVV_ERROR_IF(p2 != NULL,
+                   "The value of p2 was updated, p2 was not firstprivate");
+    OMPVV_TEST_AND_SET(errors, (p1 != &arr2[0]) || (p2 != NULL))
+  }else{
+    OMPVV_WARNING("_ompvv_isOffloadingOn: %i, _ompvv_isSharedEnv: %i, test is invalid",
+        _ompvv_isOffloadingOn, _ompvv_isSharedEnv)
+  }
   return errors;
 }
 
 int main() {
   int errors = 0;
   int on_device = 0;
-  OMPVV_TEST_AND_SET_OFFLOADING(on_device);
-  OMPVV_TEST_AND_SET(errors, test_target_pointer() != 0 || on_device == 0)
+  OMPVV_TEST_AND_SET(errors, test_target_pointer() != 0)
   OMPVV_REPORT_AND_RETURN(errors);
   return errors;
 }


### PR DESCRIPTION
frontier
clang 18.0.0
[OMPVV_WARNING: test_target_map_device_pointer.c:58] _ompvv_isOffloadingOn: 1, _ompvv_isSharedEnv: 1, test is invalid
summit
gcc 13.2.1
[OMPVV_WARNING: test_target_map_device_pointer.c:57] _ompvv_isOffloadingOn: 1, _ompvv_isSharedEnv: 1, test is invalid
nvc 22.11
line 67: warning: statement is unreachable [code_is_unreachable]
    return errors;
[OMPVV_WARNING: test_target_map_device_pointer.c:58] _ompvv_isOffloadingOn: 1, _ompvv_isSharedEnv: 1, test is invalid