### PR TITLE
Add new_test/5.1/target/test_target_thread_limit

### DIFF
--- a/tests/5.1/target/test_target_thread_limit.F90
+++ b/tests/5.1/target/test_target_thread_limit.F90
@@ -1,0 +1,69 @@
+!===--- test_target_thread_limit.F90 --------------------------===//
+!
+! OpenMP API Version 5.1 Nov 2020
+!
+! This test uses the thread_limit clause on the target construct. Specifically
+! testing if a thread_limit on a target construct properly carries
+! down to the nested teams construct, as if it were directly on the construct
+! as defined in the spec. The test validates that only the specified 
+! threads are created by summing a shared variable across all threads 
+! (and teams). If the threads are correctly limited, this should produce the
+! expected value. Additional warnings are sent if specific issues occur.
+!
+!//===----------------------------------------------------------------------===//
+#include "ompvv.F90"
+
+#define N 1024
+
+PROGRAM test_target_thread_limit
+  USE iso_fortran_env
+  USE ompvv_lib
+  USE omp_lib
+  implicit none
+  OMPVV_TEST_OFFLOADING
+
+  OMPVV_TEST_VERBOSE(test_thread_limit() .NE. 0)
+
+  OMPVV_REPORT_AND_RETURN()
+
+CONTAINS
+  INTEGER FUNCTION test_thread_limit()
+    INTEGER :: errors(OMPVV_NUM_TEAMS_DEVICE)
+    INTEGER :: num_teams, i, sum_errors
+    INTEGER :: testing_thread_limit
+
+    sum_errors = 0
+    testing_thread_limit = OMPVV_NUM_THREADS_DEVICE/OMPVV_NUM_TEAMS_DEVICE
+    IF (testing_thread_limit .EQ. 1) THEN
+        testing_thread_limit = 2
+    END IF
+
+    DO i=1, OMPVV_NUM_TEAMS_DEVICE
+        errors(i) = 0
+    END DO
+
+    !$omp target map(tofrom: num_teams,errors) thread_limit(testing_thread_limit)
+    !$omp teams num_teams(OMPVV_NUM_TEAMS_DEVICE)
+    !$omp parallel
+    IF ((omp_get_team_num() .EQ. 0) .AND. (omp_get_thread_num() .EQ. 0)) THEN
+        num_teams = omp_get_num_teams()
+    END IF 
+    IF ((omp_get_thread_num() .EQ. 0) .AND. (omp_get_team_num() .LT. OMPVV_NUM_TEAMS_DEVICE)) THEN
+        IF (omp_get_num_threads() .GT. testing_thread_limit) THEN
+            errors(omp_get_team_num()+1) = errors(omp_get_team_num()+1) + 1
+        END IF
+    END IF
+    !$omp end parallel
+    !$omp end teams
+    !$omp end target
+
+    DO i=1, OMPVV_NUM_TEAMS_DEVICE
+        sum_errors = sum_errors + errors(i)
+    END DO
+
+    OMPVV_WARNING_IF(num_teams .NE. OMPVV_NUM_TEAMS_DEVICE, "The number of teams was unexpected, the test results are likely inconclusive")
+    OMPVV_WARNING_IF(testing_thread_limit .EQ. 1, "Only one thread was allocated to each team, the test results are likely inconclusive")
+
+    test_thread_limit = sum_errors
+  END FUNCTION test_thread_limit
+END PROGRAM test_target_thread_limit

--- a/tests/5.1/target/test_target_thread_limit.c
+++ b/tests/5.1/target/test_target_thread_limit.c
@@ -1,0 +1,66 @@
+//===---------------- test_target_thread_limit.c -----------------------===//
+//
+// OpenMP API Version 5.1 Nov 2020
+//
+// This test uses the thread_limit clause on the target construct. Specifically
+// testing if a thread_limit on a target construct properly carries
+// down to the nested teams construct, as if it were directly on the construct
+// as defined in the spec. The test validates that only the specified 
+// threads are created by summing a shared variable across all threads 
+// (and teams). If the threads are correctly limited, this should produce the
+// expected value. Additional warnings are sent if specific issues occur.
+//
+////===----------------------------------------------------------------------===//
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "ompvv.h"
+
+#define N 1024
+
+int main() {
+	int errors[OMPVV_NUM_TEAMS_DEVICE];
+	int num_teams = 0;
+        int sum_errors = 0;
+        int i;
+	int testing_thread_limit = OMPVV_NUM_THREADS_DEVICE/OMPVV_NUM_TEAMS_DEVICE;
+
+	if (testing_thread_limit == 1)
+	  testing_thread_limit = 2;
+
+	OMPVV_TEST_OFFLOADING;
+      
+
+         for (i = 0; i<OMPVV_NUM_TEAMS_DEVICE; i++){
+              errors[i] = 0;
+         }
+ 
+	#pragma omp target map(tofrom:num_teams,errors) thread_limit(testing_thread_limit)
+	{
+		#pragma omp teams num_teams(OMPVV_NUM_TEAMS_DEVICE) 
+		{
+			#pragma omp parallel
+			{
+				if (omp_get_team_num() == 0 && omp_get_thread_num() == 0) {
+					num_teams = omp_get_num_teams();
+				}
+
+                if ((omp_get_thread_num() == 0) && (omp_get_team_num() < OMPVV_NUM_TEAMS_DEVICE)) {			
+					if (omp_get_num_threads() > testing_thread_limit) {
+						errors[omp_get_team_num()] += 1;
+					}
+				}
+			}
+		}
+
+	}
+	for (i = 0; i<OMPVV_NUM_TEAMS_DEVICE; i++){
+             sum_errors += errors[i];
+        }
+
+	OMPVV_WARNING_IF(num_teams != OMPVV_NUM_TEAMS_DEVICE, "The number of teams was unexpected, the test results are likely inconclusive");
+	OMPVV_WARNING_IF(testing_thread_limit == 1, "Only one thread was allocated to each team, the test results are likely inconclusive");
+
+	OMPVV_REPORT_AND_RETURN(sum_errors);
+}


### PR DESCRIPTION
This is a copy-and-renamed version of the following tests from PR #770:
    tests/5.1/teams/test_target_teams_thread_limit.c
    tests/5.1/teams/test_target_teams_thread_limit.c

[Results on Summit]
- GCC 13.1.1:
    - Both C and Fortran tests passed.  
- XL 16.1.1-10:
    - C test passed but ran on the host with the following warning: The number of teams was unexpected, the test results are likely inconclusive
    - Fortran test failed: line 45.48: 1515-022 (S) Syntax Error: Extra token " thread_limit " was found. The token is ignored.
- NVHPC 22.11:
    - C test failed: line 39: error: invalid text in pragma
        #pragma omp target map(tofrom:num_teams,errors) thread_limit(testing_thread_limit)
    - Fortran test failed: NVFORTRAN-S-0533-Clause 'THREAD_LIMIT' not allowed in OMP TARGET 
- LLVM 17.0.0:
    - C test passed.
