### PR TITLE
Adding Regression and Stress Tests to the V&V

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,16 +3,26 @@ SHELL=/bin/bash -o pipefail
 # When using make alone show the help message
 .DEFAULT_GOAL:=help
 
+
+
 ###################################################
 # OpenMP Versions. This is to support multiple
 # versions of the standard in the same testsuite
 ###################################################
 OMP_VERSION?=4.5
+TEST_LOCATION:=tests/$(OMP_VERSION)
 TEST_FOLDER_EXISTS=$(shell if [ -d tests/$(OMP_VERSION) ]; then echo "exist";fi)
 ifeq "$(TEST_FOLDER_EXISTS)" ""
   $(error The OMP_VERSION=$(OMP_VERSION) does not exist in this testsuite)
 endif
 
+###################################################
+# System specific varibles can be specified
+# in the system files sys/system/###.def
+###################################################
+ifdef REGRESSION
+	TEST_LOCATION:=regression
+endif
 
 ###################################################
 # System specific varibles can be specified
@@ -83,9 +93,9 @@ endif
 
 ifneq "$(SOURCES)" ""
 # Obtain all the possible source files for C, CPP and Fortran
-SOURCES_C := $(shell find $(CURDIR)/tests/$(OMP_VERSION) -path "*$(SOURCES)" | grep "\.c$$")
-SOURCES_CPP := $(shell find $(CURDIR)/tests/$(OMP_VERSION) -path "*$(SOURCES)" | grep "\.cpp$$")
-SOURCES_F := $(shell find $(CURDIR)/tests/$(OMP_VERSION) -path "*$(SOURCES)" | grep "\(\.F90\|\.F95\|\.F03\|\.F\|\.FOR\)$$")
+SOURCES_C := $(shell find $(CURDIR)/$(TEST_LOCATION) -path "*$(SOURCES)" | grep "\.c$$")
+SOURCES_CPP := $(shell find $(CURDIR)/$(TEST_LOCATION) -path "*$(SOURCES)" | grep "\.cpp$$")
+SOURCES_F := $(shell find $(CURDIR)/$(TEST_LOCATION) -path "*$(SOURCES)" | grep "\(\.F90\|\.F95\|\.F03\|\.F\|\.FOR\)$$")
 $(info SOURCES = $(notdir $(SOURCES_C) $(SOURCES_CPP) $(SOURCES_F)))
 
 # Obtain the list of files that were previously
@@ -139,12 +149,12 @@ endif
 ifeq "$(SOURCES)" ""
 # Getting all the source files in the project
 ifdef LINK_OMPVV_LIB
-SOURCES_C := $(shell find $(CURDIR)/tests/$(OMP_VERSION) -name "*.c")
+SOURCES_C := $(shell find $(CURDIR)/$(TEST_LOCATION) -name "*.c")
 else
-SOURCES_C := $(shell find $(CURDIR)/tests/$(OMP_VERSION) ! -name qmcpack_target_static_lib.c -name "*.c")
+SOURCES_C := $(shell find $(CURDIR)/$(TEST_LOCATION) ! -name qmcpack_target_static_lib.c -name "*.c")
 endif
-SOURCES_CPP := $(shell find $(CURDIR)/tests/$(OMP_VERSION) -name "*.cpp")
-SOURCES_F := $(shell find $(CURDIR)/tests/$(OMP_VERSION) -name "*.F90" -o -name "*.F95" -o -name "*.F03" -o -name "*.F" -o -name "*.FOR" | grep -v "ompvv.F90")
+SOURCES_CPP := $(shell find $(CURDIR)/$(TEST_LOCATION) -name "*.cpp")
+SOURCES_F := $(shell find $(CURDIR)/$(TEST_LOCATION) -name "*.F90" -o -name "*.F95" -o -name "*.F03" -o -name "*.F" -o -name "*.FOR" | grep -v "ompvv.F90")
 
 # Find all the binary files that have been previously compiled
 TESTS_TO_RUN := $(shell test -d $(BINDIR) && \
@@ -198,6 +208,7 @@ endif
 
 .PHONY: all
 all: MessageDisplay $(ALL_DEP)
+	@echo $(TEST_LOCATION)
 	@echo "====COMPILE AND RUN DONE===="
 
 

--- a/regression/stress_tests/regression_distribute_for_collapse_N_TEAMS_N_THREADS.c
+++ b/regression/stress_tests/regression_distribute_for_collapse_N_TEAMS_N_THREADS.c
@@ -1,0 +1,98 @@
+//===--- regression_distribute_for_collapse_N_TEAMS_N_THREADS.c ----------------------------------------===//
+//
+// OpenMP API Version 4.5
+//
+// Test #pragma omp target teams distribute parallel for collapse() on an 
+// N_DIM*N_DIM*N_DIM*N_DIM array by writing to it. Testing on a gloabal 
+// array with at least 3-4 dimensions in order to do a for sollapse of
+// at least 3-4. To ensure that each write to array occurred only once.
+//
+////===----------------------------------------------------------------------===//
+
+#include <stdio.h>
+#include <omp.h>
+
+#ifndef DIM_SIZE
+#define DIM_SIZE 4
+#endif
+
+#ifndef N_THREADS
+#define N_THREADS 128
+#endif
+
+#ifndef N_TEAMS
+#define N_TEAMS 128
+#endif
+
+#ifndef COLLAPSE
+#define COLLAPSE 4
+#endif
+
+int calc_index(int dim_indices, int i, int j, int k, int l){
+  return dim_indices*dim_indices*dim_indices * i + dim_indices*dim_indices * j + dim_indices * k + l;
+}
+
+int test_collapse() {
+  int errors = 0;
+  int* teams = (int*)malloc(sizeof(int)*DIM_SIZE*DIM_SIZE*DIM_SIZE*DIM_SIZE);
+  int* threads = (int*)malloc(sizeof(int)*DIM_SIZE*DIM_SIZE*DIM_SIZE*DIM_SIZE);
+  int i,j,k,l;
+
+  if (teams == NULL || threads == NULL){
+    printf("malloc failed!\n");
+    return 1;
+  }
+
+  for (i = 0; i < DIM_SIZE*DIM_SIZE*DIM_SIZE*DIM_SIZE; ++i) {
+    teams[i] = -1;
+    threads[i] = -1;
+  }
+#pragma omp target teams distribute parallel for collapse(COLLAPSE) \
+  map(tofrom: teams[:DIM_SIZE*DIM_SIZE*DIM_SIZE*DIM_SIZE], \
+              threads[:DIM_SIZE*DIM_SIZE*DIM_SIZE*DIM_SIZE]) private(i,j,k,l) \
+  num_teams(N_TEAMS) num_threads(N_THREADS)
+
+  for (i = 0; i < DIM_SIZE; ++i) {
+    for (j = 0; j < DIM_SIZE; ++j) {
+      for (k = 0; k < DIM_SIZE; ++k) {
+        for (l = 0; l < DIM_SIZE; ++l) {
+          int index = calc_index(DIM_SIZE, i, j, k, l);
+          if(teams[index] == -1)
+            teams[index] = omp_get_team_num();
+          else
+            teams[index] = -2;
+          threads[index] = omp_get_thread_num();
+        }
+      }
+    }
+  }
+
+  for (i = DIM_SIZE-1; i < DIM_SIZE; ++i) {
+    for (j = DIM_SIZE-1; j < DIM_SIZE; ++j) {
+      for (k = DIM_SIZE-1; k < DIM_SIZE; ++k) {
+        for (l = DIM_SIZE-1; l < DIM_SIZE; ++l) {
+          int index = calc_index(DIM_SIZE, i, j, k, l);
+          printf("%d, %d, %d, %d, %d, %d, %d\n",i,j,k,l,index,teams[index],threads[index]); 
+        }
+      }
+    }
+  }
+
+  for (i = 0; i < DIM_SIZE*DIM_SIZE*DIM_SIZE*DIM_SIZE; ++i) {
+    if (teams[i] == -2) {
+      ++errors;
+      printf("MULTIPLE WRITES AT INDEX %d FOR teams ARRAY\n", i);
+    }
+  }
+
+  free(teams);
+  free(threads);
+  return errors;
+}
+
+
+int main() {
+  int errors = 0;
+  errors = test_collapse();
+  return errors;
+}

--- a/regression/threaded_data_transfer/regression_large_data_async_transfers.c
+++ b/regression/threaded_data_transfer/regression_large_data_async_transfers.c
@@ -1,0 +1,156 @@
+//===--- regression_large_data_async_transfers.c ------------------------------===//
+//
+// OpenMP API Version 4.5
+//
+// this tests performs asynchrous data transfer from the host to the device. this
+// test is mean to stress out the runtime by performing 8 asynchrous operations 
+// at once
+//
+// Routine being tested
+// omp_target_memcpy_async
+//
+// Author: Aaron Liu <olympus@udel.edu> Oct 2023
+////===----------------------------------------------------------------------===//
+
+#include <math.h>
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define N 32768
+#define number_of_threads 10000
+
+int main() {
+  int errors = 0;
+  int host = omp_get_initial_device();
+  int device = omp_get_default_device();
+
+  // allocate space on host & target
+  int array_size8 = N;
+  int array_size7 = (N * .875);
+  int array_size6 = (N * .750);
+  int array_size5 = (N * .635);
+  int array_size4 = (N * .500);
+  int array_size3 = (N * .375);
+  int array_size2 = (N * .250);
+  int array_size1 = (N * .125);
+
+  double *device_memory8 =
+      (double *)omp_target_alloc(sizeof(double) * array_size8, device);
+
+  double *host_memory8 = (double *)malloc(sizeof(double) * array_size8);
+  double *host_memory7 = (double *)malloc(sizeof(double) * array_size7);
+  double *host_memory6 = (double *)malloc(sizeof(double) * array_size6);
+  double *host_memory5 = (double *)malloc(sizeof(double) * array_size5);
+  double *host_memory4 = (double *)malloc(sizeof(double) * array_size4);
+  double *host_memory3 = (double *)malloc(sizeof(double) * array_size3);
+  double *host_memory2 = (double *)malloc(sizeof(double) * array_size2);
+  double *host_memory1 = (double *)malloc(sizeof(double) * array_size1);
+
+  for (int i; i < array_size4; i++) {
+    host_memory4[i] = i;
+    if (i < array_size3) {
+      host_memory3[i] = i;
+    }
+    if (i < array_size2) {
+      host_memory2[i] = i;
+    }
+    if (i < array_size1) {
+      host_memory1[i] = i;
+    }
+  }
+
+  /* copy to target */
+  omp_target_memcpy_async(device_memory8, host_memory8,
+                          sizeof(double) * array_size8, 0, 0, device, host, 0,
+                          NULL);
+
+#pragma omp target is_device_ptr(device_memory8) device(device)
+
+#pragma omp teams distribute parallel for num_threads(number_of_threads)
+  for (int i = 0; i < N; i++) {
+    device_memory8[i] = i * 2; // initialize data on device
+  }
+
+  /* copy to host */
+  omp_target_memcpy_async(host_memory8, device_memory8,
+                          sizeof(double) * array_size8, 0, 0, host, device, 0,
+                          NULL);
+  omp_target_memcpy_async(host_memory7, device_memory8,
+                          sizeof(double) * array_size7, 0, 0, host, device, 0,
+                          NULL);
+  omp_target_memcpy_async(host_memory6, device_memory8,
+                          sizeof(double) * array_size6, 0, 0, host, device, 0,
+                          NULL);
+  omp_target_memcpy_async(host_memory5, device_memory8,
+                          sizeof(double) * array_size5, 0, 0, host, device, 0,
+                          NULL);
+  omp_target_memcpy_async(host_memory4, device_memory8,
+                          sizeof(double) * array_size4, 0, 0, host, device, 0,
+                          NULL);
+  omp_target_memcpy_async(host_memory3, device_memory8,
+                          sizeof(double) * array_size3, 0, 0, host, device, 0,
+                          NULL);
+  omp_target_memcpy_async(host_memory2, device_memory8,
+                          sizeof(double) * array_size2, 0, 0, host, device, 0,
+                          NULL);
+  omp_target_memcpy_async(host_memory1, device_memory8,
+                          sizeof(double) * array_size1, 0, 0, host, device, 0,
+                          NULL);
+
+#pragma omp taskwait
+  for (int i = 0; i < N; i++) {
+    if (i < array_size8) {
+      if (host_memory8[i] != i * 2) {
+        errors += 1;
+      }
+    }
+    if (i < array_size7) {
+      if (host_memory7[i] != i * 2) {
+        errors += 1;
+      }
+    }
+    if (i < array_size6) {
+      if (host_memory6[i] != i * 2) {
+        errors += 1;
+      }
+    }
+    if (i < array_size5) {
+      if (host_memory5[i] != i * 2) {
+        errors += 1;
+      }
+    }
+    if (i < array_size4) {
+      if (host_memory4[i] != i * 2) {
+        errors += 1;
+      }
+    }
+    if (i < array_size3) {
+      if (host_memory3[i] != i * 2) {
+        errors += 1;
+      }
+    }
+    if (i < array_size2) {
+      if (host_memory2[i] != i * 2) {
+        errors += 1;
+      }
+    }
+    if (i < array_size1) {
+      if (host_memory1[i] != i * 2) {
+        errors += 1;
+      }
+    }
+  }
+  // free resources
+  free(host_memory8);
+  free(host_memory7);
+  free(host_memory6);
+  free(host_memory5);
+  free(host_memory4);
+  free(host_memory3);
+  free(host_memory2);
+  free(host_memory1);
+
+  omp_target_free(device_memory8, device);
+  return errors;
+} 

--- a/regression/threaded_data_transfer/regression_large_data_reduction.c
+++ b/regression/threaded_data_transfer/regression_large_data_reduction.c
@@ -1,0 +1,177 @@
+//===--- regression_large_data_reduction.c ----------------------------------===//
+//
+// OpenMP API Version 4.5
+//
+// this test 8 differently sized array using 10000 threads to perform +=, -=,
+// *=, |=, &=, and ^= reductions it peforms three sum reductions since i dont
+// know how to use && and || reductions
+//
+// Clause being tested
+// reduction
+//
+// Author: Aaron Liu <olympus@udel.edu> Oct 2023
+////===----------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define N 32768
+#define number_of_threads 10000
+
+int main() {
+  int error = 0;
+
+  int array_size8 = N;
+  int array_size7 = (N * .875);
+  int array_size6 = (N * .750);
+  int array_size5 = (N * .635);
+  // any larger whould cause a overflow
+  int array_size4 = 20;
+  int array_size3 = (N * .375);
+  int array_size2 = (N * .250);
+  int array_size1 = (N * .125);
+  int initialReductionValue = 1;
+
+  int array8[array_size8];
+  int hostReduction8 = initialReductionValue;
+  int deviceReduction8 = initialReductionValue;
+
+  int array7[array_size7];
+  int hostReduction7 = initialReductionValue;
+  int deviceReduction7 = initialReductionValue;
+
+  int array6[array_size6];
+  int hostReduction6 = initialReductionValue;
+  int deviceReduction6 = initialReductionValue;
+
+  int array5[array_size5];
+  int hostReduction5 = initialReductionValue;
+  int deviceReduction5 = initialReductionValue;
+
+  int array4[array_size4];
+  int hostReduction4 = initialReductionValue;
+  int deviceReduction4 = initialReductionValue;
+
+  int array3[array_size3];
+  int hostReduction3 = initialReductionValue;
+  int deviceReduction3 = initialReductionValue;
+
+  int array2[array_size2];
+  int hostReduction2 = initialReductionValue;
+  int deviceReduction2 = initialReductionValue;
+
+  int array1[array_size1];
+  int hostReduction1 = initialReductionValue;
+  int deviceReduction1 = initialReductionValue;
+
+  for (int x = 0; x < array_size8; x++) {
+    array8[x] = x;
+    hostReduction8 += x;
+    if (x < array_size7) {
+      array7[x] = x;
+      hostReduction7 += x;
+    }
+    if (x < array_size6) {
+      array6[x] = x;
+      hostReduction6 += x;
+    }
+    if (x < array_size5) {
+      array5[x] = x;
+      hostReduction5 -= x;
+    }
+    if (x != 0 && x < array_size4) {
+      array4[x] = x;
+      hostReduction4 *= x;
+    }
+    if (x < array_size3) {
+      array3[x] = x;
+      hostReduction3 &= x;
+    }
+    if (x < array_size2) {
+      array2[x] = x;
+      hostReduction2 |= x;
+    }
+    if (x < array_size1) {
+      array1[x] = x;
+      hostReduction1 ^= x;
+    }
+  }
+
+#pragma omp target parallel for num_threads(number_of_threads)                 \
+    map(to : array8[0 : array_size8], array7[0 : array_size7],                 \
+            array6[0 : array_size6], array5[0 : array_size5],                  \
+            array4[0 : array_size4], array3[0 : array_size3],                  \
+            array2[0 : array_size2], array1[0 : array_size1])                  \
+    reduction(+ : deviceReduction8) reduction(+ : deviceReduction7)            \
+    reduction(+ : deviceReduction6) reduction(- : deviceReduction5)            \
+    reduction(* : deviceReduction4) reduction(& : deviceReduction3)            \
+    reduction(| : deviceReduction2) reduction(^ : deviceReduction1)            \
+    map(tofrom : deviceReduction8, deviceReduction7, deviceReduction6,         \
+            deviceReduction5, deviceReduction4, deviceReduction3,              \
+            deviceReduction2, deviceReduction1)
+  for (int x = 0; x < array_size8; x++) {
+    deviceReduction8 += array8[x];
+
+    if (x < array_size7) {
+      deviceReduction7 += array7[x];
+    }
+    if (x < array_size6) {
+      deviceReduction6 += array6[x];
+    }
+
+    if (x < array_size5) {
+      deviceReduction5 -= array5[x];
+    }
+
+    if (x != 0 && x < array_size4) {
+      deviceReduction4 *= array4[x];
+    }
+    if (x < array_size3) {
+      deviceReduction3 &= array3[x];
+    }
+    if (x < array_size2) {
+      deviceReduction2 |= array2[x];
+    }
+    if (x < array_size1) {
+      deviceReduction1 ^= array1[x];
+    }
+  }
+
+  if (deviceReduction8 != hostReduction8) {
+    error += 1;
+  }
+  if (deviceReduction7 != hostReduction7) {
+    error += 1;
+  }
+  if (deviceReduction6 != hostReduction6) {
+    error += 1;
+  }
+  if (deviceReduction5 != hostReduction5) {
+    error += 1;
+  }
+  if (deviceReduction4 != hostReduction4) {
+    error += 1;
+  }
+  if (deviceReduction3 != hostReduction3) {
+    error += 1;
+  }
+  if (deviceReduction2 != hostReduction2) {
+    error += 1;
+  }
+  if (deviceReduction1 != hostReduction1) {
+    error += 1;
+  }
+
+  printf("program created %d amount of errors\n", error);
+  printf(" (^= Reduction) host = %d device = %d\n (|= Reduction) host = %d "
+         "device = %d\n (&= Reduction) host = %d device = %d\n (*= Reduction) "
+         "host = %d device = %d\n (-= Reduction) host = %d device = %d\n (+= "
+         "Reduction) host = %d device = %d\n (+= Reduction) host = %d device = "
+         "%d\n (+= Reduction) host = %d device = %d\n",
+         hostReduction1, deviceReduction1, hostReduction2, deviceReduction2,
+         hostReduction3, deviceReduction3, hostReduction4, deviceReduction4,
+         hostReduction5, deviceReduction5, hostReduction6, deviceReduction6,
+         hostReduction7, deviceReduction7, hostReduction8, deviceReduction8);
+  return error;
+}

--- a/regression/threaded_data_transfer/regression_large_data_transfers.c
+++ b/regression/threaded_data_transfer/regression_large_data_transfers.c
@@ -1,0 +1,156 @@
+//===--- regression_large_data_transfers.c ---------------------------------===//
+//
+// OpenMP API Version 4.5
+//
+// this is meant to test stress the runtime for the data transfers using 8 
+// differently sized arrays 
+//
+// Author: Aaron Liu <olympus@udel.edu> Oct 2023
+////===----------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define N 32768
+#define number_of_threads 10000
+
+int main() {
+  int error = 0;
+
+  int array_size8 = N;
+  int array_size7 = (N * .875);
+  int array_size6 = (N * .750);
+  int array_size5 = (N * .635);
+  int array_size4 = (N * .500);
+  int array_size3 = (N * .375);
+  int array_size2 = (N * .250);
+  int array_size1 = (N * .125);
+
+  int data8[array_size8];
+  int empty8[array_size8];
+
+  int data7[array_size7];
+  int empty7[array_size7];
+
+  int data6[array_size6];
+  int empty6[array_size6];
+
+  int data5[array_size5];
+  int empty5[array_size5];
+
+  int data4[array_size4];
+  int empty4[array_size4];
+
+  int data3[array_size3];
+  int empty3[array_size3];
+
+  int data2[array_size2];
+  int empty2[array_size2];
+
+  int data1[array_size1];
+  int empty1[array_size1];
+
+  for (int x = 0; x < array_size8; x++) {
+    data8[x] = x;
+    if (x < array_size7) {
+      data7[x] = x;
+    }
+    if (x < array_size6) {
+      data6[x] = x;
+    }
+    if (x < array_size5) {
+      data5[x] = x;
+    }
+    if (x < array_size4) {
+      data4[x] = x;
+    }
+    if (x < array_size3) {
+      data3[x] = x;
+    }
+    if (x < array_size2) {
+      data2[x] = x;
+    }
+    if (x < array_size1) {
+      data1[x] = x;
+    }
+  }
+
+#pragma omp target parallel for num_threads(number_of_threads)                 \
+    map(to : data8[0 : array_size8], data7[0 : array_size7],                   \
+            data6[0 : array_size6], data5[0 : array_size5],                    \
+            data4[0 : array_size4], data3[0 : array_size3],                    \
+            data2[0 : array_size2], data1[0 : array_size1])                    \
+    map(from : empty8[0 : array_size8], empty7[0 : array_size7],               \
+            empty6[0 : array_size6], empty5[0 : array_size5],                  \
+            empty4[0 : array_size4], empty3[0 : array_size3],                  \
+            empty2[0 : array_size2], empty1[0 : array_size1])
+  for (int x = 0; x < array_size8; x++) {
+    empty8[x] = data8[x];
+    if (x < array_size7) {
+      empty7[x] = data7[x];
+    }
+    if (x < array_size6) {
+      empty6[x] = data6[x];
+    }
+    if (x < array_size5) {
+      empty5[x] = data5[x];
+    }
+    if (x < array_size4) {
+      empty4[x] = data4[x];
+    }
+    if (x < array_size3) {
+      empty3[x] = data3[x];
+    }
+    if (x < array_size2) {
+      empty2[x] = data2[x];
+    }
+    if (x < array_size1) {
+      empty1[x] = data1[x];
+    }
+  }
+
+  for (int x = 0; x < array_size8; x++) {
+    if (data8[x] != empty8[x]) {
+      error += 1;
+    }
+    if (x < array_size7) {
+      if (data7[x] != empty7[x]) {
+        error += 1;
+      }
+    }
+    if (x < array_size6) {
+      if (data6[x] != empty6[x]) {
+        error += 1;
+      }
+    }
+    if (x < array_size5) {
+      if (data5[x] != empty5[x]) {
+        error += 1;
+      }
+    }
+    if (x < array_size4) {
+      if (data4[x] != empty4[x]) {
+        error += 1;
+      }
+    }
+    if (x < array_size3) {
+      if (data3[x] != empty3[x]) {
+        error += 1;
+      }
+    }
+    if (x < array_size2) {
+      if (data2[x] != empty2[x]) {
+        error += 1;
+      }
+    }
+    if (x < array_size1) {
+      if (data1[x] != empty1[x]) {
+        error += 1;
+      }
+    }
+  }
+
+  printf("program created %d amount of errors\n", error);
+  return error;
+}

--- a/regression/threaded_data_transfer/regression_large_data_transfers_reduction.c
+++ b/regression/threaded_data_transfer/regression_large_data_transfers_reduction.c
@@ -1,0 +1,229 @@
+//===--- regression_large_data_transfer_reduction.c --------------------------===//
+//
+// OpenMP API Version 4.5
+//
+// this test is meant to test the runtime for the reduction clause while also 
+// performing data transfers between the accelerator and the host
+//
+// Clause being tested
+// reduction (+=, -=, *=, |=, &=, ^=) 
+//
+// Author: Aaron Liu <olympus@udel.edu> Oct 2023
+////===----------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define N 32768
+#define number_of_threads 10000
+
+int main() {
+  int error = 0;
+
+  int array_size8 = N;
+  int array_size7 = (N * .875);
+  int array_size6 = (N * .750);
+  int array_size5 = (N * .635);
+  int array_size4 = (N * .500);
+  int MultiplcationSize = 20;
+  int array_size3 = (N * .375);
+  int array_size2 = (N * .250);
+  int array_size1 = (N * .125);
+  int initialReductionValue = 1;
+
+  int data8[array_size8];
+  int empty8[array_size8];
+  int hostReduction8 = initialReductionValue;
+  int deviceReduction8 = initialReductionValue;
+
+  int data7[array_size7];
+  int empty7[array_size7];
+  int hostReduction7 = initialReductionValue;
+  int deviceReduction7 = initialReductionValue;
+
+  int data6[array_size6];
+  int empty6[array_size6];
+  int hostReduction6 = initialReductionValue;
+  int deviceReduction6 = initialReductionValue;
+
+  int data5[array_size5];
+  int empty5[array_size5];
+  int hostReduction5 = initialReductionValue;
+  int deviceReduction5 = initialReductionValue;
+
+  int data4[array_size4];
+  int empty4[array_size4];
+  int hostReduction4 = initialReductionValue;
+  int deviceReduction4 = initialReductionValue;
+
+  int data3[array_size3];
+  int empty3[array_size3];
+  int hostReduction3 = initialReductionValue;
+  int deviceReduction3 = initialReductionValue;
+
+  int data2[array_size2];
+  int empty2[array_size2];
+  int hostReduction2 = initialReductionValue;
+  int deviceReduction2 = initialReductionValue;
+
+  int data1[array_size1];
+  int empty1[array_size1];
+  int hostReduction1 = initialReductionValue;
+  int deviceReduction1 = initialReductionValue;
+
+  for (int x = 0; x < array_size8; x++) {
+    data8[x] = x;
+    hostReduction8 += x;
+    if (x < array_size7) {
+      data7[x] = x;
+      hostReduction7 += x;
+    }
+    if (x < array_size6) {
+      data6[x] = x;
+      hostReduction6 += x;
+    }
+    if (x < array_size5) {
+      data5[x] = x;
+      hostReduction5 -= x;
+    }
+    if (x < array_size4) {
+      data4[x] = x;
+      if (x != 0 && x < MultiplcationSize) {
+        hostReduction4 *= x;
+      }
+    }
+    if (x < array_size3) {
+      data3[x] = x;
+      hostReduction3 &= x;
+    }
+    if (x < array_size2) {
+      data2[x] = x;
+      hostReduction2 |= x;
+    }
+    if (x < array_size1) {
+      data1[x] = x;
+      hostReduction1 ^= x;
+    }
+  }
+
+#pragma omp target parallel for num_threads(number_of_threads)                 \
+    map(to : data8[0 : array_size8], data7[0 : array_size7],                   \
+            data6[0 : array_size6], data5[0 : array_size5],                    \
+            data4[0 : array_size4], data3[0 : array_size3],                    \
+            data2[0 : array_size2], data1[0 : array_size1], MultiplcationSize) \
+    reduction(+ : deviceReduction8) reduction(+ : deviceReduction7)            \
+    reduction(+ : deviceReduction6) reduction(- : deviceReduction5)            \
+    reduction(* : deviceReduction4) reduction(& : deviceReduction3)            \
+    reduction(| : deviceReduction2) reduction(^ : deviceReduction1)            \
+    map(from : empty8[0 : array_size8], empty7[0 : array_size7],               \
+            empty6[0 : array_size6], empty5[0 : array_size5],                  \
+            empty4[0 : array_size4], empty3[0 : array_size3],                  \
+            empty2[0 : array_size2], empty1[0 : array_size1])                  \
+    map(tofrom : deviceReduction8, deviceReduction7, deviceReduction6,         \
+            deviceReduction5, deviceReduction4, deviceReduction3,              \
+            deviceReduction2, deviceReduction1)
+  for (int x = 0; x < array_size8; x++) {
+    deviceReduction8 += data8[x];
+    empty8[x] = data8[x];
+
+    if (x < array_size7) {
+      deviceReduction7 += data7[x];
+      empty7[x] = data7[x];
+    }
+    if (x < array_size6) {
+      deviceReduction6 += data6[x];
+      empty6[x] = data6[x];
+    }
+    if (x < array_size5) {
+      deviceReduction5 -= data5[x];
+      empty5[x] = data5[x];
+    }
+    if (x < array_size4) {
+      empty4[x] = data4[x];
+      if (x != 0 && x < MultiplcationSize) {
+        deviceReduction4 *= data4[x];
+      }
+    }
+    if (x < array_size3) {
+      deviceReduction3 &= data3[x];
+      empty3[x] = data3[x];
+    }
+    if (x < array_size2) {
+      deviceReduction2 |= data2[x];
+      empty2[x] = data2[x];
+    }
+    if (x < array_size1) {
+      deviceReduction1 ^= data1[x];
+      empty1[x] = data1[x];
+    }
+  }
+
+  for (int x = 0; x < array_size8; x++) {
+    if (empty8[x] != data8[x]) {
+      error += 1;
+    }
+    if (x < array_size7) {
+      if (empty7[x] != data7[x]) {
+        error += 1;
+      }
+    }
+    if (x < array_size6) {
+      if (empty6[x] != data6[x]) {
+        error += 1;
+      }
+    }
+    if (x < array_size5) {
+      if (empty5[x] != data5[x]) {
+        error += 1;
+      }
+    }
+    if (x < array_size4) {
+      if (empty4[x] != data4[x]) {
+        error += 1;
+      }
+    }
+    if (x < array_size3) {
+      if (empty3[x] != data3[x]) {
+        error += 1;
+      }
+    }
+    if (x < array_size2) {
+      if (empty2[x] != data2[x]) {
+        error += 1;
+      }
+    }
+    if (x < array_size1) {
+      if (empty1[x] != data1[x]) {
+        error += 1;
+      }
+    }
+  }
+
+  if (deviceReduction8 != hostReduction8) {
+    error += 1;
+  }
+  if (deviceReduction7 != hostReduction7) {
+    error += 1;
+  }
+  if (deviceReduction6 != hostReduction6) {
+    error += 1;
+  }
+  if (deviceReduction5 != hostReduction5) {
+    error += 1;
+  }
+  if (deviceReduction4 != hostReduction4) {
+    error += 1;
+  }
+  if (deviceReduction3 != hostReduction3) {
+    error += 1;
+  }
+  if (deviceReduction2 != hostReduction2) {
+    error += 1;
+  }
+  if (deviceReduction1 != hostReduction1) {
+    error += 1;
+  }
+
+  return error;
+}

--- a/regression/threaded_kernel_launch/regression_threaded_kernel_launch.c
+++ b/regression/threaded_kernel_launch/regression_threaded_kernel_launch.c
@@ -1,0 +1,102 @@
+//===--- regression_threaded_kernel_launch.c ----------------------------------------===//
+//
+// OpenMP API Version 4.5
+//
+// Create N number of threads and simultaensouly launch
+// various kernels. Ensure all kernels are executed correctly.
+//
+//
+// Author: Aaron Jarmusch <jarmusch@udel.edu> Jun 2023
+////===----------------------------------------------------------------------===//
+
+#include <stdio.h>
+#include "omp.h"
+#include "ompvv.h"
+
+#define N 1024 // NUmber of threads
+#define NUM_THREADS 8 //
+#define NUM_TEAMS 8 //
+#define NUM_KERNELS 200 // Number of Kernels to launch
+
+int kernel(int a, int b, int x)
+{
+    // Perform computations for the kernel
+    int total = a + b;
+
+    // printf("Kernel %d executed by thread %d\n", x, omp_get_thread_num());
+
+    return total;
+}
+
+int test_omp_thread_kernel(void)
+{
+    int a[N];
+    int b[N];
+    int total = 0;
+    int expect_total = 0;
+    int errors = 0;
+    int num_threads[N];
+    int num_total[N];
+
+    for (int x = 0; x < N; ++x) {
+        a[x] = 1;
+        b[x] = x;
+        num_total[x] = 0;
+        // num_threads[x] = -1;
+    }
+
+    // set the number of threads
+    omp_set_num_threads(128);
+
+    #pragma omp target data map(tofrom: num_total[0:NUM_KERNELS])
+    {
+        #pragma omp parallel for 
+
+            for (int i = 0; i < NUM_KERNELS; ++i)
+            {
+                #pragma omp target parallel for reduction(+:num_total[i])
+
+                    for (int x = 0; x < N; ++x) 
+                    {
+                        for (unsigned int y = 0; y < 0xfffff; ++y) {
+                        // total += kernel(a[x], b[x], x);
+                        num_total[i] += a[x] + b[x];
+                        // while(1){
+                        //     int c = c + 1;
+                        // }
+                        }
+                    }
+
+                // num_total[i] = total;
+                // printf("hello");
+            }
+
+    }
+    #pragma omp barrier 
+
+    for (int i = 0; i < NUM_KERNELS; ++i){
+        printf("%d\n", num_total[i]);
+    }
+
+    for (int x = 0; x < NUM_KERNELS; ++x) {
+        expect_total += a[x] + b[x];
+    }
+
+
+    OMPVV_TEST_AND_SET_VERBOSE(errors, expect_total != total);
+    printf("Total from loop directive is %d but expected total is %d.\n", total, expect_total);
+    OMPVV_ERROR_IF(expect_total != total, "Total from loop directive is %d but expected total is %d.", total, expect_total);
+
+    return errors;
+}
+
+int main(void)
+{
+    OMPVV_TEST_OFFLOADING;
+    int errors = 0;
+
+    OMPVV_TEST_AND_SET_VERBOSE(errors, test_omp_thread_kernel() != 0);
+
+    // No error will be reported even if it is recorded.
+    OMPVV_REPORT_AND_RETURN(errors);
+}


### PR DESCRIPTION
We added a regression folder with regression and stress tests. We updated the makefile to include a flag `REGRESSION=1` if you want to run the regression tests. By default `REGRESSION` is assigned to 0 thus omitting all regression tests during the run. 

We tested this change on Frontier and Perlmutter without issues during the run. 