### PR TITLE
test_metadirective_target_device_num.c: Add missing 'target' to #pragma omp

### DIFF
--- a/tests/5.1/metadirective/test_metadirective_target_device_num.c
+++ b/tests/5.1/metadirective/test_metadirective_target_device_num.c
@@ -23,11 +23,11 @@ int test_metadirective_target_device() {
    }
    int dev = omp_get_default_device();
 
-   #pragma omp enter data map(alloc: A)
+   #pragma omp target enter data map(alloc: A)
 
    // Expect that device_num is 0, so the array should be mapped back.
    #pragma omp metadirective \
-      when( target_device={device_num(dev)}: target defaultmap(none) map(tofrom: A)) \
+      when( target_device={device_num(dev)}: target defaultmap(none) map(always,tofrom: A)) \
       default( target defaultmap(none) map(to: A))
       for(int i = 0; i < N; i++){
          A[i] = i;


### PR DESCRIPTION
The first pragma lacked a `target` in `#pragma omp enter data`; however, adding one will enable the 'alloc' mapping of A such that the `map(tofrom` will not copy back data. Hence, an additional 'always' modifier then becomes required.

_(An alternative would be to remove the 'omp enter data' and the pointless* but valid 'omp target exit data'. [* – it is only pointless "as is" or without 'omp enter data' line; with 'omp **target** enter data', it will do what it should do: unmap the 'target enter data' mapping.])_


@spophale @nolanbaker31 @seyonglee @fel-cab — Please review.

_This is a rather obvious fix, which, here, showed up as error as I compile with -Werror=unknown-pragmas._