### PR TITLE
test_target_memcpy_rect_async_{dep,no_}obj.F90: null ptr, fix idx calc

### DIFF
--- a/tests/5.1/target/test_target_memcpy_rect_async_depobj.F90
+++ b/tests/5.1/target/test_target_memcpy_rect_async_depobj.F90
@@ -82,6 +82,7 @@ CONTAINS
         fptr((i-1)*M+j) = fptr((i-1)*M+j) * 2 ! initialize data
       END DO
     END DO
+    fptr => null()
     !$omp end target
 
     ! copy to host memory

--- a/tests/5.1/target/test_target_memcpy_rect_async_depobj.F90
+++ b/tests/5.1/target/test_target_memcpy_rect_async_depobj.F90
@@ -39,6 +39,7 @@ CONTAINS
     INTEGER (omp_depend_kind) :: obj, obj_arr(1)
 
     errors = 0
+    fptr => null()
     h = omp_get_initial_device()
     t = omp_get_default_device()
     volume = (/ M, N /)
@@ -75,10 +76,10 @@ CONTAINS
 
     !$omp taskwait depend(depobj: obj)
     !$omp target is_device_ptr(devRect) device(t) depend(depobj: obj)
+    CALL c_f_pointer(devRect, fptr, [M*N])
     DO i=1, N
       DO j=1, M
-        CALL c_f_pointer(devRect, fptr, [M*N])
-        fptr(i*M+j) = fptr(i*M+j) * 2 ! initialize data
+        fptr((i-1)*M+j) = fptr((i-1)*M+j) * 2 ! initialize data
       END DO
     END DO
     !$omp end target

--- a/tests/5.1/target/test_target_memcpy_rect_async_no_obj.F90
+++ b/tests/5.1/target/test_target_memcpy_rect_async_no_obj.F90
@@ -38,6 +38,7 @@ CONTAINS
     DOUBLE PRECISION, TARGET :: hostRect(M,N)
 
     errors = 0
+    fptr => null()
     h = omp_get_initial_device()
     t = omp_get_default_device()
     volume = (/ M, N /)
@@ -66,10 +67,10 @@ CONTAINS
 
     !$omp taskwait
     !$omp target is_device_ptr(devRect) device(t)
+    CALL c_f_pointer(devRect, fptr, [M*N])
     DO i=1, N
       DO j=1, M
-        CALL c_f_pointer(devRect, fptr, [M*N])
-        fptr(i*M+j) = fptr(i*M+j) * 2 ! initialize data
+        fptr((i-1)*M+j) = fptr((i-1)*M+j) * 2 ! initialize data
       END DO
     END DO
     !$omp end target

--- a/tests/5.1/target/test_target_memcpy_rect_async_no_obj.F90
+++ b/tests/5.1/target/test_target_memcpy_rect_async_no_obj.F90
@@ -73,6 +73,7 @@ CONTAINS
         fptr((i-1)*M+j) = fptr((i-1)*M+j) * 2 ! initialize data
       END DO
     END DO
+    fptr => null()
     !$omp end target
 
     ! copy to host memory


### PR DESCRIPTION
As pointer targets get automatically copied, 'fptr' either needs to be disassociated (nullified) before mapping - or it could be defined inside the target region (with 'block, ... end block').

Additionally there was an off-by-one issue with the pointer indices; an alternative would be a two-dimensional array and using that shape in 'c_f_pointer' call - and such leaving the calculation to the compiler.

@seyonglee @fel-cab @spophale – please review