### PR TITLE
Fixing a possible Deadlock when run parallel on SPMD mod

### DIFF
--- a/tests/5.0/target_requires/test_target_requires_atomic_default_mem_order_acq_rel.c
+++ b/tests/5.0/target_requires/test_target_requires_atomic_default_mem_order_acq_rel.c
@@ -15,17 +15,15 @@
 #include <stdlib.h>
 #include "ompvv.h"
 
-#define N 1024
-
 #pragma omp requires atomic_default_mem_order(acq_rel)
 
 int test_target_requires_atomic_acq_rel() {
   OMPVV_INFOMSG("test_target_requires_atomic_acq_rel");
 
   int x = 0, y = 0;
-  int errors = 0;
+  int errors = 0, tmp = 0;
       
-#pragma omp target parallel num_threads(2) map(tofrom: x, y, errors)
+#pragma omp target parallel num_threads(2) map(tofrom: x, y, errors) map(to: tmp)
    {
        int thrd = omp_get_thread_num();
        if (thrd == 0) {
@@ -33,7 +31,20 @@ int test_target_requires_atomic_acq_rel() {
           #pragma omp atomic write 
           y = 1;
        } else {
-          int tmp = 0;
+         tmp = 0;
+       }
+
+       // Instead of a else as in the original test, a separated if was included
+       // Given that the Device can be executed on SPMD, it is
+       // possible that the else can be executed first by all threads
+       // generating a deadlock on the while
+       // furthermore, it also necesary to create an else, with 
+       // a shared variable to prevent the optimizer to marge the
+       // if and have the same problem than before
+       // therefore a separated if is geenrated for the code
+       // and this way it is possible to guarantee that there is
+       // no deadlock on the while
+       if (thrd == 1) {
           while (tmp == 0) {
             #pragma omp atomic read 
             tmp = y;

--- a/tests/5.0/target_requires/test_target_requires_atomic_default_mem_order_relaxed.c
+++ b/tests/5.0/target_requires/test_target_requires_atomic_default_mem_order_relaxed.c
@@ -24,9 +24,9 @@ int test_target_requires_atomic_relaxed() {
   OMPVV_INFOMSG("test_target_requires_atomic_relaxed");
 
   int x = 0, y = 0;
-  int errors = 0;
+  int errors = 0, tmp = 0;
 
-#pragma omp target parallel num_threads(2) map(tofrom: x, y, errors)
+#pragma omp target parallel num_threads(2) map(tofrom: x, y, errors) map(to: tmp)
    {
       int thrd = omp_get_thread_num();
        if (thrd == 0) {
@@ -35,7 +35,20 @@ int test_target_requires_atomic_relaxed() {
           #pragma omp atomic write 
           y = 1;
        } else {
-          int tmp = 0;
+          tmp = 0;
+       }
+
+       // Instead of a else as in the original test, a separated if was included      
+       // Given that the Device can be executed on SPMD, it is
+       // possible that the else can be executed first by all threads
+       // generating a deadlock on the while
+       // furthermore, it also necesary to create an else, with
+       // a shared variable to prevent the optimizer to marge the
+       // if and have the same problem than before
+       // therefore a separated if is geenrated for the code
+       // and this way it is possible to guarantee that there is
+       // no deadlock on the while
+       if (thrd == 1) {
           while (tmp == 0) {
             #pragma omp atomic read 
             tmp = y;


### PR DESCRIPTION
Instead of an `else` as in the original tests, a separated `if` was included for the `while` loop, Given that the code in the Device can be executed on SPMD, it is possible that the `else` can be executed first by all threads generating a deadlock on the `while`.

Furthermore, it also necessary to create an `else`, with a shared variable to prevent the optimizer to marge the `if` and to have the same problem than before.

Therefore a separated `if` is generated for the code and this way it is possible to guarantee that there is no deadlock on the `while`.
