### PR TITLE
test_target_parallel_linear.c: Fix memory allocation

### DIFF
--- a/tests/5.0/target/test_target_parallel_linear.c
+++ b/tests/5.0/target/test_target_parallel_linear.c
@@ -15,7 +15,7 @@
 
 
 int Runtst(int gpu) {
-  int *A = malloc(sizeof(int) * THREADS), errors = 0;
+  int *A = malloc(sizeof(int) * N), errors = 0;
   for (int i = 0; i < N; ++i) {
     A[i] = i;
   }

--- a/tests/5.0/target/test_target_parallel_linear.c
+++ b/tests/5.0/target/test_target_parallel_linear.c
@@ -46,8 +46,7 @@ int main() {
   OMPVV_TEST_OFFLOADING;
   int TotGpus = omp_get_num_devices();
   int errors = 0;
-  for (int gpu = 0; gpu < TotGpus; ++gpu) {
-    errors = 0;
+  for (int gpu = 0; gpu <= TotGpus; ++gpu) {
     OMPVV_TEST_AND_SET_VERBOSE(errors, (Runtst(gpu) != 0));
   }
   OMPVV_REPORT_AND_RETURN(errors);


### PR DESCRIPTION
Fix a bug in https://github.com/SOLLVE/sollve_vv/tree/master/tests/5.0/target/test_target_parallel_linear.c — where the undefined THREADS is use instead of the N.

That test is rather newish and was added via Pull Req. #724

@seyonglee, @fel-cab, @spophale, @lthakur007 – please review.