### PR TITLE
Add new_test/5.1/test_target_is_accessible.F90

### DIFF
--- a/tests/5.1/target/test_target_is_accessible.F90
+++ b/tests/5.1/target/test_target_is_accessible.F90
@@ -1,0 +1,72 @@
+!===--- test_target_is_accessible.F90 -------------------------------===//
+!
+! OpenMP API Version 5.1 Nov 2020
+!
+! This test checks that the omp_target_is_accessible device routine.
+! In this test the output of the target_is_accessible call should return
+! true because the storage indicated by the first and second arguements
+! is accessible by the targeted device. This test is closely adapdted
+! from the 5.1 OpenMP example sheet.
+!
+!//===---------------------------------------------------------------------===//
+
+#include "ompvv.F90"
+
+PROGRAM test_target_is_accessible
+  USE iso_fortran_env
+  USE, INTRINSIC :: iso_c_binding
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+  OMPVV_TEST_OFFLOADING
+
+  OMPVV_TEST_VERBOSE(check_device() .NE. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION check_device()
+    INTEGER :: errors, i, isSharedMemory, N
+    INTEGER, POINTER :: fptr(:)
+    TYPE (C_PTR) :: ptr
+    INTEGER (C_SIZE_T) :: buf_size
+    INTEGER (C_INT) :: dev, check_test
+
+    errors = 0
+    isSharedMemory = 0
+    check_test = 2
+    N = 100
+    dev = omp_get_default_device()
+
+    !Assumes that on shared-memory systems, no copy is done
+    !$omp target map(to: isSharedMemory)
+    isSharedMemory = 1
+    !$omp end target
+
+    ALLOCATE(fptr(N))
+    
+    ptr = c_loc(fptr(1))
+    buf_size = c_sizeof(fptr(1)) * N
+
+    check_test = omp_target_is_accessible(ptr, buf_size, dev)
+
+    IF( check_test .NE. 0 ) THEN
+      !$omp target firstprivate(fptr)
+      DO i=1, N
+        fptr(i) = 5*i
+      END DO
+      !$omp end target
+      DO i=1, N
+        OMPVV_TEST_AND_SET(errors, fptr(i) .NE. 5*i)
+      END DO
+    END IF
+
+    DEALLOCATE(fptr)
+    OMPVV_TEST_AND_SET_VERBOSE(errors, check_test .NE. isSharedMemory)
+    OMPVV_INFOMSG_IF(check_test .EQ. 1, "Omp_target_is_accessible returning true")
+    OMPVV_INFOMSG_IF(check_test .EQ. 0, "Omp_target_is_accessible returning false")
+    OMPVV_ERROR_IF(check_test .EQ. 2, "omp_target_is_accessible did not return true or false")
+    check_device = errors
+  END FUNCTION check_device
+END PROGRAM test_target_is_accessible
+

--- a/tests/5.1/target/test_target_is_accessible.c
+++ b/tests/5.1/target/test_target_is_accessible.c
@@ -1,6 +1,6 @@
 //--------------- test_target_is_accessible.c---------------------//
 //
-// OpenMP API Version 5.1 Aug 2021
+// OpenMP API Version 5.1 Aug 2020
 //
 // This test checks that the omp_target_is_accessible device routine.
 // In this test the output of the target_is_accessible call should return
@@ -23,7 +23,7 @@ int check_device(){
 	const int buf_size = sizeof(int) * N;
 	const int dev = omp_get_default_device();
 	
-	/*Assumes that one shared-memory systems, no copy is done*/
+	/*Assumes that on shared-memory systems, no copy is done*/
 	#pragma omp target map(to: isSharedMemory)
 		isSharedMemory = 1;
 


### PR DESCRIPTION
- GCC 13.1.1:
            - Both C and Fortran tests passed on the device: Omp_target_is_accessible returning false
- XL 16.1.1-10: 
            - C test failed: undefined reference to `omp_target_is_accessible'
            - Fortran test failed: line 51.18: 1516-036 (S) Entity omp_target_is_accessible has undefined type.
- NVHPC 22.11:
            - C test failed: test_target_is_accessible.c.o: FAIL. exit code: 134
            - Fortran test failed: test_target_is_accessible.F90.o: FAIL. exit code: 134
 - LLVM 17.0.0:
            - C test failed: undefined reference to `omp_target_is_accessible'
