### PR TITLE
Fix fixed-form Fortran quote and line-length issues

### DIFF
--- a/ompvv/ompvv.F
+++ b/ompvv/ompvv.F
@@ -270,10 +270,12 @@
      &        TRIM(clean_fn(__FILE__)), __LINE__, TRIM(message2dis)
           !OMPVV_INFOMSG(message2dis)
           IF (ompvv_isHost) THEN
-            WRITE(*,OMPVV_HEADER_RESULT_FMT) TRIM(clean), "failed", 
+            WRITE(*,OMPVV_HEADER_RESULT_FMT)
+     &      TRIM(clean), "failed",
      &      "host"
           ELSE
-            WRITE(*,OMPVV_HEADER_RESULT_FMT) TRIM(clean), "failed", 
+            WRITE(*,OMPVV_HEADER_RESULT_FMT)
+     &      TRIM(clean), "failed",
      &      "device"
           END IF
         ELSE
@@ -282,10 +284,12 @@
      &        TRIM("Test ran with no errors")
           !OMPVV_INFOMSG("Test ran with no errors")
           IF (ompvv_isHost) THEN
-            WRITE(*,OMPVV_HEADER_RESULT_FMT) TRIM(clean), "passed", 
+            WRITE(*,OMPVV_HEADER_RESULT_FMT)
+     &      TRIM(clean), "passed",
      &      "host"
           ELSE
-            WRITE(*,OMPVV_HEADER_RESULT_FMT) TRIM(clean), "passed", 
+            WRITE(*,OMPVV_HEADER_RESULT_FMT)
+     &      TRIM(clean), "passed",
      &      "device"
           END IF
         END IF
@@ -340,9 +344,9 @@
         INTEGER ln
 #ifdef VERBOSE_MODE
         CHARACTER(len=*) msg
-        PARAMETER (msg = "This tests is running on 
-     &   a shared data environment between host and device. This may 
-     &   cause errors")
+        PARAMETER (msg = "This tests is running on " //
+     &   "a shared data environment between host and device. This " //
+     &   "may cause errors")
 #endif
 
         clean = TRIM(clean_fn(fn))
@@ -353,11 +357,13 @@
 
         call test_shared_environment_probe(ompvv_sharedEnv)
 
+#ifdef VERBOSE_MODE
         IF (ompvv_sharedEnv) THEN
           !OMPVV_WARNING_HELPER(msg, clean, ln)
           WRITE(*, OMPVV_HEADER_FMT(OMPVV_WARNING)) 
      &     TRIM(clean_fn(__FILENAME__)), __LINE__, TRIM(msg)
         END IF
+#endif
       end subroutine test_shared_environment
 
       function test_and_set_shared_environment(fn, ln)

--- a/tests/5.2/implementation_defined/test_omx_fixed.F
+++ b/tests/5.2/implementation_defined/test_omx_fixed.F
@@ -27,7 +27,7 @@
         !OMPVV_TEST_OFFLOADING
         ! Not using the macros, since tested compilers
         ! do not support them
-        ! __FILE__ doesn't work
+        ! __FILE__ does not work
         call test_offloading("test_ompx.F", __LINE__)
 
         res = test_fixed_omx()


### PR DESCRIPTION
_Follow up to Pull Req. #616_

The C preprocessor (cpp alias fpp) preprocessing fails here with:
```
ompvv/ompvv.F:343:26: warning: missing terminating " character
  343 |         PARAMETER (msg = "This tests is running on
      |                          ^
...
tests/5.2/implementation_defined/test_omx_fixed.F:30:25: warning: missing terminating ' character
   30 |         ! __FILE__ doesn't work
      |                         ^
```
which was fixed by adding some more `"` and `" //` to the code and avoiding the `'` in the comment.

Additionally, without `VERBOSE_MODE`, the `msg` was not defined which caused errors due to `implicit none`; I now also enclose the user of `msg` in the `#ifdef` - alternatively, the declaration `#ifdef` could be removed.

And with `VERBOSE_MODE`, some lines were exceeding the 72 characters limits of fixed-form Fortran. Solution: some shifting of words and line breaks.

@krishols @spophale @fel-cab @nolanbaker31 — please review.