### PR TITLE
Added initial test for scope construct

### DIFF
--- a/tests/5.1/scope/test_scope_construct.c
+++ b/tests/5.1/scope/test_scope_construct.c
@@ -1,0 +1,39 @@
+//-------------test_scope_construct.c---------------------//
+//
+// OpenMP API Version 5.1 Aug 2021
+//
+// Tests the behavior of the scope construct with no clauses
+// specified.
+// Offloads to a device.
+//--------------------------------------------------------//
+
+#include "ompvv.h"
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define N 64
+
+int test_scope() {
+  int errors = 0;
+  int total = 0;
+  #pragma omp target parallel shared(total) map(tofrom : total)
+  {
+    #pragma omp scope
+    {
+      #pragma omp for
+      for (int i = 0; i < N; ++i) {
+        #pragma omp atomic update
+        ++total;
+      }
+    }
+  }
+  OMPVV_TEST_AND_SET_VERBOSE(errors, total != N);
+  return errors;
+}
+int main() {
+  int errors = 0;
+  OMPVV_TEST_OFFLOADING;
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_scope() != 0);
+  OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.1/scope/test_scope_construct.c
+++ b/tests/5.1/scope/test_scope_construct.c
@@ -1,16 +1,18 @@
-//-------------test_scope_construct.c---------------------//
-//
-// OpenMP API Version 5.1 Aug 2021
-//
-// Tests the behavior of the scope construct with no clauses
-// specified.
-// Offloads to a device.
+//------------ test_scope_construct.c --------------------//
+// OpenMP API Version 5.1 Nov 2020
+// *****************
+// DIRECTIVE: scope
+// *****************
+// The scope directive is being tested. Scope binds to the 
+// innermost parallel region. However, since no
+// clauses are specified, there should be no modification
+// to the behavior of code execution. Therefore, the test
+// checks that the the total is updated correctly as if the
+// scope directive were not present.
 //--------------------------------------------------------//
 
-#include "ompvv.h"
 #include <omp.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include "ompvv.h"
 
 #define N 64
 


### PR DESCRIPTION
On summit
gcc (GCC) 13.1.1 20230614 [devel/omp/gcc-13 aa827ff02ec]
PASS
test_scope_construct.c.o:
[OMPVV_INFO: test_scope_construct.c:38] Test is running on device.
[OMPVV_INFO: test_scope_construct.c:40] The value of errors is 0.
[OMPVV_RESULT: test_scope_construct.c] Test passed on the device.
clang version 17.0.0, InstalledDir: /sw/summit/ums/stf010/llvm/17.0.0-20230501/bin
FAIL
24:17: error: expected an OpenMP directive
    #pragma omp scope
1 error generated.
nvc 22.5-0 linuxpower target on Linuxpower
FAIL
line 24: error: invalid text in pragma
      #pragma omp scope
1 error detected in the compilation of "/autofs/nccs-svm1_home1/andrewka/sollve_vv/tests/5.1/scope/test_scope_construct.c"