### PR TITLE
Add new_test/5.1/test_atomic_compare_device.F90

### DIFF
--- a/tests/5.1/atomic/test_atomic_compare_device.F90
+++ b/tests/5.1/atomic/test_atomic_compare_device.F90
@@ -1,0 +1,81 @@
+!//===------ test_atomic_compare_device.F90 --------------------------===//
+!
+! OpenMP API Version 5.1 Nov 2020
+!
+! Adapted from OpenMP example video https://www.youtube.com/watch?v=iS6IG7nzCSo
+! Creates an array with random numbers, and uses atomic compare to find the max,
+! testing against non-parallel maximum.
+!
+!//===----------------------------------------------------------------------===//
+
+#include "ompvv.F90"
+
+#define N 100
+
+PROGRAM test_atomic_compare_program
+  USE iso_fortran_env
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+
+  OMPVV_TEST_OFFLOADING
+
+  OMPVV_TEST_VERBOSE(test_atomic_compare() .ne. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION test_atomic_compare()
+    INTEGER:: errors, pmax, smax, i
+    INTEGER:: arr(N)
+    INTEGER:: assume, oldval, newval
+    REAL:: rN
+
+    errors = 0
+    pmax = 0
+    smax = 0
+
+    OMPVV_INFOMSG("test_atomic_compare_device")
+
+    DO i=1, N
+      call RANDOM_NUMBER(rN)
+      arr(i) = INT(rN*1000) 
+    END DO
+
+    !Sets max through non-parallel methods
+    DO i=1, N
+      IF( arr(i) > smax ) THEN
+        smax = arr(i)
+      END IF
+    END DO
+
+    !Sets max using parallel for loop, using atomic to ensure max is correct
+    !$omp target parallel do map(pmax) shared(pmax) private(oldval, assume, newval)
+    DO i=1, N
+      oldval = pmax 
+      DO 
+        assume = oldval
+        IF( arr(i) .GT. assume ) THEN
+            newval = arr(i) 
+        ELSE
+            newval = assume
+        END IF
+        !$omp atomic compare capture
+        IF( pmax .EQ. assume ) THEN
+          pmax = newval 
+        ELSE
+          oldval = pmax
+        END IF
+        !$omp end atomic
+        IF( assume .EQ. oldval) THEN
+          EXIT
+        END IF
+      END DO
+    END DO
+    !$omp end target parallel do
+    
+    OMPVV_TEST_AND_SET(errors, pmax .NE. smax)    
+
+    test_atomic_compare = errors
+  END FUNCTION test_atomic_compare
+END PROGRAM test_atomic_compare_program

--- a/tests/5.1/atomic/test_atomic_compare_device.c
+++ b/tests/5.1/atomic/test_atomic_compare_device.c
@@ -17,7 +17,7 @@
 #define N 100
 
 int test_atomic_compare() {
-  OMPVV_INFOMSG("test_atomic_compare");
+  OMPVV_INFOMSG("test_atomic_compare_device");
 
   int arr[N];
   int errors = 0;
@@ -45,6 +45,7 @@ int test_atomic_compare() {
 
 int main() {
   int errors = 0;
+  OMPVV_TEST_OFFLOADING;
   OMPVV_TEST_AND_SET_VERBOSE(errors, test_atomic_compare());
   OMPVV_REPORT_AND_RETURN(errors);
 }


### PR DESCRIPTION
While the original C test uses the `>` operator for the atomic compare operation, Fortran atomic compare construct allows only the `==` operator. Therefore, the Fortan test uses a slightly different algorithm to atomically perform the max operation using the `atomic compare capture` directive.

[Evaluation Results on Summit]
- GCC 13.1.1: both C and Fortran tests passed.
- XL 16.1.1-10:
    - C test passed but ran on the host.
    - Fortran test failed: line 63.13: 1514-050 (S) Specification statement is out of order. 
- NVHPC 22.11:
    - C test failed: line 36: error: invalid text in pragma
    - Fortran test failed: NVFORTRAN-S-0034-Syntax error at or near COMPARE 
- LLVM 17.0.0:
    - C test passed.