### PR TITLE
Minor fixes: typos, zero-sized VLA, memory leaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -438,7 +438,7 @@ report_html: $(RESULTS_JSON_OUTPUT_FILE) $(RESULTS_CSV_OUTPUT_FILE)
 	@echo " === REPORT DONE === "
 
 ifdef REPORT_ONLINE_TAG
-  # Check if the lenght is appropriate
+  # Check if the length is appropriate
   ifneq ("$(shell echo ${REPORT_ONLINE_TAG} | wc -m | grep -oh '[0-9]\+')", "10")
     $(error "REPORT_ONLINE_TAG is a 9 digit hex value. Not 9 digits")
   endif
@@ -449,7 +449,7 @@ ifdef REPORT_ONLINE_TAG
 endif
 
 ifdef REPORT_ONLINE_APPEND
-  # Check if the lenght is appropriate
+  # Check if the length is appropriate
   ifndef REPORT_ONLINE_TAG
     $(error "In order to append to an online report, it is necessary to have an REPORT_ONLINE_TAG")
   endif

--- a/tests/4.5/target_data/test_target_data_if.F90
+++ b/tests/4.5/target_data/test_target_data_if.F90
@@ -38,7 +38,7 @@
 
          OMPVV_TEST_AND_SET_OFFLOADING(isOffloading)
          IF (.NOT. isOffloading) THEN 
-           WRITE(infoMessage, *) "Offloading is off. Mighth not be&
+           WRITE(infoMessage, *) "Offloading is off. Might not be&
            & possible to test if clause correctly "
            OMPVV_WARNING(infoMessage)
          END IF

--- a/tests/4.5/target_data/test_target_data_map_devices.c
+++ b/tests/4.5/target_data/test_target_data_map_devices.c
@@ -32,7 +32,8 @@ int test_map_set_default_dev() {
   OMPVV_INFOMSG("initial device: %d", omp_get_initial_device());
   OMPVV_INFOMSG("default device: %d", def_dev);
 
-  int sum[num_dev], errors = 0;
+  // Allocate num_devices + 1 to avoid zero-sized VLA if num_devices == 0
+  int sum[num_dev+1], errors = 0;
   int* h_matrix = (int*) malloc(num_dev * N * sizeof(int));
 
   for (int dev = 0; dev < num_dev; ++dev) {
@@ -73,7 +74,8 @@ int test_map_device() {
   OMPVV_INFOMSG("initial device: %d", omp_get_initial_device());
   OMPVV_INFOMSG("default device: %d", omp_get_default_device());
 
-  int sum[num_dev], errors = 0;
+  // Allocate num_devices + 1 to avoid zero-sized VLA if num_devices == 0
+  int sum[num_dev+1], errors = 0;
   int* h_matrix = (int*) malloc(num_dev * N * sizeof(int));
 
   for (int dev = 0; dev < num_dev; ++dev) {

--- a/tests/4.5/target_data/test_target_data_map_pointer_translation.c
+++ b/tests/4.5/target_data/test_target_data_map_pointer_translation.c
@@ -6,7 +6,7 @@
 // and the pointer points to a host array that is already available in the device,
 // this pointer's address has to be updated with the device address. 
 //
-// See page 105, lines 24 throuhg 32. 
+// See page 105, lines 24 through 32.
 //
 // This test check these conditions are valid
 //
@@ -49,7 +49,7 @@ int test_map_same_function() {
       }
     } // end target
 
-    OMPVV_INFOMSG("map(ptr) specified zero-lenght array section")
+    OMPVV_INFOMSG("map(ptr) specified zero-length array section")
 #pragma omp target map(ptr_h_array_h[:0], ptr_h_array_s[:0])
     {
       for (int i = 0; i < N; ++i) {
@@ -82,7 +82,7 @@ int test_map_same_function() {
 
 void helper_function(int *ptr_h_array_h, int *ptr_h_array_s) {
 
-    OMPVV_INFOMSG("map(ptr) specified full-lenght array section")
+    OMPVV_INFOMSG("map(ptr) specified full-length array section")
 #pragma omp target map(ptr_h_array_h[0:N], ptr_h_array_s[0:N])
     {
       for (int i = 0; i < N; ++i) {
@@ -91,7 +91,7 @@ void helper_function(int *ptr_h_array_h, int *ptr_h_array_s) {
       }
     } // end target
 
-    OMPVV_INFOMSG("map(ptr) specified zero-lenght array section")
+    OMPVV_INFOMSG("map(ptr) specified zero-length array section")
 #pragma omp target map(ptr_h_array_h[:0], ptr_h_array_s[:0])
     {
       for (int i = 0; i < N; ++i) {

--- a/tests/4.5/target_enter_data/test_target_enter_data_devices.c
+++ b/tests/4.5/target_enter_data/test_target_enter_data_devices.c
@@ -31,13 +31,14 @@ int test_set_default_dev() {
   OMPVV_INFOMSG("initial device: %d", omp_get_initial_device());
   OMPVV_INFOMSG("default device: %d", def_dev);
 
-  int sum[num_dev], errors = 0, isHost[num_dev];
-  int h_matrix[num_dev][N], h_matrix_copy[num_dev][N];
+  // Allocate num_devices + 1 to avoid zero-sized VLA if num_devices == 0
+  int sum[num_dev+1], errors = 0, isHost[num_dev+1];
+  int h_matrix[num_dev+1][N], h_matrix_copy[num_dev+1][N];
 
   // Initialize all the matrices
   for (int dev = 0; dev < num_dev; ++dev) {
     sum[dev] = 0;
-    isHost[num_dev] = 0;
+    isHost[dev] = 0;
   }
 
   for (int dev = 0; dev < num_dev; ++dev) {
@@ -94,13 +95,14 @@ int test_device() {
   OMPVV_INFOMSG("initial device: %d", omp_get_initial_device());
   OMPVV_INFOMSG("default device: %d", omp_get_default_device());
 
-  int sum[num_dev], errors = 0, isHost[num_dev];
-  int h_matrix[num_dev][N], h_matrix_copy[num_dev][N];
+  // Allocate num_devices + 1 to avoid zero-sized VLA if num_devices == 0
+  int sum[num_dev+1], errors = 0, isHost[num_dev+1];
+  int h_matrix[num_dev+1][N], h_matrix_copy[num_dev+1][N];
 
   // Initialize all the matrices
   for (int dev = 0; dev < num_dev; ++dev) {
     sum[dev] = 0;
-    isHost[num_dev] = 0;
+    isHost[dev] = 0;
   }
   for (int dev = 0; dev < num_dev; ++dev) {
     // unstructured mapping

--- a/tests/4.5/target_enter_data/test_target_enter_data_if.F90
+++ b/tests/4.5/target_enter_data/test_target_enter_data_if.F90
@@ -45,7 +45,7 @@
            OMPVV_REPORT_AND_RETURN()
          END IF
          IF (.NOT. isOffloading) THEN 
-           WRITE(infoMessage, *) "Offloading is off. Mighth not be&
+           WRITE(infoMessage, *) "Offloading is off. Might not be&
            & possible to test if clause correctly "
            OMPVV_WARNING(infoMessage)
           OMPVV_REPORT_AND_RETURN()

--- a/tests/4.5/target_enter_exit_data/test_target_enter_exit_data_devices.c
+++ b/tests/4.5/target_enter_exit_data/test_target_enter_exit_data_devices.c
@@ -34,8 +34,9 @@ int test_set_default_dev() {
   OMPVV_INFOMSG("initial device: %d", omp_get_initial_device());
   OMPVV_INFOMSG("default device: %d", def_dev);
 
-  int sum[num_dev], errors = 0;
-  int h_matrix[num_dev][N];
+  // Allocate num_devices + 1 to avoid zero-sized VLA if num_devices == 0
+  int sum[num_dev+1], errors = 0;
+  int h_matrix[num_dev+1][N];
 
   for (int dev = 0; dev < num_dev; ++dev) {
     omp_set_default_device(dev);
@@ -77,8 +78,9 @@ int test_device() {
   OMPVV_INFOMSG("initial device: %d", omp_get_initial_device());
   OMPVV_INFOMSG("default device: %d", omp_get_default_device());
 
-  int sum[num_dev], errors = 0;
-  int h_matrix[num_dev][N];
+  // Allocate num_devices + 1 to avoid zero-sized VLA if num_devices == 0
+  int sum[num_dev+1], errors = 0;
+  int h_matrix[num_dev+1][N];
 
   for (int dev = 0; dev < num_dev; ++dev) {
 

--- a/tests/4.5/target_enter_exit_data/test_target_enter_exit_data_if.F90
+++ b/tests/4.5/target_enter_exit_data/test_target_enter_exit_data_if.F90
@@ -35,7 +35,7 @@
            OMPVV_REPORT_AND_RETURN()
          END IF
          IF (.NOT. isOffloading) THEN 
-           WRITE(infoMessage, *) "Offloading is off. Mighth not be&
+           WRITE(infoMessage, *) "Offloading is off. Might not be&
            & possible to test if clause correctly "
            OMPVV_WARNING(infoMessage)
           OMPVV_REPORT_AND_RETURN()

--- a/tests/4.5/target_enter_exit_data/test_target_enter_exit_data_map_pointer_translation.c
+++ b/tests/4.5/target_enter_exit_data/test_target_enter_exit_data_map_pointer_translation.c
@@ -47,7 +47,7 @@ int test_map_same_function() {
       }
     } // end target
 
-    OMPVV_INFOMSG("map(ptr) specified zero-lenght array section")
+    OMPVV_INFOMSG("map(ptr) specified zero-length array section")
 #pragma omp target map(ptr_h_array_h[:0], ptr_h_array_s[:0])
     {
       for (int i = 0; i < N; ++i) {
@@ -79,7 +79,7 @@ int test_map_same_function() {
 
 void helper_function(int *ptr_h_array_h, int *ptr_h_array_s) {
 
-    OMPVV_INFOMSG("map(ptr) specified full-lenght array section")
+    OMPVV_INFOMSG("map(ptr) specified full-length array section")
 #pragma omp target map(ptr_h_array_h[0:N], ptr_h_array_s[0:N])
     {
       for (int i = 0; i < N; ++i) {
@@ -88,7 +88,7 @@ void helper_function(int *ptr_h_array_h, int *ptr_h_array_s) {
       }
     } // end target
 
-    OMPVV_INFOMSG("map(ptr) specified zero-lenght array section")
+    OMPVV_INFOMSG("map(ptr) specified zero-length array section")
 #pragma omp target map(ptr_h_array_h[:0], ptr_h_array_s[:0])
     {
       for (int i = 0; i < N; ++i) {

--- a/tests/4.5/target_simd/test_target_simd_collapse.c
+++ b/tests/4.5/target_simd/test_target_simd_collapse.c
@@ -102,7 +102,7 @@ int test_collapse2() {
   }
 
   if (num_teams == 1) {
-    OMPVV_WARNING("Test operated with one team.  Parallelism of teams distribute can't be guarunteed.");
+    OMPVV_WARNING("Test operated with one team.  Parallelism of teams distribute can't be guaranteed.");
   }
 
   free(a_mem);

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_collapse.c
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_collapse.c
@@ -101,7 +101,7 @@ int test_collapse2() {
   }
 
   if (num_teams == 1) {
-    OMPVV_WARNING("Test operated with one team.  Parallelism of teams distribute can't be guarunteed.");
+    OMPVV_WARNING("Test operated with one team.  Parallelism of teams distribute can't be guaranteed.");
   }
 
   free (a_mem);

--- a/tests/4.5/target_teams_distribute/test_target_teams_distribute_device.c
+++ b/tests/4.5/target_teams_distribute/test_target_teams_distribute_device.c
@@ -26,10 +26,11 @@ int main() {
   OMPVV_TEST_AND_SET_OFFLOADING(isOffloading);
 
   int num_devices = omp_get_num_devices();
-  int a[num_devices][ARRAY_SIZE];
+  // Allocate num_devices + 1 to avoid zero-sized VLA if num_devices == 0
+  int a[num_devices+1][ARRAY_SIZE];
   int b[ARRAY_SIZE];
-  int num_teams[num_devices];
-  int errors[num_devices];
+  int num_teams[num_devices+1];
+  int errors[num_devices+1];
   int sum_errors = 0;
 
   OMPVV_INFOMSG("Running tests on %d devices", num_devices);

--- a/tests/4.5/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for.F90
+++ b/tests/4.5/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for.F90
@@ -54,7 +54,7 @@
   
             ! Rise lack of parallelism alerts
             WRITE(msgHelper, *) "Test operated with one team.  &
-            &Parallelism of teams distribute can't be guarunteed."
+            &Parallelism of teams distribute can't be guaranteed."
             OMPVV_WARNING_IF(num_teams == 1, msgHelper);
 
             WRITE(msgHelper, *) "Test operated with one thread &

--- a/tests/4.5/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_devices.c
+++ b/tests/4.5/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_devices.c
@@ -19,7 +19,8 @@ int test_target_teams_distribute_parallel_for_devices() {
   
   int num_dev = omp_get_num_devices();
   int a[SIZE_N];
-  int isHost[num_dev];
+  // Allocate num_devices + 1 to avoid zero-sized VLA if num_devices == 0
+  int isHost[num_dev+1];
   int errors = 0;
   int i, dev;
 

--- a/tests/5.0/parallel_for/test_parallel_for_allocate.c
+++ b/tests/5.0/parallel_for/test_parallel_for_allocate.c
@@ -27,7 +27,7 @@ int test_parallel_for_allocate() {
   int successful_alloc = 0;
 
   omp_memspace_handle_t x_memspace = omp_default_mem_space;
-  omp_alloctrait_t x_traits[1] = {omp_atk_alignment, 64};
+  omp_alloctrait_t x_traits[1] = {{omp_atk_alignment, 64}};
   omp_allocator_handle_t x_alloc = omp_init_allocator(x_memspace, 1, x_traits);
 
   for (int i = 0; i < N; i++) {

--- a/tests/5.0/requires/test_requires_unified_shared_memory_omp_target_alloc.c
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_omp_target_alloc.c
@@ -5,7 +5,7 @@
 // This test Checks for unified shared memory of an array that is allocated on 
 // the device and accessed in both host and device
 //
-// We use default mapping of pointers, which should be mappend as a zero lenght
+// We use default mapping of pointers, which should be mappend as a zero length
 // array
 //
 ////===----------------------------------------------------------------------===//

--- a/tests/5.0/requires/test_requires_unified_shared_memory_static.F90
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_static.F90
@@ -7,7 +7,7 @@
 ! a pointer from the host and the device.
 !
 ! We use default mapping of the pointer, which should result in mapping of a zero
-! lenght array.
+! length array.
 !
 !===------------------------------------------------------------------------------===//
 

--- a/tests/5.0/requires/test_requires_unified_shared_memory_static.c
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_static.c
@@ -7,7 +7,7 @@
 // a pointer from the host and the device.
 //
 // We use default mapping of the pointer, which should result in mapping of a zero
-// lenght array.
+// length array.
 //
 ////===----------------------------------------------------------------------===//
 #include <omp.h>

--- a/tests/5.0/requires/test_requires_unified_shared_memory_static_map.F90
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_static_map.F90
@@ -6,7 +6,7 @@
 ! Checking for static arrays. The array is global and then accessed through 
 ! a pointer from the host and the device.
 !
-! We use the map clause on the pointer, with zero lenght array, to use the host
+! We use the map clause on the pointer, with zero length array, to use the host
 ! pointer on the device.
 !
 !===------------------------------------------------------------------------------===//

--- a/tests/5.0/requires/test_requires_unified_shared_memory_static_map.c
+++ b/tests/5.0/requires/test_requires_unified_shared_memory_static_map.c
@@ -6,7 +6,7 @@
 // Checking for static arrays. The array is global and then accessed through 
 // a pointer from the host and the device.
 //
-// We use the map clause on the pointer, with zero lenght array, to use the host
+// We use the map clause on the pointer, with zero length array, to use the host
 // pointer on the device.
 ////===----------------------------------------------------------------------===//
 #include <omp.h>

--- a/tests/5.0/target/test_target_defaultmap_to_from_tofrom.F90
+++ b/tests/5.0/target/test_target_defaultmap_to_from_tofrom.F90
@@ -70,6 +70,7 @@ CONTAINS
     OMPVV_TEST_AND_SET_VERBOSE(errors, new_struct%s /= 1)
     OMPVV_TEST_AND_SET_VERBOSE(errors, new_struct%SA(1) /= 1)
     OMPVV_TEST_AND_SET_VERBOSE(errors, new_struct%SA(2) /= 1)
+    DEALLOCATE(B, ptr)
 
     defaultmap_with_to = errors
   END FUNCTION defaultmap_with_to
@@ -118,6 +119,7 @@ CONTAINS
     OMPVV_TEST_AND_SET_VERBOSE(errors, new_struct%s /= 10)
     OMPVV_TEST_AND_SET_VERBOSE(errors, new_struct%SA(1) /= 10)
     OMPVV_TEST_AND_SET_VERBOSE(errors, new_struct%SA(2) /= 10)
+    DEALLOCATE(B,ptr)
 
     defaultmap_with_from = errors
   END FUNCTION defaultmap_with_from
@@ -167,6 +169,7 @@ CONTAINS
     OMPVV_TEST_AND_SET_VERBOSE(errors, new_struct%s /= 11)
     OMPVV_TEST_AND_SET_VERBOSE(errors, new_struct%SA(1) /= 11)
     OMPVV_TEST_AND_SET_VERBOSE(errors, new_struct%SA(2) /= 11)
+    DEALLOCATE(B, ptr)
 
     defaultmap_with_tofrom = errors
   END FUNCTION defaultmap_with_tofrom

--- a/tests/5.0/target/test_target_device.c
+++ b/tests/5.0/target/test_target_device.c
@@ -55,7 +55,7 @@ int test_target_device_ancestor() {
     }
     OMPVV_TEST_AND_SET_VERBOSE(errors, errors2 != 0);
 
-    OMPVV_ERROR_IF(which_device != 75, "Target region was executed on a target device. Due to ancestor device-modifier,"
+    OMPVV_ERROR_IF(which_device != 75, "Target region was executed on a target device. Due to ancestor device-modifier, "
                                          "this region should execute on a host device");
 
 
@@ -78,7 +78,7 @@ int test_target_device_device_num() {
 
     
     OMPVV_TEST_AND_SET(errors, omp_get_num_devices() <= 0);
-    OMPVV_WARNING_IF(omp_get_num_devices() <= 0, "[SKIPPED] Since no target devices were found, this test"
+    OMPVV_WARNING_IF(omp_get_num_devices() <= 0, "[SKIPPED] Since no target devices were found, this test "
                                                  "will be skipped");
 	
     if (omp_get_num_devices() > 0) {

--- a/tests/5.0/taskgroup/test_taskgroup_task_reduction.c
+++ b/tests/5.0/taskgroup/test_taskgroup_task_reduction.c
@@ -69,5 +69,11 @@ int main(int argc, char *argv[]) {
 
   OMPVV_TEST_AND_SET_VERBOSE(errors, result != seq_linked_list_sum(root));
 
+  while (root) {
+    temp = root;
+    root = root->next;
+    free(temp);
+  }
+
   OMPVV_REPORT_AND_RETURN(errors);
 }

--- a/tests/5.0/teams/test_teams.c
+++ b/tests/5.0/teams/test_teams.c
@@ -17,7 +17,6 @@ int main() {
   int num_teams[OMPVV_NUM_TEAMS_DEVICE];
   int num_threads[OMPVV_NUM_THREADS_DEVICE];
   int errors[2] = {0,0};
-  int is_offloading;
 
 
   for (int x = 0; x < OMPVV_NUM_TEAMS_DEVICE; ++x) {

--- a/tests/5.1/memory_routines/test_get_mapped_ptr.c
+++ b/tests/5.1/memory_routines/test_get_mapped_ptr.c
@@ -18,7 +18,7 @@ int test_get_mapped_ptr() {
 int * device_ptr;
 int x = 4;
 int num_devices = omp_get_num_devices(); 
-int * arr_ptrs[num_devices];
+int * arr_ptrs;
 OMPVV_INFOMSG_IF(num_devices == 0, "No devices available. ");
 // test to make sure it is NULL if no devices exist
 if (num_devices == 0) {
@@ -29,11 +29,11 @@ if (num_devices == 0) {
 }
 for (int i = 0; i < num_devices; i ++) {
 # pragma omp target enter data device(i) map(to:x)
-	arr_ptrs[i] = (int *) omp_get_mapped_ptr(&x, i);
+	arr_ptrs = (int *) omp_get_mapped_ptr(&x, i);
 
-	OMPVV_TEST_AND_SET(errors, arr_ptrs[i] == NULL);
-	OMPVV_INFOMSG_IF(arr_ptrs[i] == NULL, "get_mapped_ptr() failed on getting device pointer. ");
-	OMPVV_INFOMSG_IF(arr_ptrs[i] != NULL, "get_mapped_ptr() mapped pointer to device. ");
+	OMPVV_TEST_AND_SET(errors, arr_ptrs == NULL);
+	OMPVV_INFOMSG_IF(arr_ptrs == NULL, "get_mapped_ptr() failed on getting device pointer. ");
+	OMPVV_INFOMSG_IF(arr_ptrs != NULL, "get_mapped_ptr() mapped pointer to device. ");
 # pragma omp target exit data map(from:x)
 }
 

--- a/tests/5.2/implementation_defined/test_ompx_free.F90
+++ b/tests/5.2/implementation_defined/test_ompx_free.F90
@@ -31,7 +31,7 @@ CONTAINS
                 INTEGER, DIMENSION(2) :: ARR_ERR
                 errors = 0
                 !$omp parallel shared(ARR_ERR) private(i)  num_threads(2)
-                !$ompx test_nonexistant
+                !$ompx test_nonexistent
                         i = omp_get_thread_num()
                         i = i + 1
                         ARR_ERR(i) = 1

--- a/tests/5.2/misc/test_printf_in_target_region.c
+++ b/tests/5.2/misc/test_printf_in_target_region.c
@@ -41,7 +41,7 @@ int main () {
       printf("The value of the long int mapped into target region is %ld\n", long_one);
       printf("The value of the unsigned long int mapped into target region is %lu\n", unsigned_long);
       printf("The value of the long long int mapped into target region is %lld\n", long_long);
-      printf("Values of everything mapped in target region are %d, %f, %lf, %c, %hd, %hu, %ld, %lu, %lld", integer, floater, doubler, single_char,
+      printf("Values of everything mapped in target region are %d, %f, %lf, %c, %hd, %hu, %ld, %lu, %lld\n", integer, floater, doubler, single_char,
 shortie, unsigned_shortie, long_one, unsigned_long, long_long);
    }
    


### PR DESCRIPTION
I stumbled over some typos/spacing issues when looking at the logs and found some more using 'hunspell'. I also fixed some warnings and errors, mostly found via the sanitizer and turning on warnings. Still, I think those should be fixed.

_(There are more warnings of the type unused vars or unused but set, which I ignored; and I only fixed typos which (also) showed up in the logs. For Fortran, just freeing 'ptr' would be enough as 'B' is autodeallocated being an allocatable.)_

@spophale @fel-cab – pleases review.

* tests/5.0/taskgroup/test_taskgroup_task_reduction.c: Free memory at the end.
* tests/5.0/target/test_target_defaultmap_to_from_tofrom.F90: Likewise.
* tests/5.0/teams/test_teams.c: Remove unused var.
* tests/5.1/memory_routines/test_get_mapped_ptr.c: Use scalar pointer nor VLA of pointers as the latter is invalid if num_devices == 0.
* tests/4.5/target_teams_distribute/test_target_teams_distribute_device.c: Allocate always one element more than num_devices to avoid zero-sized VLA.
* tests/4.5/target_enter_exit_data/test_target_enter_exit_data_devices.c: Likewise.
* tests/4.5/target_data/test_target_data_map_devices.c: Likewise.
* tests/4.5/target_enter_data/test_target_enter_data_devices.c: Likewise; fix isHost initialization.
* tests/5.2/misc/test_printf_in_target_region.c: Add tailing linebreak to I/O.
* tests/5.0/parallel_for/test_parallel_for_allocate.c: Silence C compiler warning about missing { }. Leaving out the outer braces seems to be valid for C++, only.
* Various typo fixes in strings show at runtime (plus fixing the same typo in other files as well).