### PR TITLE
Change the memory-order-clause in atomic fail tests to seq_cst.

### DIFF
--- a/tests/5.1/atomic/test_atomic_fail_acquire.F90
+++ b/tests/5.1/atomic/test_atomic_fail_acquire.F90
@@ -26,7 +26,6 @@ CONTAINS
   INTEGER FUNCTION test_atomic_fail_acquire()
     INTEGER:: errors, x, y
     INTEGER:: thrd
-    INTEGER:: tmp
 
     errors = 0
     x = 0
@@ -34,7 +33,7 @@ CONTAINS
 
     OMPVV_INFOMSG("test_atomic_fail_acquire")
 
-    !$omp parallel num_threads(2) private(thrd, tmp)
+    !$omp parallel num_threads(2) private(thrd)
     thrd = omp_get_thread_num()
     IF( thrd .EQ. 0 ) THEN
       y = 1
@@ -42,7 +41,6 @@ CONTAINS
       x = 10
       !$omp end atomic
     ELSE
-      tmp = 0
       DO WHILE ( y .NE. 5 )
         !$omp atomic compare seq_cst fail(acquire)
         IF (y == 1) THEN

--- a/tests/5.1/atomic/test_atomic_fail_acquire.F90
+++ b/tests/5.1/atomic/test_atomic_fail_acquire.F90
@@ -38,7 +38,7 @@ CONTAINS
     thrd = omp_get_thread_num()
     IF( thrd .EQ. 0 ) THEN
       y = 1
-      !$omp atomic write release 
+      !$omp atomic write seq_cst 
       x = 10
       !$omp end atomic
     ELSE

--- a/tests/5.1/atomic/test_atomic_fail_acquire.c
+++ b/tests/5.1/atomic/test_atomic_fail_acquire.c
@@ -29,7 +29,6 @@ int test_atomic_fail_acquire() {
           #pragma omp atomic write seq_cst
           x = 10;
        } else {
-          int tmp = 0;
           while (y != 5) {
             #pragma omp atomic compare seq_cst fail(acquire)
             if(y == 1){

--- a/tests/5.1/atomic/test_atomic_fail_acquire.c
+++ b/tests/5.1/atomic/test_atomic_fail_acquire.c
@@ -26,7 +26,7 @@ int test_atomic_fail_acquire() {
       int thrd = omp_get_thread_num();
        if (thrd == 0) {
           y = 1;
-          #pragma omp atomic write release // or seq_cst
+          #pragma omp atomic write seq_cst
           x = 10;
        } else {
           int tmp = 0;

--- a/tests/5.1/atomic/test_atomic_fail_relaxed.F90
+++ b/tests/5.1/atomic/test_atomic_fail_relaxed.F90
@@ -26,7 +26,6 @@ CONTAINS
   INTEGER FUNCTION test_atomic_fail_relaxed()
     INTEGER:: errors, x, y
     INTEGER:: thrd
-    INTEGER:: tmp
 
     errors = 0
     x = 0
@@ -34,7 +33,7 @@ CONTAINS
 
     OMPVV_INFOMSG("test_atomic_fail_relaxed")
 
-    !$omp parallel num_threads(2) private(thrd, tmp)
+    !$omp parallel num_threads(2) private(thrd)
     thrd = omp_get_thread_num()
     IF( thrd .EQ. 0 ) THEN
       y = 1
@@ -42,7 +41,6 @@ CONTAINS
       x = 10
       !$omp end atomic
     ELSE
-      tmp = 0
       DO WHILE ( y .NE. 5 )
         !$omp atomic compare fail(relaxed)
         IF (y == 1) THEN

--- a/tests/5.1/atomic/test_atomic_fail_relaxed.F90
+++ b/tests/5.1/atomic/test_atomic_fail_relaxed.F90
@@ -38,7 +38,7 @@ CONTAINS
     thrd = omp_get_thread_num()
     IF( thrd .EQ. 0 ) THEN
       y = 1
-      !$omp atomic write release 
+      !$omp atomic write seq_cst 
       x = 10
       !$omp end atomic
     ELSE

--- a/tests/5.1/atomic/test_atomic_fail_relaxed.c
+++ b/tests/5.1/atomic/test_atomic_fail_relaxed.c
@@ -29,7 +29,6 @@ int test_atomic_fail_relaxed() {
           #pragma omp atomic write seq_cst
           x = 10;
        } else {
-          int tmp = 0;
           while (y != 5) {
             #pragma omp atomic compare fail(relaxed)
             if(y == 1){

--- a/tests/5.1/atomic/test_atomic_fail_relaxed.c
+++ b/tests/5.1/atomic/test_atomic_fail_relaxed.c
@@ -26,7 +26,7 @@ int test_atomic_fail_relaxed() {
       int thrd = omp_get_thread_num();
        if (thrd == 0) {
           y = 1;
-          #pragma omp atomic write release // or seq_cst
+          #pragma omp atomic write seq_cst
           x = 10;
        } else {
           int tmp = 0;

--- a/tests/5.1/atomic/test_atomic_fail_seq_cst.c
+++ b/tests/5.1/atomic/test_atomic_fail_seq_cst.c
@@ -26,7 +26,7 @@ int test_atomic_fail_seq_cst() {
       int thrd = omp_get_thread_num();
        if (thrd == 0) {
           y = 1;
-          #pragma omp atomic write release // or seq_cst
+          #pragma omp atomic write seq_cst
           x = 10;
        } else {
           int tmp = 0;

--- a/tests/5.1/atomic/test_atomic_fail_seq_cst.c
+++ b/tests/5.1/atomic/test_atomic_fail_seq_cst.c
@@ -29,7 +29,6 @@ int test_atomic_fail_seq_cst() {
           #pragma omp atomic write seq_cst
           x = 10;
        } else {
-          int tmp = 0;
           while (y != 5) {
             #pragma omp atomic compare acquire fail(seq_cst)
             if(y == 1){


### PR DESCRIPTION
This PR changes the memory-order clause used in the `atomic write` directive of atomic fail tests to `seq_cst`.
The atomic fail tests in `tests/5.1/atomic` directory rely on flush synchronization between implicit release flush and acquire flush. However, the original implementations didn't have the correct dependency because the `atomic write` construct and `atomic compare` construct worked on different variables. Therefore, the memory-order clause in the `atomic write` construct is changed to `seq_cst` to enforce flush dependency. 