### PR TITLE
Initial test for metadirective construct with otherwise clause

### DIFF
--- a/tests/5.2/metadirective/test_metadirective_otherwise.c
+++ b/tests/5.2/metadirective/test_metadirective_otherwise.c
@@ -23,9 +23,7 @@
 #include <omp.h>
 #include "ompvv.h"
 
-#ifndef N
 #define N 16
-#endif
 
 int test_otherwise() {
   int errors = 0;

--- a/tests/5.2/metadirective/test_metadirective_otherwise.c
+++ b/tests/5.2/metadirective/test_metadirective_otherwise.c
@@ -42,7 +42,7 @@ int test_otherwise() {
     OMPVV_TEST_AND_SET_VERBOSE(errors, on_host == 1);
   } else {
     OMPVV_WARNING(
-        "NO DEVICES ARE AVAILABLE, OTHERWISE CLAUSE WAS NOT ACCESSED");
+        "NO DEVICES ARE AVAILABLE, OTHERWISE CLAUSE WAS ACCESSED ON HOST");
   }
 
   return errors;

--- a/tests/5.2/metadirective/test_metadirective_otherwise.c
+++ b/tests/5.2/metadirective/test_metadirective_otherwise.c
@@ -2,7 +2,7 @@
 // OpenMP API Version 5.2 Nov 2021
 // *************************
 // DIRECTIVE: metadirective
-// CLAUSES: when, otherwise 
+// CLAUSES: when, otherwise
 // *************************
 // The otherwise clause of the metadirective construct is being tested. The
 // metadirective construct contains a when clause, which itself contains a
@@ -10,47 +10,54 @@
 // The metadirective construct also contains an otherwise clause, which itself
 // contains a directive-variant (parallel for).
 // The when clause of the metadirective construct is
-// evaluated for a valid context-selector pertaining to a device related 
+// evaluated for a valid context-selector pertaining to a device related
 // characteristic of a certain kind (host), defined in the OpenMP additional
 // definitions. If no target construct were specified, the evaluation would
-// be true, and the directive-variant nothing would be executed as if 
+// be true, and the directive-variant nothing would be executed as if
 // #pragma omp nothing were present. Target is present, so the directive-variant
-// of the otherwise clause will be executed. This would not occur if 
-// device = {kind(nohost)} were specified. If the given for loop executes in 
-// parallel, the test will pass.
+// of the otherwise clause will be executed. This would not occur if
+// device = {kind(nohost)} were specified. If the given for loop executes in
+// a nested parallel region, the test will pass.
 //----------------------------------------------------------------------------//
 
-#include <omp.h>
 #include "ompvv.h"
+#include <omp.h>
 
 #define N 16
 
 int test_otherwise() {
   int errors = 0;
   int total = 0;
+  int num_devices = omp_get_num_devices();
 
-#pragma omp target map(tofrom : total)
-{
+  #pragma omp target map(tofrom : total)
+  {
   #pragma omp metadirective \
     when(device = {kind(host)}: nothing) \
     otherwise(parallel for)
     {
       for (int i = 0; i < N; ++i) {
-        if (omp_in_parallel()) {
+        if (omp_get_level()) {
           #pragma omp atomic update
           ++total;
         }
       }
     }
-}
-  OMPVV_ERROR_IF(total != N, "Value of total is %i, not %i", total, N);
-  OMPVV_TEST_AND_SET_VERBOSE(errors, total != N);
+  }
+  if (num_devices > 0) {
+    OMPVV_ERROR_IF(total != N, "Value of total is %i, not %i", total, N);
+    OMPVV_TEST_AND_SET_VERBOSE(errors, total != N);
+  } else {
+    OMPVV_WARNING(
+        "NO DEVICES ARE AVAILABLE, OTHERWISE CLAUSE WAS NOT ACCESSED");
+  }
 
   return errors;
 }
 
 int main() {
   int errors = 0;
+  OMPVV_INFOMSG("IMPLEMENTATION DEFINED OPENMP VERSION: %d", _OPENMP);
   OMPVV_TEST_OFFLOADING;
   OMPVV_TEST_AND_SET_VERBOSE(errors, test_otherwise() != 0);
   OMPVV_REPORT_AND_RETURN(errors);

--- a/tests/5.2/metadirective/test_metadirective_otherwise.c
+++ b/tests/5.2/metadirective/test_metadirective_otherwise.c
@@ -1,0 +1,56 @@
+//--------------- test_scope_allocate_construct.c ----------------------------//
+// OpenMP API Version 5.2 Nov 2021
+// ************************
+// DIRECTIVE: metadirective
+// CLAUSES: when, otherwise 
+// ************************
+// The otherwise clause of the metadirective construct is being tested. The
+// metadirective construct contains a when clause, which itself contains a
+// context-selector (device = {kind(host)}) and a directive-variant (nothing).
+// The metadirective construct also contains a otherwise clause, which itself
+// contains a directive-variant (parallel for).
+// The when clause of the metadirective construct is
+// evaluated for a valid context-selector pertaining to an implementation
+// defined device of kind host. If no target construct were specified, the
+// evaluation would be true, and the directive-variant nothing would be executed
+// as if #pragma omp nothing were present. Target is present, so the
+// directive-variant of the otherwise clause will be executed. This would not 
+// occur if device = {kind(nohost)} were specified. If the given for loop 
+// executes in parallel, the test will pass.
+//----------------------------------------------------------------------------//
+
+#include <omp.h>
+#include "ompvv.h"
+
+#define N 16
+
+int test_otherwise() {
+  int errors = 0;
+  int total = 0;
+
+#pragma omp target map(tofrom : total)
+{
+  #pragma omp metadirective \
+    when(device = {kind(host)}: nothing) \
+    otherwise(parallel for)
+    {
+      for (int i = 0; i < N; ++i) {
+        if (omp_in_parallel()) {
+          #pragma omp atomic update
+          ++total;
+        }
+      }
+    }
+}
+  OMPVV_ERROR_IF(total != N, "Value of total is %i, not %i", total, N);
+  OMPVV_TEST_AND_SET_VERBOSE(errors, total != N);
+
+  return errors;
+}
+
+int main() {
+  int errors = 0;
+  OMPVV_TEST_OFFLOADING;
+  OMPVV_TEST_AND_SET_VERBOSE(errors, test_otherwise() != 0);
+  OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.2/metadirective/test_metadirective_otherwise.c
+++ b/tests/5.2/metadirective/test_metadirective_otherwise.c
@@ -6,47 +6,40 @@
 // *************************
 // The otherwise clause of the metadirective construct is being tested. The
 // metadirective construct contains a when clause, which itself contains a
-// context-selector (device = {kind(host)}) and a directive-variant (nothing).
+// context-selector (device = {kind(nohost)}) and a directive-variant (nothing).
 // The metadirective construct also contains an otherwise clause, which itself
-// contains a directive-variant (parallel for).
+// contains a directive-variant (target map(tofrom : on_host)).
 // The when clause of the metadirective construct is
 // evaluated for a valid context-selector pertaining to a device related
-// characteristic of a certain kind (host), defined in the OpenMP additional
-// definitions. If no target construct were specified, the evaluation would
+// characteristic of a certain kind (nohost), defined in the OpenMP additional
+// definitions. If a target construct were specified, the evaluation would
 // be true, and the directive-variant nothing would be executed as if
-// #pragma omp nothing were present. Target is present, so the directive-variant
-// of the otherwise clause will be executed. This would not occur if
-// device = {kind(nohost)} were specified. If the given for loop executes in
-// a nested parallel region, the test will pass.
+// #pragma omp nothing were present. Target is not present, so the
+// directive-variant of the otherwise clause will be executed. This would not
+// occur if device = {kind(host)} were specified. If omp_is_initial_device()
+// evaluates to false (0), then the test will pass.
 //----------------------------------------------------------------------------//
 
 #include "ompvv.h"
 #include <omp.h>
 
-#define N 16
-
 int test_otherwise() {
   int errors = 0;
-  int total = 0;
+  int on_host = 1;
   int num_devices = omp_get_num_devices();
 
-  #pragma omp target map(tofrom : total)
-  {
   #pragma omp metadirective \
-    when(device = {kind(host)}: nothing) \
-    otherwise(parallel for)
+    when(device = {kind(nohost)}: nothing) \
+    otherwise(target map(tofrom : on_host))
     {
-      for (int i = 0; i < N; ++i) {
-        if (omp_get_level()) {
-          #pragma omp atomic update
-          ++total;
-        }
-      }
+      on_host = omp_is_initial_device();
     }
-  }
+
   if (num_devices > 0) {
-    OMPVV_ERROR_IF(total != N, "Value of total is %i, not %i", total, N);
-    OMPVV_TEST_AND_SET_VERBOSE(errors, total != N);
+    OMPVV_ERROR_IF(
+        on_host == 1,
+        "A device was available, but the target directive was not executed");
+    OMPVV_TEST_AND_SET_VERBOSE(errors, on_host == 1);
   } else {
     OMPVV_WARNING(
         "NO DEVICES ARE AVAILABLE, OTHERWISE CLAUSE WAS NOT ACCESSED");
@@ -57,7 +50,6 @@ int test_otherwise() {
 
 int main() {
   int errors = 0;
-  OMPVV_INFOMSG("IMPLEMENTATION DEFINED OPENMP VERSION: %d", _OPENMP);
   OMPVV_TEST_OFFLOADING;
   OMPVV_TEST_AND_SET_VERBOSE(errors, test_otherwise() != 0);
   OMPVV_REPORT_AND_RETURN(errors);

--- a/tests/5.2/metadirective/test_metadirective_otherwise.c
+++ b/tests/5.2/metadirective/test_metadirective_otherwise.c
@@ -1,22 +1,23 @@
-//--------------- test_scope_allocate_construct.c ----------------------------//
+//--------------- test_metadirective_otherwise.c ----------------------------//
 // OpenMP API Version 5.2 Nov 2021
-// ************************
+// *************************
 // DIRECTIVE: metadirective
 // CLAUSES: when, otherwise 
-// ************************
+// *************************
 // The otherwise clause of the metadirective construct is being tested. The
 // metadirective construct contains a when clause, which itself contains a
 // context-selector (device = {kind(host)}) and a directive-variant (nothing).
-// The metadirective construct also contains a otherwise clause, which itself
+// The metadirective construct also contains an otherwise clause, which itself
 // contains a directive-variant (parallel for).
 // The when clause of the metadirective construct is
-// evaluated for a valid context-selector pertaining to an implementation
-// defined device of kind host. If no target construct were specified, the
-// evaluation would be true, and the directive-variant nothing would be executed
-// as if #pragma omp nothing were present. Target is present, so the
-// directive-variant of the otherwise clause will be executed. This would not 
-// occur if device = {kind(nohost)} were specified. If the given for loop 
-// executes in parallel, the test will pass.
+// evaluated for a valid context-selector pertaining to a device related 
+// characteristic of a certain kind (host), defined in the OpenMP additional
+// definitions. If no target construct were specified, the evaluation would
+// be true, and the directive-variant nothing would be executed as if 
+// #pragma omp nothing were present. Target is present, so the directive-variant
+// of the otherwise clause will be executed. This would not occur if 
+// device = {kind(nohost)} were specified. If the given for loop executes in 
+// parallel, the test will pass.
 //----------------------------------------------------------------------------//
 
 #include <omp.h>


### PR DESCRIPTION
Summit
@@@clang version 17.0.0 (https://github.com/llvm/llvm-project.git d366da97bd24ddfb91c9f260fa0aaf105d947652)
32:42: warning: extra tokens at the end of '#pragma omp nothing' are ignored [-Wextra-tokens]
    when(device = {kind(nohost)}: nothing) \
1 warning generated.
test_metadirective_otherwise.c.o:
"PluginInterface" error: Failure to load binary image 0x11361adb0 on device 0: Error in cuModuleGetFunction('__omp_offloading_37_1aa5ae09_test_otherwise_l33'): named symbol not found
Libomptarget error: Unable to generate entries table for device id 0.
Libomptarget error: Failed to init globals on device 0
Libomptarget error: Consult https://openmp.llvm.org/design/Runtimes.html for debugging options.
Libomptarget error: Source location information not present. Compile with -g or -gline-tables-only.
Libomptarget fatal error 1: failure of target construct while offloading is mandatory
timeout: the monitored command dumped core
@@@gcc (GCC) 13.1.1 20230622 [devel/omp/gcc-13 f1e86148ca1]
In function 'test_otherwise':
33:14: error: expected 'when' or 'default' before '(' token
   33 |     otherwise(target map(tofrom : on_host))
@@@nvc 22.11-0 linuxpower target on Linuxpower
line 32: error: invalid text in pragma
      when(device = {kind(nohost)}: nothing) \
line 33: error: extra text after expected end of preprocessing directive
      otherwise(target map(tofrom : on_host))
2 errors detected in the compilation
Perlmutter
@@@clang version 17.0.0 (https://github.com/llvm/llvm-project.git bfb5d2e6f854f16eb4f4d49ce8c0160f89584a00)
32:42: warning: extra tokens at the end of '#pragma omp nothing' are ignored [-Wextra-tokens]
   32 |     when(device = {kind(nohost)}: nothing) \
1 warning generated.
test_metadirective_otherwise.c.o:
"PluginInterface" error: Failure to load binary image 0x559290737f00 on device 0: Error in cuModuleGetFunction('__omp_offloading_6c_30176039_test_otherwise_l33'): named symbol not found
Libomptarget error: Unable to generate entries table for device id 0.
Libomptarget error: Failed to init globals on device 0
Libomptarget error: Consult https://openmp.llvm.org/design/Runtimes.html for debugging options.
Libomptarget error: Source location information not present. Compile with -g or -gline-tables-only.
Libomptarget fatal error 1: failure of target construct while offloading is mandatory