### PR TITLE
Allow not expected result for const allocator

### DIFF
--- a/tests/5.0/target/test_target_uses_allocators_const.c
+++ b/tests/5.0/target/test_target_uses_allocators_const.c
@@ -39,7 +39,8 @@ int test_uses_allocators_const() {
   device_result = x;
 }
 
-  OMPVV_TEST_AND_SET_VERBOSE(errors, result != device_result);
+  OMPVV_WARNING_IF(result != device_result,"Variable x may have been assigned to const memory space and device_result wasn't updated to the expected value, but it is correct");
+  OMPVV_WARNING_IF(result == device_result,"Variable x may or may not have been assigned to const memory space but device_result was updated to the expected value");
 
   return errors;
 }

--- a/tests/5.0/target/test_target_uses_allocators_const.c
+++ b/tests/5.0/target/test_target_uses_allocators_const.c
@@ -29,7 +29,7 @@ int test_uses_allocators_const() {
     }
   }
 
-#pragma omp target uses_allocators(omp_const_mem_alloc) allocate(omp_const_mem_alloc: x) firstprivate(x) map(from: device_result) map(tofrom: device_result)
+#pragma omp target uses_allocators(omp_const_mem_alloc) allocate(omp_const_mem_alloc: x) firstprivate(x) map(tofrom: device_result)
 {
   for (int i = 0; i < N; i++) {
     for (int j = 0; j < N; j++) {


### PR DESCRIPTION
The test tests/5.0/target/test_target_uses_allocators_const.c
was checking that  writing to `x` was successful even though the specification says that
the `omp_const_mem_space`:
Represents storage optimized for variables with constant values. The result of writing to this storage is unspecified.
Which means that if the variable `x` is not written, the result is also correct.
This PR seeks to solve this problem.