### PR TITLE
Add new_test/5.1/metadirective/test_metadirective_nothing.F90

### DIFF
--- a/tests/5.1/metadirective/test_metadirective_nothing.F90
+++ b/tests/5.1/metadirective/test_metadirective_nothing.F90
@@ -1,0 +1,102 @@
+!===--- test_metadirective_nothing.F90 -------------------------------------===//
+!
+! OpenMP API Version 5.1 Nov 2020
+!
+! Test for nothing directive within metadirectives. Runs a variety of
+! metadirectives that check if the nothing directive is properly rendered.
+! Primarily tests based on the fact that no matter what 'when' clause is 
+! rendered it should result in nothing, and thus no additional pragma should
+! be created. Thus, the threads should remain unchanged through this process
+! and the compiler should handle it properly. Handles both device and host
+! based tests.
+!
+!//===----------------------------------------------------------------------===//
+#include "ompvv.F90"
+
+#define N 1024
+
+PROGRAM test_metadirective_nothing
+  USE iso_fortran_env
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+  OMPVV_TEST_OFFLOADING
+
+  IF( omp_get_num_devices() .GT. 0 ) THEN
+    OMPVV_TEST_VERBOSE(metadirectiveOnDevice() .NE. 0)
+  ELSE
+    OMPVV_TEST_VERBOSE(metadirectiveOnHost() .NE. 0)
+  END IF
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION metadirectiveOnDevice()
+    INTEGER :: errors, i
+    INTEGER :: A(N)
+
+    errors = 0
+
+    DO i=1, N
+        A(i) = 0
+    END DO
+
+    !$omp target map(tofrom: A)
+    ! We expect at least one of these when conditons to eval to true, thus having the nothing directive utilized
+    !$omp begin metadirective &
+    !$omp when( device={kind(nohost)}: nothing ) &
+    !$omp when( device={arch("nvptx")}: nothing ) &
+    !$omp when( implementation={vendor(amd)}: nothing ) &
+    !$omp default( parallel do )
+    DO i=1, N
+        IF( omp_in_parallel() ) THEN
+            A(i) = A(i) + 1
+        END IF
+    END DO
+    !$omp end metadirective
+    !$omp end target
+
+    DO i=1, N
+        OMPVV_TEST_AND_SET(errors, A(i) .NE. 0)
+    END DO
+
+    OMPVV_INFOMSG("Test ran with a number of available devices greater than 0")
+    OMPVV_INFOMSG_IF(A(1) .EQ. 0, "Test recognized device was of arch/vendor/kind nvidia, amd, or nohost")
+    OMPVV_WARNING_IF(A(1) .EQ. 1, "Test could not recognize if device was of arch/vendor/kind nvidia, amd or, nohost, even though there are devices available.")
+
+    metadirectiveOnDevice = errors
+  END FUNCTION metadirectiveOnDevice
+
+  INTEGER FUNCTION metadirectiveOnHost()
+    INTEGER :: errors, i
+    INTEGER :: A(N)
+
+    errors = 0
+
+    DO i=1, N
+        A(i) = 0
+    END DO
+
+    ! We expect all of these when statements to eval to false, causing body of code to run using 'nothing' as the default pragma
+    !$omp begin metadirective &
+    !$omp when( device={kind(nohost)}: parallel do ) &
+    !$omp when( device={arch("nvptx")}: parallel do) &
+    !$omp when( implementation={vendor(amd)}: parallel do ) &
+    !$omp default( nothing )
+    DO i=1, N
+        IF( omp_in_parallel() ) THEN
+            A(i) = A(i) + 1
+        END IF
+    END DO
+    !$omp end metadirective
+
+    OMPVV_WARNING_IF(A(1) .EQ. 1, "Even though no devices were available the test recognized kind/arch equal to nohost or nvptx or amd")
+
+    DO i=1, N
+        OMPVV_TEST_AND_SET(errors, A(i) .NE. 0)
+    END DO
+
+
+    metadirectiveOnHost = errors
+  END FUNCTION metadirectiveOnHost
+END PROGRAM test_metadirective_nothing

--- a/tests/5.1/metadirective/test_metadirective_nothing.c
+++ b/tests/5.1/metadirective/test_metadirective_nothing.c
@@ -18,30 +18,34 @@
 #include "ompvv.h"
 
 #define N 1024
+#define THREAD_LIMIT 32
 
 int metadirectiveOnDevice() {
    int errors = 0;
    int A[N];
-   int max_num_threads_target = 0;
-   int max_num_threads_parallel = 0;
+   int thread_limit_target = THREAD_LIMIT;
+   int thread_limit_teams = 0;
 
    for (int i = 0; i < N; i++) {
       A[i] = 0;
    }
-
-   #pragma omp target map(tofrom: A, max_num_threads_target, max_num_threads_parallel)
+   #pragma omp target map(from: thread_limit_target) thread_limit(thread_limit_target)
    {
-      max_num_threads_target = omp_get_max_threads();
+      thread_limit_target = omp_get_thread_limit();
+   }
+
+   #pragma omp target map(tofrom: A, thread_limit_teams) thread_limit(thread_limit_target)
+   {
       // We expect at least one of these when conditons to eval to true, thus having the nothing directive utilized
       #pragma omp metadirective \
          when( device={kind(nohost)}: nothing ) \
          when( device={arch("nvptx")}: nothing) \
          when( implementation={vendor(amd)}: nothing ) \
-         default( parallel for num_threads(max_num_threads_target+1) )
+         default( teams distribute parallel for thread_limit(thread_limit_target+1) )
             for (int i = 0; i < N; i++) {
                A[i] += omp_in_parallel();
                if( i == 0 ) {
-                 max_num_threads_parallel = omp_get_max_threads();
+                 thread_limit_teams = omp_get_thread_limit();
                }
             }
    }
@@ -49,10 +53,10 @@ int metadirectiveOnDevice() {
    for (int i = 0; i < N; i++) {
       OMPVV_TEST_AND_SET(errors, A[i] != 0);
    }
-   OMPVV_TEST_AND_SET(errors, max_num_threads_parallel != max_num_threads_target);
+   OMPVV_TEST_AND_SET(errors, thread_limit_target != thread_limit_teams);
 
    OMPVV_INFOMSG("Test ran with a number of available devices greater than 0");
-   OMPVV_INFOMSG_IF(max_num_threads_parallel == max_num_threads_target, "Test recognized device was of arch/vendor/kind nvidia, amd, or nohost");
+   OMPVV_INFOMSG_IF(thread_limit_target == thread_limit_teams, "Test recognized device was of arch/vendor/kind nvidia, amd, or nohost");
    OMPVV_WARNING_IF(A[0] == 1, "Test could not recognize if device was of arch/vendor/kind nvidia, amd or, nohost, even though there are devices available.");
 
    return errors;
@@ -61,24 +65,24 @@ int metadirectiveOnDevice() {
 int metadirectiveOnHost() {
   int errors = 0;
   int A[N];
-  int max_num_threads_initial = 0;
-  int max_num_threads_loop = 0;
+  int thread_limit_initial = THREAD_LIMIT;
+  int thread_limit_teams = 0;
 
   for (int i = 0; i < N; i++) {
      A[i] = 0;
   }
 
-  max_num_threads_initial = omp_get_max_threads();
+  thread_limit_initial = omp_get_thread_limit();
   // We expect all of these when statements to eval to false, causing body of code to run using 'nothing' as the default pragma
   #pragma omp metadirective \
-     when( device={kind(nohost)}: parallel for num_threads(max_num_threads_initial+1) ) \
-     when( device={arch("nvptx")}: parallel for num_threads(max_num_threads_initial+1) ) \
-     when( implementation={vendor(amd)}: parallel for num_threads(max_num_threads_initial+1) ) \
+     when( device={kind(nohost)}: teams distribute parallel for thread_limit(thread_limit_initial+1) ) \
+     when( device={arch("nvptx")}: teams distribute parallel for thread_limit(thread_limit_initial+1) ) \
+     when( implementation={vendor(amd)}: teams distribute parallel for thread_limit(thread_limit_initial+1) ) \
      default( nothing )
         for (int i = 0; i < N; i++) {
            A[i] += omp_in_parallel();
            if( i == 0 ) {
-              max_num_threads_loop = omp_get_max_threads();
+              thread_limit_teams = omp_get_thread_limit();
            }
         }
 
@@ -87,7 +91,7 @@ int metadirectiveOnHost() {
   for (int i = 0; i < N; i++) {
      OMPVV_TEST_AND_SET(errors, A[i] != 0);
   }
-  OMPVV_TEST_AND_SET(errors, max_num_threads_initial != max_num_threads_loop);
+  OMPVV_TEST_AND_SET(errors, thread_limit_initial != thread_limit_teams);
 
   return errors;
 } 

--- a/tests/5.1/metadirective/test_metadirective_nothing.c
+++ b/tests/5.1/metadirective/test_metadirective_nothing.c
@@ -22,30 +22,37 @@
 int metadirectiveOnDevice() {
    int errors = 0;
    int A[N];
+   int max_num_threads_target = 0;
+   int max_num_threads_parallel = 0;
 
    for (int i = 0; i < N; i++) {
       A[i] = 0;
    }
 
-   #pragma omp target map(tofrom: A)
+   #pragma omp target map(tofrom: A, max_num_threads_target, max_num_threads_parallel)
    {
+      max_num_threads_target = omp_get_max_threads();
       // We expect at least one of these when conditons to eval to true, thus having the nothing directive utilized
       #pragma omp metadirective \
          when( device={kind(nohost)}: nothing ) \
          when( device={arch("nvptx")}: nothing) \
          when( implementation={vendor(amd)}: nothing ) \
-         default( parallel for)
+         default( parallel for num_threads(max_num_threads_target+1) )
             for (int i = 0; i < N; i++) {
                A[i] += omp_in_parallel();
+               if( i == 0 ) {
+                 max_num_threads_parallel = omp_get_max_threads();
+               }
             }
    }
 
    for (int i = 0; i < N; i++) {
       OMPVV_TEST_AND_SET(errors, A[i] != 0);
    }
+   OMPVV_TEST_AND_SET(errors, max_num_threads_parallel != max_num_threads_target);
 
    OMPVV_INFOMSG("Test ran with a number of available devices greater than 0");
-   OMPVV_INFOMSG_IF(A[0] == 0, "Test recognized device was of arch/vendor/kind nvidia, amd, or nohost");
+   OMPVV_INFOMSG_IF(max_num_threads_parallel == max_num_threads_target, "Test recognized device was of arch/vendor/kind nvidia, amd, or nohost");
    OMPVV_WARNING_IF(A[0] == 1, "Test could not recognize if device was of arch/vendor/kind nvidia, amd or, nohost, even though there are devices available.");
 
    return errors;
@@ -54,19 +61,25 @@ int metadirectiveOnDevice() {
 int metadirectiveOnHost() {
   int errors = 0;
   int A[N];
+  int max_num_threads_initial = 0;
+  int max_num_threads_loop = 0;
 
   for (int i = 0; i < N; i++) {
      A[i] = 0;
   }
 
+  max_num_threads_initial = omp_get_max_threads();
   // We expect all of these when statements to eval to false, causing body of code to run using 'nothing' as the default pragma
   #pragma omp metadirective \
-     when( device={kind(nohost)}: parallel for ) \
-     when( device={arch("nvptx")}: parallel for) \
-     when( implementation={vendor(amd)}: parallel for ) \
+     when( device={kind(nohost)}: parallel for num_threads(max_num_threads_initial+1) ) \
+     when( device={arch("nvptx")}: parallel for num_threads(max_num_threads_initial+1) ) \
+     when( implementation={vendor(amd)}: parallel for num_threads(max_num_threads_initial+1) ) \
      default( nothing )
         for (int i = 0; i < N; i++) {
            A[i] += omp_in_parallel();
+           if( i == 0 ) {
+              max_num_threads_loop = omp_get_max_threads();
+           }
         }
 
   OMPVV_WARNING_IF(A[0] == 1, "Even though no devices were available the test recognized kind/arch equal to nohost or nvptx or amd");
@@ -74,6 +87,7 @@ int metadirectiveOnHost() {
   for (int i = 0; i < N; i++) {
      OMPVV_TEST_AND_SET(errors, A[i] != 0);
   }
+  OMPVV_TEST_AND_SET(errors, max_num_threads_initial != max_num_threads_loop);
 
   return errors;
 } 


### PR DESCRIPTION
[Results on Summit]
- GCC 13.1.1:
    - Both C and Fortran tests passed.
- XL 16.1.1-10:
    - C test passed but ran on the host.
    - Fortran test failed: line 46.10: 1515-019 (S) Syntax is incorrect.
- NVHPC 22.11:
    - C test failed: line 34: error: invalid text in pragma
    - Fortran test failed: NVFORTRAN-F-1241-OpenMP begin/end METADIRECTIVE not supported in this version of the compiler.
- LLVM 17.0.0:
    - C test passed but with a warning: extra tokens at the end of '#pragma omp nothing' are ignored [-Wextra-tokens]