### PR TITLE
Add new_test/5.1/teams/test_target_teams_default_firstprivate.F90

### DIFF
--- a/tests/5.1/teams/test_target_teams_default_firstprivate.F90
+++ b/tests/5.1/teams/test_target_teams_default_firstprivate.F90
@@ -41,7 +41,7 @@ CONTAINS
         num_teams = omp_get_num_teams()
         ! check first private
         IF (not_shared .NE. 5) then
-          errors = error + 1
+          errors = errors + 1
         END IF
     END IF 
     DO i=1, omp_get_num_teams()

--- a/tests/5.1/teams/test_target_teams_default_firstprivate.F90
+++ b/tests/5.1/teams/test_target_teams_default_firstprivate.F90
@@ -1,0 +1,53 @@
+!===--- test_target_teams_default_firstprivate.F90 --------------------------===//
+!
+! OpenMP API Version 5.1 Nov 2020
+!
+! This test uses the default(firstprivate) clause on a teams directive. The test
+! validates that when the default(firstprivate) clause is present all
+! variables without explicit sharing rules are not avaialble outside the region
+! and are private to each team. The default(firstprivate) clause is tested using
+! the not_shared variable, whose value should have not changed after the target
+! teams construct since all changes to the firstprivate variable should not persist
+! after the construct. Additionally if there is a race condition, we know the 
+! variable is not defaulting to firstprivate either.
+!
+!//===----------------------------------------------------------------------===//
+#include "ompvv.F90"
+
+#define N 1024
+
+PROGRAM test_target_teams_firstprivate
+  USE iso_fortran_env
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+  OMPVV_TEST_OFFLOADING
+
+  OMPVV_TEST_VERBOSE(test_teams_firstprivate() .NE. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION test_teams_firstprivate()
+    INTEGER :: errors, i
+    INTEGER :: not_shared, num_teams
+
+    errors = 0
+    not_shared = 5
+    num_teams = 0
+
+    !$omp target teams default(firstprivate) map(tofrom: num_teams) shared(num_teams) num_teams(OMPVV_NUM_TEAMS_DEVICE)
+    IF (omp_get_team_num() .EQ. 0) then
+        num_teams = omp_get_num_teams()
+    END IF 
+    DO i=1, omp_get_num_teams()
+        not_shared = not_shared + 5
+    END DO
+    !$omp end target teams
+
+    OMPVV_WARNING_IF(num_teams .NE. OMPVV_NUM_TEAMS_DEVICE, "Number of teams was unexpected, test results likely inconclusive")
+    OMPVV_TEST_AND_SET(errors, (not_shared .NE. 5))
+
+    test_teams_firstprivate = errors
+  END FUNCTION test_teams_firstprivate
+END PROGRAM test_target_teams_firstprivate

--- a/tests/5.1/teams/test_target_teams_default_firstprivate.F90
+++ b/tests/5.1/teams/test_target_teams_default_firstprivate.F90
@@ -36,9 +36,13 @@ CONTAINS
     not_shared = 5
     num_teams = 0
 
-    !$omp target teams default(firstprivate) map(tofrom: num_teams) shared(num_teams) num_teams(OMPVV_NUM_TEAMS_DEVICE)
+    !$omp target teams default(firstprivate) map(tofrom: num_teams,errors) shared(num_teams,errors) num_teams(OMPVV_NUM_TEAMS_DEVICE)
     IF (omp_get_team_num() .EQ. 0) then
         num_teams = omp_get_num_teams()
+        ! check first private
+        IF (not_shared .NE. 5) then
+          errors = error + 1
+        END IF
     END IF 
     DO i=1, omp_get_num_teams()
         not_shared = not_shared + 5

--- a/tests/5.1/teams/test_target_teams_default_firstprivate.c
+++ b/tests/5.1/teams/test_target_teams_default_firstprivate.c
@@ -28,10 +28,13 @@ int main() {
 	int not_shared = 5;
 	int num_teams = 0; 
 
-	#pragma omp target teams default(firstprivate) map(tofrom:num_teams) shared(num_teams) num_teams(OMPVV_NUM_TEAMS_DEVICE)
+	#pragma omp target teams default(firstprivate) map(tofrom:num_teams,errors) shared(num_teams,errors) num_teams(OMPVV_NUM_TEAMS_DEVICE)
 	{
 		if (omp_get_team_num() == 0) {
 			num_teams = omp_get_num_teams();
+			if( not_shared != 5 ) {
+				errors = errors + 1;
+			}
 		}
 
 		for (int i = 0; i < omp_get_num_teams(); i++) {

--- a/tests/5.1/teams/test_target_teams_default_firstprivate.c
+++ b/tests/5.1/teams/test_target_teams_default_firstprivate.c
@@ -3,13 +3,13 @@
 // OpenMP API Version 5.1 Nov 2020
 //
 // This test uses the default(firstprivate) clause on a teams directive. The test
-// validates that when the default(firstprivate) clause is present that all
-// variables without explicit sharing rules is not avaialble outside the region
-// and is encapsulated between each thread. Starting with the initial value from
-// outside the region. This is checked by by establishing a not_shared value. Since
-// all changes should not persist after the construct region, it should have 
-// not changed. Additionally if there is a race condition, we know the variable 
-// is not defaulting to firstprivate either.
+// validates that when the default(firstprivate) clause is present all
+// variables without explicit sharing rules are not avaialble outside the region
+// and are private to each team. The default(firstprivate) clause is tested using
+// the not_shared variable, whose value should have not changed after the target
+// teams construct since all changes to the firstprivate variable should not persist
+// after the construct. Additionally if there is a race condition, we know the 
+// variable is not defaulting to firstprivate either.
 //
 //===------------------------------------------------------------------------===//
 
@@ -40,7 +40,7 @@ int main() {
 	}
 
 
-	OMPVV_WARNING_IF(num_teams != 8, "Number of teams was unexpected, test results likely inconclusive");
+	OMPVV_WARNING_IF(num_teams != OMPVV_NUM_TEAMS_DEVICE, "Number of teams was unexpected, test results likely inconclusive");
 
 	OMPVV_TEST_AND_SET(errors, (not_shared != 5));
 


### PR DESCRIPTION
Added a new Fortran test and fixed minor bugs in the original C test.

[Evaluation Results on Summit]
- GCC 13.1.1:
    - Both C and Fortran tests passed.
- XL 16.1.1-10:
    - C test failed on the host with the following warning: Number of teams was unexpected, test results likely inconclusive
    - Fortran test passed.
- NVHPC 22.11:
    - C test failed: line 31: error: invalid text in pragma
    - Fortran test passed.
- LLVM 17.0.0:
    - C test passed.