### PR TITLE
4.5/taskloop/test_taskloop_private.c: Init variable

### DIFF
--- a/tests/4.5/taskloop/test_taskloop_private.c
+++ b/tests/4.5/taskloop/test_taskloop_private.c
@@ -20,7 +20,7 @@ int test_taskloop_private() {
    int errors = 0;
 
    int private_var;
-   int shared_var_sum;
+   int shared_var_sum = 0;
 
    #pragma omp parallel num_threads(NUM_THREADS)
    {

--- a/tests/4.5/taskloop/test_taskloop_simd_shared.c
+++ b/tests/4.5/taskloop/test_taskloop_simd_shared.c
@@ -17,7 +17,7 @@
 int taskloop_simd_shared() {
 
   int errors = 0;
-  int i, j;
+  int i;
   int A[N], B[N], C[N];
   for(int i = 0; i < N; i++){
     A[i] = 1;


### PR DESCRIPTION
* **tests/4.5/taskloop/test_taskloop_private.c:** Initialize stack variable 'shared_var_sum', used in manual '+=' reduction.
* **tests/4.5/taskloop/test_taskloop_simd_shared.c:** Remove unused 'j' variable.

Without initializing "shared_var_sum", execution might fail with: `Condition shared_var_sum != (NUM_TASKS * 10) failed`.

_(Interestingly, in one version of my compilers it keeps failing, in the other not – it is still a genuine bug and also valgrind shows the warning, which is silenced by the fix.)_

The test case was originally added in #799.

@fel-cab @spophale @andrewkallai – please review.