### PR TITLE
Fixing bug of test_target_memcpy_async_no_obj.c

### DIFF
--- a/tests/5.1/target/test_target_memcpy_async_no_obj.c
+++ b/tests/5.1/target/test_target_memcpy_async_no_obj.c
@@ -43,6 +43,8 @@ int test_target_memcpy_async_no_obj() {
                                 t,          h,
                                 0,          NULL);
 
+    #pragma omp taskwait
+
     #pragma omp target is_device_ptr(mem_dev_cpy) device(t)
     #pragma omp teams distribute parallel for
     for(i = 0; i < N; i++){


### PR DESCRIPTION
Fixing bug reported on issue #795

Adding `#pragma omp taskwait` after `omp_target_memcpy_async`
