### PR TITLE
Fix metadirective_arch_*.F90: var init; condition

### DIFF
--- a/tests/5.0/metadirective/test_metadirective_arch_is_nvidia.F90
+++ b/tests/5.0/metadirective/test_metadirective_arch_is_nvidia.F90
@@ -43,7 +43,7 @@ CONTAINS
     !$omp atomic write
        target_device_num = omp_get_device_num()
     !$omp end atomic
-       v3(i) = v1(i) * v2(2)
+       v3(i) = v1(i) * v2(i)
     END DO
     !$omp end metadirective
     !$omp end target

--- a/tests/5.0/metadirective/test_metadirective_arch_is_nvidia.F90
+++ b/tests/5.0/metadirective/test_metadirective_arch_is_nvidia.F90
@@ -16,6 +16,8 @@ PROGRAM test_metadirective_arch_is_nvidia
   USE omp_lib
   implicit none
 
+  OMPVV_TEST_OFFLOADING
+
   OMPVV_TEST_VERBOSE(test_metadirective1() .NE. 0)
 
   OMPVV_REPORT_AND_RETURN()

--- a/tests/5.0/metadirective/test_metadirective_arch_nvidia_or_amd.F90
+++ b/tests/5.0/metadirective/test_metadirective_arch_nvidia_or_amd.F90
@@ -53,8 +53,8 @@ CONTAINS
        device_num = device_num + 1
     END DO
 
-    OMPVV_TEST_AND_SET_VERBOSE(errors, .NOT. initial_device)
-    OMPVV_ERROR_IF(.NOT. initial_device, "NVIDIA and AMD architecture not available, ran on host")
+    OMPVV_TEST_AND_SET_VERBOSE(errors, initial_device)
+    OMPVV_ERROR_IF(initial_device, "NVIDIA and AMD architecture not available, ran on host")
 
     DO i = 1, N
        OMPVV_TEST_AND_SET_VERBOSE(errors, a(i) .NE. i)


### PR DESCRIPTION
* tests/5.0/metadirective/test_metadirective_arch_is_nvidia.F90: Fix index for on-device initialization.
* tests/5.0/metadirective/test_metadirective_arch_nvidia_or_amd.F90: Fix condition: it was reverse.

@spophale @nolanbaker31 @seyonglee @fel-cab — Please review.
* * *
_With error checking macros including C's `assert`, I always confused whether the positive or negative condition should be used. Seemingly, I am not alone. When I add a `print *, 'initial_device', initial_device` after the big WHILE loop, I get (w/o the patch):_
```
 initial_device F
[OMPVV_ERROR test_metadirective_arch_nvidia_or_amd.F90:57]  Condition  .NOT. initial_device failed
[OMPVV_ERROR test_metadirective_arch_nvidia_or_amd.F90:58] NVIDIA and AMD architecture not available, ran on host
```