### PR TITLE
Add new_test/5.1/atomic/test_atomic_fail_acquire.F90

### DIFF
--- a/tests/5.1/atomic/test_atomic_fail_acquire.F90
+++ b/tests/5.1/atomic/test_atomic_fail_acquire.F90
@@ -1,0 +1,60 @@
+!//===------ test_atomic_fail_acquire.F90 --------------------------===//
+!
+! OpenMP API Version 5.1 Nov 2020
+!
+! Utilizes an atomic seq_cst w/ an atomic release to ensure the implicit
+! setting of x=10. Restrictions on atomic fail state they must be used
+! on an atomic compare.
+!
+!//===----------------------------------------------------------------------===//
+
+#include "ompvv.F90"
+
+#define N 1024
+
+PROGRAM test_atomic_fail_acquire_program
+  USE iso_fortran_env
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+
+  OMPVV_TEST_VERBOSE(test_atomic_fail_acquire() .ne. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION test_atomic_fail_acquire()
+    INTEGER:: errors, x, y
+    INTEGER:: thrd
+    INTEGER:: tmp
+
+    errors = 0
+    x = 0
+    y = 0
+
+    OMPVV_INFOMSG("test_atomic_fail_acquire")
+
+    !$omp parallel num_threads(2) private(thrd, tmp)
+    thrd = omp_get_thread_num()
+    IF( thrd .EQ. 0 ) THEN
+      y = 1
+      !$omp atomic write release 
+      x = 10
+      !$omp end atomic
+    ELSE
+      tmp = 0
+      DO WHILE ( y .NE. 5 )
+        !$omp atomic compare seq_cst fail(acquire)
+        IF (y == 1) THEN
+          y = 5
+        END IF 
+        !$omp end atomic
+      END DO
+      OMPVV_TEST_AND_SET(errors, x .NE. 10)
+      OMPVV_TEST_AND_SET(errors, y .NE. 5)
+    END IF
+    !$omp end parallel
+    
+    test_atomic_fail_acquire = errors
+  END FUNCTION test_atomic_fail_acquire
+END PROGRAM test_atomic_fail_acquire_program


### PR DESCRIPTION
- GCC 13.1.1:
            - Both C and Fortran test passed.
- XL 16.1.1-10:
            - C test passed.
            - Fortran test failed: line 41.12: 1515-019 (S) Syntax is incorrect.
- NVHPC 22.11:
            - C test failed: line 29: error: invalid text in pragma
            - Fortran test failed: NVFORTRAN-S-0034-Syntax error at or near identifier release 
- LLVM 17.0.0:
            - C test passed but with the following warning:  warning: extra tokens at the end of '#pragma omp atomic' are ignored [-Wextra-tokens]
