### PR TITLE
Add uses_allocators to fix compiler error

### DIFF
--- a/tests/5.0/target/test_target_allocate.c
+++ b/tests/5.0/target/test_target_allocate.c
@@ -24,7 +24,7 @@ int test_target_allocate() {
       host_result += i;
    }
    
-   #pragma omp target allocate(omp_default_mem_alloc:x) firstprivate(x) map(from: device_result)
+   #pragma omp target uses_allocators(omp_default_mem_alloc) allocate(omp_default_mem_alloc:x) firstprivate(x) map(from: device_result)
    {
       for (int i = 0; i < N; i++) {
          x += i;


### PR DESCRIPTION
LLVM error: 
`error: allocator must be specified in the 'uses_allocators' clause`
adding `uses_allocators(omp_default_mem_alloc)` fixes the problem

