### PR TITLE
Add (int*) cast to malloc to avoid C++ errors

### DIFF
--- a/tests/5.0/target/test_target_firstprivate_device.c
+++ b/tests/5.0/target/test_target_firstprivate_device.c
@@ -15,7 +15,7 @@
 
 
 int Runtst(int gpu) {
-  int *A = malloc(sizeof(int) * ELMTS), errors = 0;
+  int *A = (int*) malloc(sizeof(int) * ELMTS), errors = 0;
   if (A == NULL) {
     OMPVV_ERROR("Memory allocation failed");
     return 1;

--- a/tests/5.0/target/test_target_parallel_if_device.c
+++ b/tests/5.0/target/test_target_parallel_if_device.c
@@ -13,8 +13,8 @@
 
 
 int Runtst(int gpu, int Proc) { // Proc = 0(host), 1(gpu)
-  int *A = malloc(sizeof(int) * N), Errors = 0;
-  int *InitDev = malloc(sizeof(int));
+  int *A = (int*) malloc(sizeof(int) * N), Errors = 0;
+  int *InitDev = (int*) malloc(sizeof(int));
   for (int i = 0; i < N; ++i) {
     A[i] = i;
   }

--- a/tests/5.0/target/test_target_parallel_is_dev_ptr.c
+++ b/tests/5.0/target/test_target_parallel_is_dev_ptr.c
@@ -13,7 +13,7 @@
 #define N 1024
 
 int Runtst(int gpu) {
-  int *Hst_A = malloc(sizeof(int) * N);
+  int *Hst_A = (int*)malloc(sizeof(int) * N);
   int *Dev_B = (int*)omp_target_alloc(sizeof(int) * N, gpu);
   int errors = 0;
   for (int i = 0; i < N; ++i) {

--- a/tests/5.0/target/test_target_parallel_linear.c
+++ b/tests/5.0/target/test_target_parallel_linear.c
@@ -15,7 +15,7 @@
 
 
 int Runtst(int gpu) {
-  int *A = malloc(sizeof(int) * N), errors = 0;
+  int *A = (int *) malloc(sizeof(int) * N), errors = 0;
   for (int i = 0; i < N; ++i) {
     A[i] = i;
   }

--- a/tests/5.0/target/test_target_parallel_reduction.c
+++ b/tests/5.0/target/test_target_parallel_reduction.c
@@ -12,8 +12,8 @@
 #define N 1024*32
 
 int Runtst(int gpu) {
-  int *A = malloc(sizeof(int) * N);
-  int *B = malloc(sizeof(int) * N);
+  int *A = (int *) malloc(sizeof(int) * N);
+  int *B = (int *) malloc(sizeof(int) * N);
   int errors = 0;
   for (int i = 0; i < N; ++i) {
     A[i] = i;

--- a/tests/5.1/target_update/test_target_update_iterator.c
+++ b/tests/5.1/target_update/test_target_update_iterator.c
@@ -26,7 +26,7 @@ typedef struct test_struct{
 
 void init(struct test_struct *s ){
     s->len = N;
-    s->data = malloc(sizeof(int) * N);
+    s->data = (int *) malloc(sizeof(int) * N);
     for(size_t i = 0; i < s->len; i++){
         s->data[i] = i;
     }


### PR DESCRIPTION
While the C compiler happy accepts the assignment of the void* returning malloc call, C++ compilers reject the void* to int* cast. Hence, add the cast such that those tests also compile with C++.

@fel-cab @spophale