### PR TITLE
New test for omp_get_max_teams()

### DIFF
--- a/tests/5.1/teams/test_target_get_max_teams.c
+++ b/tests/5.1/teams/test_target_get_max_teams.c
@@ -1,56 +1,59 @@
-//===--------------------- test_target_get_max_teams.c ----------------------===//
-//
+//--------------- test_target_get_max_teams.c --------------------------------//
 // OpenMP API Version 5.1 Nov 2020
-//
-// This test uses the omp_get_max_teams routine to check what the max teams 
-// capacity is for this device. It should return the total amount of teams
-// that could be allocated to a specific teams region
-//
-//===------------------------------------------------------------------------===//
-
-#include <omp.h>
-#include <stdio.h>
-#include <stdlib.h>
+// ***************************
+// ROUTINE: omp_get_max_teams
+// ***************************
+// This test uses the omp_get_max_teams routine to check what the max teams
+// capacity is for the current device. If the routine returns 0, the nteams-var
+// ICV is 0, thus it is not treated as an upper bound and the behavior of the
+// program is implementation defined. If the routine were to return a negative
+// integer, the same behavior applies. If the routine returns a positive
+// integer, the value of the ICV is treated as an upperbound. If the value is a
+// number greater than the maximum capacity which an implementation supports,
+// than the test will pass as the number of teams is less than that value, but
+// the value itself has no functional purpose. The ICV is initialized to 0 per
+// device. Thus, if omp_get_num_teams returns a positive number as
+// expected, the test will pass when the ICV value is 0 or less than 0. In the
+// case where the OMP_NUM_TEAMS environmental variable is set to a positive
+// integer, or the omp_set_num_teams routine is given a positive integer as an
+// argument, the test will pass if and only if the omp_get_num_teams routine
+// returns an integer that is less than or equal to the positive ICV value.
+//----------------------------------------------------------------------------//
 #include "ompvv.h"
+#include <omp.h>
 
-#define N 1024
+int test_get_max_teams(int offload) {
+  int errors = 0;
+  int max_teams = omp_get_max_teams(); // on host
+  int num_teams = 0; // a value that is not possible for omp_get_num_teams()
+
+  // clang-format off
+  #pragma omp target map(tofrom : num_teams) if(offload)
+  {
+    #pragma omp teams 
+    {
+      num_teams = omp_get_num_teams();
+    }
+  }
+  // clang-format on
+
+  OMPVV_ERROR_IF(
+      max_teams <= 0 && num_teams <= 0,
+      "Number of teams reported is non-positive, should not be possible");
+  OMPVV_ERROR_IF(
+      max_teams > 0 && num_teams > max_teams,
+      "Number of teams reported exceeded max number of teams (max no. > 0)");
+  OMPVV_TEST_AND_SET(errors, max_teams <= 0 && num_teams <= 0);
+  OMPVV_TEST_AND_SET(errors, max_teams > 0 && num_teams > max_teams);
+
+  return errors;
+}
 
 int main() {
-
-        OMPVV_TEST_OFFLOADING;
-
-        int errors = 0;
-        int MAX_TEAMS = omp_get_max_teams(); //on host
-        int num_teams = MAX_TEAMS + 1; //a value that is not possible
-        printf("max on host:%d\n",MAX_TEAMS);
-        #pragma omp teams
-        {
-                if (omp_get_team_num() == 0) {
-                        num_teams = omp_get_num_teams();
-                }
-        }       
-
-        OMPVV_ERROR_IF(MAX_TEAMS > 0 && num_teams > MAX_TEAMS, "Number of teams reported on host exceeded max number of teams (max no. > 0)");
-        OMPVV_ERROR_IF(num_teams <= 0, "Number of teams reported on host is 0 or negative");
-        OMPVV_TEST_AND_SET(errors, num_teams > MAX_TEAMS);
-        OMPVV_TEST_AND_SET(errors, num_teams <= 0);
-        
-        #pragma omp target map(tofrom:num_teams)
-        {
-           MAX_TEAMS = omp_get_max_teams(); //first-private
-          #pragma omp teams 
-          {
-             if (omp_get_team_num() == 0) {
-               printf("max on target:%d\n",MAX_TEAMS);
-               num_teams = MAX_TEAMS + 1; //a value that is not possible
-               num_teams = omp_get_num_teams();
-             }  
-          }
-        }
-        OMPVV_ERROR_IF(MAX_TEAMS > 0 && num_teams > MAX_TEAMS, "Number of teams reported on device exceeded max number of teams (max no. > 0)");
-        OMPVV_ERROR_IF(num_teams <= 0, "Number of teams reported on device is 0 or negative");
-        OMPVV_TEST_AND_SET(errors, num_teams > MAX_TEAMS);
-        OMPVV_TEST_AND_SET(errors, num_teams <= 0);
-
-        OMPVV_REPORT_AND_RETURN(errors);
+  int errors = 0;
+  OMPVV_TEST_AND_SET(errors, test_get_max_teams(0) != 0);
+  OMPVV_TEST_OFFLOADING;
+  OMPVV_TEST_AND_SET(errors, test_get_max_teams(1) != 0);
+  OMPVV_REPORT_AND_RETURN(errors);
+  return errors;
 }

--- a/tests/5.1/teams/test_target_get_max_teams.c
+++ b/tests/5.1/teams/test_target_get_max_teams.c
@@ -1,18 +1,19 @@
 //--------------- test_target_get_max_teams.c --------------------------------//
 // OpenMP API Version 5.1 Nov 2020
+// Pg. 669, line 29
 // ***************************
 // ROUTINE: omp_get_max_teams
 // ***************************
 // This test uses the omp_get_max_teams routine to check what the max teams
-// capacity is for the current device. If the routine returns 0, the nteams-var
-// ICV is 0, thus it is not treated as an upper bound and the behavior of the
-// program is implementation defined. If the routine were to return a negative
-// integer, the same behavior applies. If the routine returns a positive
-// integer, the value of the ICV is treated as an upperbound. If the value is a
-// number greater than the maximum capacity which an implementation supports,
-// than the test will pass as the number of teams is less than that value, but
-// the value itself has no functional purpose. The ICV is initialized to 0 per
-// device. Thus, if omp_get_num_teams returns a positive number as
+// capacity is for host and the current device. If the routine returns 0, the
+// nteams-var ICV is 0, thus it is not treated as an upper bound and the
+// behavior of the program is implementation defined. If the routine were to
+// return a negative integer, the same behavior applies. If the routine returns
+// a positive integer, the value of the ICV is treated as an upperbound. If the
+// value is a number greater than the maximum capacity that the implementation
+// supports, then the test will pass if the number of teams is less than that
+// value, but the value itself has no functional purpose. The ICV is initialized
+// to 0 per device. Thus, if omp_get_num_teams returns a positive number as
 // expected, the test will pass when the ICV value is 0 or less than 0. In the
 // case where the OMP_NUM_TEAMS environmental variable is set to a positive
 // integer, or the omp_set_num_teams routine is given a positive integer as an
@@ -27,7 +28,6 @@ int test_get_max_teams(int offload) {
   int max_teams = omp_get_max_teams(); // on host
   int num_teams = 0; // a value that is not possible for omp_get_num_teams()
 
-  // clang-format off
   #pragma omp target map(tofrom : num_teams) if(offload)
   {
     #pragma omp teams 
@@ -35,15 +35,10 @@ int test_get_max_teams(int offload) {
       num_teams = omp_get_num_teams();
     }
   }
-  // clang-format on
 
-  OMPVV_ERROR_IF(
-      max_teams <= 0 && num_teams <= 0,
-      "Number of teams reported is non-positive, should not be possible");
   OMPVV_ERROR_IF(
       max_teams > 0 && num_teams > max_teams,
       "Number of teams reported exceeded max number of teams (max no. > 0)");
-  OMPVV_TEST_AND_SET(errors, max_teams <= 0 && num_teams <= 0);
   OMPVV_TEST_AND_SET(errors, max_teams > 0 && num_teams > max_teams);
 
   return errors;

--- a/tests/5.1/teams/test_target_get_max_teams.c
+++ b/tests/5.1/teams/test_target_get_max_teams.c
@@ -47,8 +47,10 @@ int test_get_max_teams(int offload) {
 int main() {
   int errors = 0;
   OMPVV_TEST_AND_SET(errors, test_get_max_teams(0) != 0);
+  OMPVV_REPORT(errors);
   OMPVV_TEST_OFFLOADING;
   OMPVV_TEST_AND_SET(errors, test_get_max_teams(1) != 0);
-  OMPVV_REPORT_AND_RETURN(errors);
+  OMPVV_REPORT(errors);
+  OMPVV_RETURN(errors);
   return errors;
 }

--- a/tests/5.1/teams/test_target_get_max_teams.c
+++ b/tests/5.1/teams/test_target_get_max_teams.c
@@ -33,7 +33,7 @@ int test_get_max_teams(int offload) {
   {
     max_teams = omp_get_max_teams();
   }
-  #pragma omp target map(tofrom : max_teams, num_teams) if(offload)
+  #pragma omp target map(tofrom : num_teams) if(offload)
   {
     #pragma omp teams 
     {

--- a/tests/5.1/teams/test_target_get_max_teams.c
+++ b/tests/5.1/teams/test_target_get_max_teams.c
@@ -4,32 +4,34 @@
 // ***************************
 // ROUTINE: omp_get_max_teams
 // ***************************
-// This test uses the omp_get_max_teams routine to check what the max teams
-// capacity is for host and the current device. If the routine returns 0, the
-// nteams-var ICV is 0, thus it is not treated as an upper bound and the
-// behavior of the program is implementation defined. If the routine were to
-// return a negative integer, the same behavior applies. If the routine returns
-// a positive integer, the value of the ICV is treated as an upperbound. If the
-// value is a number greater than the maximum capacity that the implementation
-// supports, then the test will pass if the number of teams is less than that
-// value, but the value itself has no functional purpose. The ICV is initialized
-// to 0 per device. Thus, if omp_get_num_teams returns a positive number as
-// expected, the test will pass when the ICV value is 0 or less than 0. In the
-// case where the OMP_NUM_TEAMS environmental variable is set to a positive
-// integer, or the omp_set_num_teams routine is given a positive integer as an
-// argument, the test will pass if and only if the omp_get_num_teams routine
-// returns an integer that is less than or equal to the positive ICV value.
+// This test uses the omp_get_max_teams routine on the host and device (if
+// available) to check what the max teams capacity is for host and the current
+// device. If the routine returns 0, the nteams-var ICV is 0, thus it is not
+// treated as an upper bound and the behavior of the program is implementation
+// defined. If the routine were to return a negative integer, the same behavior
+// applies. If the routine returns a positive integer, the value of the ICV is
+// treated as an upperbound. If the value is a number greater than the maximum
+// capacity that the implementation supports, then the test will pass if the
+// number of teams is less than that value, but the value itself has no
+// functional purpose. The ICV is initialized to 0 per device. Thus, if
+// omp_get_num_teams returns a positive number as expected, the test will pass
+// when the ICV value is 0 or less than 0. In the case where the OMP_NUM_TEAMS
+// environmental variable is set to a positive integer, or the omp_set_num_teams
+// routine is given a positive integer as an argument, the test will pass if and
+// only if the omp_get_num_teams routine returns an integer that is less than or
+// equal to the positive ICV value.
 //----------------------------------------------------------------------------//
 #include "ompvv.h"
 #include <omp.h>
 
 int test_get_max_teams(int offload) {
   int errors = 0;
-  int max_teams = omp_get_max_teams(); // on host
+  int max_teams;
   int num_teams = 0; // a value that is not possible for omp_get_num_teams()
 
-  #pragma omp target map(tofrom : num_teams) if(offload)
+  #pragma omp target map(tofrom : max_teams, num_teams) if(offload)
   {
+    max_teams = omp_get_max_teams();
     #pragma omp teams 
     {
       num_teams = omp_get_num_teams();

--- a/tests/5.1/teams/test_target_get_max_teams.c
+++ b/tests/5.1/teams/test_target_get_max_teams.c
@@ -29,9 +29,12 @@ int test_get_max_teams(int offload) {
   int max_teams;
   int num_teams = 0; // a value that is not possible for omp_get_num_teams()
 
-  #pragma omp target map(tofrom : max_teams, num_teams) if(offload)
+  #pragma omp target map(tofrom: max_teams) if(offload)
   {
     max_teams = omp_get_max_teams();
+  }
+  #pragma omp target map(tofrom : max_teams, num_teams) if(offload)
+  {
     #pragma omp teams 
     {
       if (omp_get_team_num() == 0)

--- a/tests/5.1/teams/test_target_get_max_teams.c
+++ b/tests/5.1/teams/test_target_get_max_teams.c
@@ -17,24 +17,40 @@
 
 int main() {
 
-	OMPVV_TEST_OFFLOADING;
+        OMPVV_TEST_OFFLOADING;
 
-	int errors = 0; 
-	int MAX_TEAMS = omp_get_max_teams();
-	int num_teams = MAX_TEAMS + 1; //a value that is not possible
+        int errors = 0;
+        int MAX_TEAMS = omp_get_max_teams(); //on host
+        int num_teams = MAX_TEAMS + 1; //a value that is not possible
+        printf("max on host:%d\n",MAX_TEAMS);
+        #pragma omp teams
+        {
+                if (omp_get_team_num() == 0) {
+                        num_teams = omp_get_num_teams();
+                }
+        }       
 
-	#pragma omp target teams map(tofrom: num_teams)
-	{
-		if (omp_get_team_num() == 0) {
-			num_teams = omp_get_num_teams();
-		}
-	}               
+        OMPVV_ERROR_IF(MAX_TEAMS > 0 && num_teams > MAX_TEAMS, "Number of teams reported on host exceeded max number of teams (max no. > 0)");
+        OMPVV_ERROR_IF(num_teams <= 0, "Number of teams reported on host is 0 or negative");
+        OMPVV_TEST_AND_SET(errors, num_teams > MAX_TEAMS);
+        OMPVV_TEST_AND_SET(errors, num_teams <= 0);
+        
+        #pragma omp target map(tofrom:num_teams)
+        {
+           MAX_TEAMS = omp_get_max_teams(); //first-private
+          #pragma omp teams 
+          {
+             if (omp_get_team_num() == 0) {
+               printf("max on target:%d\n",MAX_TEAMS);
+               num_teams = MAX_TEAMS + 1; //a value that is not possible
+               num_teams = omp_get_num_teams();
+             }  
+          }
+        }
+        OMPVV_ERROR_IF(MAX_TEAMS > 0 && num_teams > MAX_TEAMS, "Number of teams reported on device exceeded max number of teams (max no. > 0)");
+        OMPVV_ERROR_IF(num_teams <= 0, "Number of teams reported on device is 0 or negative");
+        OMPVV_TEST_AND_SET(errors, num_teams > MAX_TEAMS);
+        OMPVV_TEST_AND_SET(errors, num_teams <= 0);
 
-        OMPVV_ERROR_IF(MAX_TEAMS > 0 && num_teams > MAX_TEAMS, "Number of teams reported exceeded max number of teams (max no. > 0)");
-	OMPVV_ERROR_IF(num_teams < 0, "Number of teams is negative");
-	
-	OMPVV_TEST_AND_SET(errors, num_teams < 0);
-	OMPVV_TEST_AND_SET(errors, num_teams > MAX_TEAMS);
-
-	OMPVV_REPORT_AND_RETURN(errors);
+        OMPVV_REPORT_AND_RETURN(errors);
 }

--- a/tests/5.1/teams/test_target_get_max_teams.c
+++ b/tests/5.1/teams/test_target_get_max_teams.c
@@ -1,0 +1,39 @@
+//===--------------------- test_target_get_max_teams.c ----------------------===//
+//
+// OpenMP API Version 5.1 Nov 2020
+//
+// This test uses the omp_get_max_teams routine to check what the max teams 
+// capacity is for this device. It should return the total amount of teams
+// that could be allocated to a specific teams region
+//
+//===------------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+int main() {
+
+	OMPVV_TEST_OFFLOADING;
+
+	int errors = 0; 
+	int num_teams = 0;
+	int MAX_TEAMS = omp_get_max_teams();
+
+	#pragma omp target teams map(tofrom: num_teams, MAX_TEAMS)
+	{
+		if (omp_get_team_num() == 0) {
+			num_teams = omp_get_num_teams();
+		}
+	}               
+
+	printf("%d %d %d\n", num_teams, MAX_TEAMS, OMPVV_NUM_TEAMS_DEVICE);
+
+	OMPVV_ERROR_IF(num_teams != MAX_TEAMS, "Number of teams reported was not the max amount of teams");
+	OMPVV_TEST_AND_SET(errors, num_teams != MAX_TEAMS);
+
+	OMPVV_REPORT_AND_RETURN(errors);
+}

--- a/tests/5.1/teams/test_target_get_max_teams.c
+++ b/tests/5.1/teams/test_target_get_max_teams.c
@@ -20,20 +20,21 @@ int main() {
 	OMPVV_TEST_OFFLOADING;
 
 	int errors = 0; 
-	int num_teams = 0;
 	int MAX_TEAMS = omp_get_max_teams();
+	int num_teams = MAX_TEAMS + 1; //a value that is not possible
 
-	#pragma omp target teams map(tofrom: num_teams, MAX_TEAMS)
+	#pragma omp target teams map(tofrom: num_teams)
 	{
 		if (omp_get_team_num() == 0) {
 			num_teams = omp_get_num_teams();
 		}
 	}               
 
-	printf("%d %d %d\n", num_teams, MAX_TEAMS, OMPVV_NUM_TEAMS_DEVICE);
-
-	OMPVV_ERROR_IF(num_teams != MAX_TEAMS, "Number of teams reported was not the max amount of teams");
-	OMPVV_TEST_AND_SET(errors, num_teams != MAX_TEAMS);
+        OMPVV_ERROR_IF(MAX_TEAMS > 0 && num_teams > MAX_TEAMS, "Number of teams reported exceeded max number of teams (max no. > 0)");
+	OMPVV_ERROR_IF(num_teams < 0, "Number of teams is negative");
+	
+	OMPVV_TEST_AND_SET(errors, num_teams < 0);
+	OMPVV_TEST_AND_SET(errors, num_teams > MAX_TEAMS);
 
 	OMPVV_REPORT_AND_RETURN(errors);
 }

--- a/tests/5.1/teams/test_target_get_max_teams.c
+++ b/tests/5.1/teams/test_target_get_max_teams.c
@@ -34,7 +34,8 @@ int test_get_max_teams(int offload) {
     max_teams = omp_get_max_teams();
     #pragma omp teams 
     {
-      num_teams = omp_get_num_teams();
+      if (omp_get_team_num() == 0)
+        num_teams = omp_get_num_teams();
     }
   }
 


### PR DESCRIPTION
PLEASE REFER TO CLOSED PR729 FOR RELEVANT DISCUSSION COMMENTS
frontier
clang 18.0.0
ld.lld: error: undefined symbol: omp_get_max_teams
|>>> referenced by /tmp/test_target_get_max_teams.c.o.amdgcn-amd-amdhsa.gfx90a-b5ea00.o:(__omp_offloading_72_118bc122_test_get_max_teams_l32)
|>>> referenced by /tmp/test_target_get_max_teams.c.o.amdgcn-amd-amdhsa.gfx90a-b5ea00.o:(__omp_offloading_72_118bc122_test_get_max_teams_l32)
clang: error: ld.lld command failed with exit code 1 (use -v to see invocation)
/sw/frontier/ums/ums012/llvm/18.0.0-20230828/bin/clang-linker-wrapper: error: 'clang' failed
clang: error: linker command failed with exit code 1 (use -v to see invocation)
summit
gcc 13.2.1
PASS
nvc 22.11
line 61: warning: statement is unreachable [code_is_unreachable]
    return errors;
Remark: individual warnings can be suppressed with "--diag_suppress <warning-name>"
NVC++-S-1073-Procedures called in a OpenMP target region must have 'omp declare target' information - omp_get_max_teams (/autofs/nccs-svm1_home1/andrewka/sollve_vv/tests/5.1/teams/test_target_get_max_teams.c: 34)
NVC++/power Linux 22.11-0: compilation completed with severe errors