### PR TITLE
test_allocate_allocator.c: Fix 'omp allocate' usage

### DIFF
--- a/tests/5.0/allocate/test_allocate_allocator.c
+++ b/tests/5.0/allocate/test_allocate_allocator.c
@@ -15,6 +15,7 @@
 #include <omp.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include "ompvv.h"
 
 #define N 1024
@@ -22,25 +23,40 @@
 int test_allocate_allocator() {
   int errors = 0;
 
-  int* x;
+  int n = N;
   omp_memspace_handle_t x_memspace = omp_default_mem_space;
   omp_alloctrait_t x_traits[1] = {{omp_atk_alignment, 64}};
   omp_allocator_handle_t x_alloc = omp_init_allocator(x_memspace, 1, x_traits);
+  {
+    // x and y must be in an inner scope as their lifetime must exceed the
+    // lifetime of the allocator associated with x_alloc; i.e. the lifetime
+    // must have ended before omp_destroy_allocator is called.
+    //
+    // The following two lines allocate the pointer 'x' itself
+    // (i.e. sizeof(void*) bytes) and 'y'. The omp_alloc allocates then
+    // space for the actual data stored in 'x'.
+    int* x, y[n];
+#pragma omp allocate(x,y) allocator(x_alloc)
 
+    x = (int *)omp_alloc(N * sizeof(int), x_alloc);
 
-#pragma omp allocate(x) allocator(x_alloc)
-  x = (int *)omp_alloc(N * sizeof(int), x_alloc);
+    OMPVV_TEST_AND_SET_VERBOSE(errors, ((intptr_t) &x) % 64 != 0);
+    OMPVV_TEST_AND_SET_VERBOSE(errors, ((intptr_t) &y) % 64 != 0);
+    OMPVV_TEST_AND_SET_VERBOSE(errors, ((intptr_t) x) % 64 != 0);
 
-#pragma omp parallel for simd simdlen(16) aligned(x: 64)
-  for (int i = 0; i < N; i++) {
-    x[i] = i;
+#pragma omp parallel for simd simdlen(16) aligned(x, y: 64)
+    for (int i = 0; i < N; i++) {
+      x[i] = i;
+      y[i] = 3*i;
+    }
+
+    for (int i = 0; i < N; i++) {
+      OMPVV_TEST_AND_SET_VERBOSE(errors, x[i] != i);
+      OMPVV_TEST_AND_SET_VERBOSE(errors, y[i] != 3*i);
+    }
+
+    omp_free(x, x_alloc);
   }
-
-  for (int i = 0; i < N; i++) {
-    OMPVV_TEST_AND_SET_VERBOSE(errors, x[i] != i);
-  }
-
-  omp_free(x, x_alloc);
   omp_destroy_allocator(x_alloc);
 
   return errors;

--- a/tests/5.0/allocate/test_allocate_allocator.c
+++ b/tests/5.0/allocate/test_allocate_allocator.c
@@ -40,9 +40,17 @@ int test_allocate_allocator() {
 
     x = (int *)omp_alloc(N * sizeof(int), x_alloc);
 
-    OMPVV_TEST_AND_SET_VERBOSE(errors, ((intptr_t) &x) % 64 != 0);
-    OMPVV_TEST_AND_SET_VERBOSE(errors, ((intptr_t) &y) % 64 != 0);
-    OMPVV_TEST_AND_SET_VERBOSE(errors, ((intptr_t) x) % 64 != 0);
+    // OMPVV_TEST_AND_SET_VERBOSE diagnostic uses printf, which
+    // causes compiler warnigns for '% '. Hence:
+    OMPVV_TEST_AND_SET(errors, ((intptr_t) &x) % 64 != 0);
+    OMPVV_TEST_AND_SET(errors, ((intptr_t) &y) % 64 != 0);
+    OMPVV_TEST_AND_SET(errors, ((intptr_t) x) % 64 != 0);
+    OMPVV_ERROR_IF(((intptr_t) &x) % 64 != 0,
+                   "Condition (intptr_t) &x) %% 64 != 0 failed")
+    OMPVV_ERROR_IF(((intptr_t) &y) % 64 != 0,
+                   "Condition (intptr_t) &y) %% 64 != 0 failed")
+    OMPVV_ERROR_IF(((intptr_t) x) % 64 != 0,
+                   "Condition (intptr_t) x) %% 64 != 0 failed")
 
 #pragma omp parallel for simd simdlen(16) aligned(x, y: 64)
     for (int i = 0; i < N; i++) {

--- a/tests/5.0/allocate/test_allocate_allocator.c
+++ b/tests/5.0/allocate/test_allocate_allocator.c
@@ -28,8 +28,8 @@ int test_allocate_allocator() {
   omp_alloctrait_t x_traits[1] = {{omp_atk_alignment, 64}};
   omp_allocator_handle_t x_alloc = omp_init_allocator(x_memspace, 1, x_traits);
   {
-    // x and y must be in an inner scope as their lifetime must exceed the
-    // lifetime of the allocator associated with x_alloc; i.e. the lifetime
+    // x and y must be in an inner scope as their lifetime must not exceed the
+    // lifetime of the allocator associated with x_alloc; i.e. their lifetime
     // must have ended before omp_destroy_allocator is called.
     //
     // The following two lines allocate the pointer 'x' itself


### PR DESCRIPTION
There were two issues with `omp allocate`:

First, the variable `x` is declared (`int *x;`) before the the `omp_allocator_handle_t` variable `x_alloc` is declared and initialized; while the `#pragma omp allocate(x) allocator(x_alloc)` line comes after the latter, there is a potential ordering issue: Per C semantic, `x` is available before `x_alloc` but before it can exist and be initialized, it has to be allocated - but for this `x_alloc` has to exist.

Solution: Moving the `x` declaration after the `x_alloc` declaration and initialization solves the issue.

Secondly, the OpenMP semantic states that the lifetime of an omp-allocated automatic (stack) variable such as `x` is its scope, i.e. it ends at the enclosing `}`. However, as allocator used for allocation is also used for deallocation, its lifetime must exceed the liftime of `x`. Thus, `omp_destory_allocator` cannot be in in the same scope as 'x'.

Solution: Place the omp-allocated variables in an inner scope such that 'x_alloc' has a longer lifetime.

_Additionally, some comments have been added to make it clearer to the code reader what happens and why code is as it is._
* * *
@spophale @fel-cab @ — please review. Thanks!

* * *

While the second issue did not show up when trying it with GCC (not even with `-fsanitize=address,undefined`), the first one shows up in the current draft patch as:
```
test_allocate_allocator.c:31:21: error: allocator variable ‘x_alloc’ must be declared before ‘x’`.
```
_[BTW: This topic has now an associated OpenMP spec issue (Issue 3676).]_

While a compiler could handle the first issue for this test case (by doing what the patch does), the following example causes an unsolvable hen-and-egg problem:
```C
int n=4;
omp_allocator_handle_t n_alloc = (omp_allocator_handle_t) (omp_default_mem_alloc + n);
#pragma omp allocate(n) allocator(n_alloc)
```
_This assumes that the allocator exists, but in most/all implementation, `omp_default_mem_alloc + 4` = `omp_low_lat_mem_alloc` as that's the rather obvious choice when implementing the predefined allocators (as enum values). – But playing around with arguments to omp_init_allocator, e.g. for the second argument (traits size), a variant of this issue can be created. – Both are not very sensible, but illustrate the issue._