### PR TITLE
Fix test_target_defaultmap_present_pointer.F90

### DIFF
--- a/tests/5.1/target/test_target_defaultmap_present_pointer.F90
+++ b/tests/5.1/target/test_target_defaultmap_present_pointer.F90
@@ -48,7 +48,7 @@ CONTAINS
         ptr(i) = i + 2
     END DO
     !$omp end target
-    !$omp target exit data map(delete: ptr)
+    !$omp target exit data map(from: ptr)
 
     OMPVV_ERROR_IF(errors .GT. 0, "Values were not mapped to the device properly")
 


### PR DESCRIPTION
Follow up to Pull Request #711, which added this testcase.

The problem is that using ...
```F90
    !$omp target enter data map(to: ptr)
    !$omp target map(tofrom: errors) defaultmap(present:pointer)
        ...
        ptr(i) = i + 2
        ...
    !$omp end target
    !$omp target exit data map(delete: ptr)
```
... the data is not copied back to the device. This will only work if either host fallback is done – or `map(to: ptr)` is a _self_ map. Solution is to copy it back, e.g. `map(from:` as done in this commit or to use `!$omp target update from(ptr)`.

@spophale @fel-cab @andrewkallai @seyonglee