### PR TITLE
Fix target_parallel_loop_bind.c + target_teams_loop_defaultmap.c

### DIFF
--- a/tests/5.0/target_parallel_loop/test_target_parallel_loop_bind.c
+++ b/tests/5.0/target_parallel_loop/test_target_parallel_loop_bind.c
@@ -33,7 +33,7 @@ int test_target_parallel_loop_bind() {
   }
 
 #pragma omp target parallel loop bind(parallel) map(tofrom: arr) \
-                       num_threads(OMPVV_NUM_THREADS_DEVICE)
+                       num_threads(OMPVV_NUM_THREADS_DEVICE) private(j,k)
   for (i = 0; i < DIM_1; i++) {
     for (j = 0; j < DIM_2; j++) {
       for (k = i; k < DIM_3; k++) {

--- a/tests/5.0/teams_loop/test_target_teams_loop_defaultmap.c
+++ b/tests/5.0/teams_loop/test_target_teams_loop_defaultmap.c
@@ -159,7 +159,7 @@ int testDefaultMapToFromAggr() {
 int testDefaultMapToFromScalar() {
   int errors = 0;
   int x = 0;
-#pragma omp target teams loop defaultmap(tofrom:scalar)
+#pragma omp target teams loop defaultmap(tofrom:scalar) reduction(+:x)
   for (int i = 0; i < N; i++) {
     x += i;
   }


### PR DESCRIPTION
_Follow up to Pull Req. #784 and #761_

* **tests/5.0/target_parallel_loop/test_target_parallel_loop_bind.c:** Contrary to Fortran, loop variables not associated with the OpenMP construct are not implicitly `private`. There are three solutions: `collapse(3)`, declaring the variable inside the `for` statement (`for (int j = ...`) or to explicitly use a `private` clause; this commit does the latter.

* **tests/5.0/teams_loop/test_target_teams_loop_defaultmap.c:** When updating the same part of a in multiple loops as in `testDefaultMapToFromScalar`, there is a race. Solution: `#pragma omp atomic update` or `reduction(+:x)`. However, as `atomic` is only permitted since the second preview for OpenMP 6.0 (i.e. TR12), this commit uses the reduction. _(The restriction is a bit hidden: It is for the `order` clause and `loop` implies `order(concurrent)`.)_

@spophale , @seyonglee, @fel-cab – please review.
 @ronlieb – likewise, if you want, given that looked at the test_target_parallel_loop_bind.c testcase in #784.