### PR TITLE
Break possible deadlock on lockstep execution

### DIFF
--- a/tests/5.0/target_requires/test_target_requires_atomic_default_mem_order_acq_rel.c
+++ b/tests/5.0/target_requires/test_target_requires_atomic_default_mem_order_acq_rel.c
@@ -15,8 +15,6 @@
 #include <stdlib.h>
 #include "ompvv.h"
 
-#define N 1024
-
 #pragma omp requires atomic_default_mem_order(acq_rel)
 
 int test_target_requires_atomic_acq_rel() {
@@ -25,15 +23,20 @@ int test_target_requires_atomic_acq_rel() {
   int x = 0, y = 0;
   int errors = 0;
       
-#pragma omp target parallel num_threads(2) map(tofrom: x, y, errors)
+#pragma omp target parallel num_threads(2) map(tofrom: x, y, errors) 
    {
        int thrd = omp_get_thread_num();
+       int tmp = 0;
        if (thrd == 0) {
           x = 10;
           #pragma omp atomic write 
           y = 1;
        } else {
-          int tmp = 0;
+          #pragma omp atomic read 
+          tmp = y;
+       }
+       if (thrd != 0) {
+          tmp = 0;
           while (tmp == 0) {
             #pragma omp atomic read 
             tmp = y;

--- a/tests/5.0/target_requires/test_target_requires_atomic_default_mem_order_relaxed.c
+++ b/tests/5.0/target_requires/test_target_requires_atomic_default_mem_order_relaxed.c
@@ -29,13 +29,19 @@ int test_target_requires_atomic_relaxed() {
 #pragma omp target parallel num_threads(2) map(tofrom: x, y, errors)
    {
       int thrd = omp_get_thread_num();
+      int tmp = 0;
        if (thrd == 0) {
           x = 10;
           #pragma omp flush
           #pragma omp atomic write 
           y = 1;
        } else {
-          int tmp = 0;
+          #pragma omp atomic read
+          tmp = y;
+       }
+
+       if (thrd != 0 ) {
+          tmp = 0;
           while (tmp == 0) {
             #pragma omp atomic read 
             tmp = y;

--- a/tests/5.0/target_requires/test_target_requires_atomic_default_mem_order_seq_cst.c
+++ b/tests/5.0/target_requires/test_target_requires_atomic_default_mem_order_seq_cst.c
@@ -29,12 +29,17 @@ int test_target_atomic_seq_cst() {
 #pragma omp target parallel num_threads(2) map(tofrom: x, y, errors)
    {
       int thrd = omp_get_thread_num();
+      int tmp = 0;
        if (thrd == 0) {
           x = 10;
           #pragma omp atomic write 
           y = 1;
        } else {
-          int tmp = 0;
+          #pragma omp atomic read
+          y = tmp;
+       }
+
+       if (thrd != 0) {
           while (tmp == 0) {
             #pragma omp atomic read 
             tmp = y;


### PR DESCRIPTION
Some of the target_requires_atomic tests get on infinite loop with LLVM/Clang compiler because lockstep execution on the target device and the `if-else` order of execution. These tests are written assuming that target threads are independent or that if they execute in a warp, in lockstep execution, the order of execution would be first the `if` part and then the `else` part.
The modifications on the tests are meant to make sure that this problem does not happens for LLVM/Clang or any compiler that could encounter this problem.
