### PR TITLE
Fixes for tests/5.0/target_update/*_discontiguous.c tests

### DIFF
--- a/tests/5.0/target_update/test_target_update_from_discontiguous.c
+++ b/tests/5.0/target_update/test_target_update_from_discontiguous.c
@@ -32,7 +32,7 @@ int target_update_from_discontiguous() {
     }//end target
 
 
-    #pragma omp target update from(result[0:N:2])
+    #pragma omp target update from(result[0:N/2:2])
 
   }
 

--- a/tests/5.0/target_update/test_target_update_mapper_from_discontiguous.c
+++ b/tests/5.0/target_update/test_target_update_mapper_from_discontiguous.c
@@ -48,7 +48,7 @@ int target_update_from_mapper() {
       s.data[i] += i ;
     }
   
-  #pragma omp target update from(s.data[0:s.len:2]) //only update even array elements
+  #pragma omp target update from(s.data[0:s.len/2:2]) //only update even array elements
   } 
   
 

--- a/tests/5.0/target_update/test_target_update_mapper_to_discontiguous.c
+++ b/tests/5.0/target_update/test_target_update_mapper_to_discontiguous.c
@@ -23,7 +23,7 @@ typedef struct newvec {
 } newvec_t;
 
 size_t i;
-int errors;
+int errors = 0;
 
 #pragma omp declare mapper(newvec_t v) map(v, v.data[0:v.len])
 
@@ -32,7 +32,6 @@ int target_update_to_mapper() {
   OMPVV_TEST_OFFLOADING;
 
   newvec_t s;
-  int errors;
 
   s.data = (double *)calloc(N,sizeof(double));
   s.len = N;
@@ -44,7 +43,7 @@ int target_update_to_mapper() {
     }
     // update even array position values from host
     // This should set them to i  
-    #pragma omp target update to(s.data[0:s.len:2])
+    #pragma omp target update to(s.data[0:s.len/2:2])
 
     //update array on the device
     #pragma omp target 

--- a/tests/5.0/target_update/test_target_update_to_discontiguous.c
+++ b/tests/5.0/target_update/test_target_update_to_discontiguous.c
@@ -28,7 +28,7 @@ int target_update_to_discontiguous() {
       result[i] += i;
     }
 
-    #pragma omp target update to(result[0:N:2])
+    #pragma omp target update to(result[0:N/2:2])
 
     #pragma omp target map(alloc: result[0:N]) 
     {


### PR DESCRIPTION
This patch fixes two problems with the OpenMP 5.0 discontiguous 'target update' tests: firstly, the length in an array section specifier does not mean that "base+length" describes the exclusive upper limit for the elements to be transferred when the stride is not one, but rather it is the *number of elements* to be transferred.  (This is different in Fortran, where the array syntax is (lower bound:upper bound:stride) instead, and no elements beyond the upper bound will be accessed.)

That means that several tests contain buffer overruns, as they use e.g. [0:N:2] for an array section specifier for an array of size N -- such an array section describes elements at indices 0, 2, 4, [...], 2*(N-1), which was clearly not the intention.

The patch also fixes an uninitialised 'error' count variable in test_target_update_mapper_to_discontiguous.c.

(I've been working on discontiguous OpenMP "target update" support in GCC, and came across these problems during testing.)